### PR TITLE
Fix invalid iterator use in TransferItemState

### DIFF
--- a/src/Basescape/TransferItemsState.cpp
+++ b/src/Basescape/TransferItemsState.cpp
@@ -223,10 +223,10 @@ void TransferItemsState::completeTransfer()
 				{
 					if (*s == _soldiers[i])
 					{
-						_baseFrom->getSoldiers()->erase(s);
 						Transfer *t = new Transfer(time);
 						t->setSoldier(*s);
 						_baseTo->getTransfers()->push_back(t);
+						s = _baseFrom->getSoldiers()->erase(s);
 						break;
 					}
 				}
@@ -241,10 +241,10 @@ void TransferItemsState::completeTransfer()
 				{
 					if ((*s)->getCraft() == craft)
 					{
-						_baseFrom->getSoldiers()->erase(s);
 						Transfer *t = new Transfer(time);
 						t->setSoldier(*s);
 						_baseTo->getTransfers()->push_back(t);
+						s = _baseFrom->getSoldiers()->erase(s);
 					}
 				}
 
@@ -253,10 +253,10 @@ void TransferItemsState::completeTransfer()
 				{
 					if (*c == craft)
 					{
-						_baseFrom->getCrafts()->erase(c);
 						Transfer *t = new Transfer(time);
 						t->setCraft(*c);
 						_baseTo->getTransfers()->push_back(t);
+						c = _baseFrom->getCrafts()->erase(c);
 						break;
 					}
 				}


### PR DESCRIPTION
Fixed error in TransferItemState where an invalid iterator was being used due to it being erased.

We you remove an item from a std::vector, your iterator will be invalid.  std::vector::erase() will return the next valid iterator.  My change moves the erase call after dereferencing the iterator and assigns the iterator to the return value of erase().

This error was found with cppcheck, a static C/C++ code analysis tool.
http://cppcheck.sourceforge.net/
