### PR TITLE
Fix CrossPlatform for non Windows platforms

### DIFF
--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -33,6 +33,7 @@
 #pragma comment(lib, "shell32.lib")
 #pragma comment(lib, "shlwapi.lib")
 #else
+#include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/param.h>
@@ -63,7 +64,7 @@ std::string getDataFile(const std::string &filename)
 
 	// Try lowercase and uppercase names
 	struct stat info;
-	if (stat(newName.c_str(), &info) == 0)
+	if (stat(newPath.c_str(), &info) == 0)
 	{
 		return newPath;
 	}
@@ -159,20 +160,22 @@ std::wstring findDataFolder()
 		}
 	}
 #else
-	char path[MAXPATHLEN];
+	wchar_t path[MAXPATHLEN];
 	struct stat info;
 
 	// Check shared directory
-	path = "/usr/share/openxcom/"
-	if (stat(path, &info) == 0 && S_ISDIR(info.st_mode))
+	const char* shared = "/usr/share/openxcom/";
+	if (stat(shared, &info) == 0 && S_ISDIR(info.st_mode))
 	{
+		mbstowcs(path, shared, strlen(shared)+1);
 		return path;
 	}
 
 	// Check working directory
-	path = "./DATA/";
-	if (stat(path, &info) == 0 && S_ISDIR(info.st_mode))
+	const char* working = "./DATA/";
+	if (stat(working, &info) == 0 && S_ISDIR(info.st_mode))
 	{
+		mbstowcs(path, working, strlen(working)+1);
 		return path;
 	}
 #endif
@@ -220,24 +223,27 @@ std::wstring findUserFolder()
 		}
 	}
 #else
-	char path[MAXPATHLEN];
+	wchar_t path[MAXPATHLEN];
 	struct stat info;
-
+	
 	// Check HOME directory
 	char *homedir = getenv("HOME");
 	if (homedir)
 	{
-		snprintf(path, MAXPATHLEN, "%s/.openxcom/", homedir);
-		if (stat(path, &info) == 0 && S_ISDIR(info.st_mode))
+		char homePath[MAXPATHLEN];
+		snprintf(homePath, MAXPATHLEN, "%s/.openxcom/", homedir);
+		if (stat(homePath, &info) == 0 && S_ISDIR(info.st_mode))
 		{
+			mbstowcs(path, homePath, strlen(homePath)+1);
 			return path;
 		}
 	}
 
 	// Check working directory
-	path = "./USER/";
-	if (stat(path, &info) == 0 && S_ISDIR(info.st_mode))
+	const char* working = "./USER/";
+	if (stat(working, &info) == 0 && S_ISDIR(info.st_mode))
 	{
+		mbstowcs(path, working, strlen(working)+1);
 		return path;
 	}
 #endif


### PR DESCRIPTION
- CrossPlatform::getDataFile() contained a bug in which the first if should be checking newPath and instead of newName.
- Reworked findDataFolder() and findUserFolder() for non Windows platforms as they contained compile errors and were just wrong.
  - You can't convert from char\* to std::wstring() by the std::wstring() constructor.  You have to convert char\* to wchar_t\* first. The mbstowcs() function is use to convert a multibyte character string to wide character string.
  - Something like char temp[1024]; temp = "test string"; doesn't copy the value test string in to the array.  If you want to copy the string you need to use strcpy().
  - Should use const char\* for referencing strings defined in the code, instead of trying to copy them.
