### PR TITLE
Fixed compile errors

### DIFF
--- a/src/Battlescape/BattleAction.cpp
+++ b/src/Battlescape/BattleAction.cpp
@@ -18,7 +18,7 @@
  */
 #include "BattleAction.h"
 #include "Pathfinding.h"
-#include "Terrainmodifier.h"
+#include "TerrainModifier.h"
 #include "Projectile.h"
 #include "../Savegame/BattleItem.h"
 #include "../Savegame/BattleUnit.h"

--- a/src/Battlescape/BattleAction.h
+++ b/src/Battlescape/BattleAction.h
@@ -19,6 +19,7 @@
 #ifndef OPENXCOM_BATTLEACTION_H
 #define OPENXCOM_BATTLEACTION_H
 
+#include <string>
 #include <vector>
 #include "Position.h"
 


### PR DESCRIPTION
I fixed the following compile errors:
- Battlescape/BattleAction.cpp was using the wrong case when including TerrainModifier.h
- Battlescape/BattleAction.h was not including the string header file for std::string
