### PR TITLE
LanguageState::changeLanguage() should call insensitive before loadLng()

### DIFF
--- a/src/Menu/LanguageState.cpp
+++ b/src/Menu/LanguageState.cpp
@@ -91,9 +91,10 @@ LanguageState::~LanguageState()
 void LanguageState::changeLanguage(const std::string &lang)
 {
 	std::stringstream ss;
-	ss << _game->getResourcePack()->getFolder() << "Language/" << lang;
+	ResourcePack *rp = _game->getResourcePack();
+	ss << rp->getFolder() << "Language/" << lang;
 	Language *l = new Language();
-	l->loadLng(ss.str());
+	l->loadLng(rp->insensitive(ss.str()));
 	_game->setLanguage(l);
 	_game->setState(new MainMenuState(_game));
 }


### PR DESCRIPTION
In LanguageState::changeLanguage() we need to call insensitive() on our language file path before calling loadLng() or it will fail for paths that have a different case.
