### PR TITLE
Fix button down states on Purchase/Hire screen

### DIFF
--- a/src/Engine/Surface.cpp
+++ b/src/Engine/Surface.cpp
@@ -604,32 +604,35 @@ void Surface::unlock()
 
 /**
  * Shifts all the colors in the surface's palette by a set amount.
+ * Optionally inverts the colors according to a middle point as well.
  * This is a common method in 8bpp games to simulate color
  * effects for cheap.
  * @param off Amount to shift.
  * @param mul Shift multiplier.
+ * @param mid Optional middle point used to invert palette. If 0, palette is not inverted
  */
-void Surface::paletteShift(int off, int mul)
+void Surface::paletteShift(int off, int mul, int mid)
 {
+	int ncolors = _surface->format->palette->ncolors;
+
 	// store the original palette
-	_originalColors = (SDL_Color *)malloc(sizeof(SDL_Color) * _surface->format->palette->ncolors);
+	_originalColors = (SDL_Color *)malloc(sizeof(SDL_Color) * ncolors);
 
 	// create a temporary new palette
-	int ncolors = _surface->format->palette->ncolors - off;
 	SDL_Color *newColors = (SDL_Color *)malloc(sizeof(SDL_Color) * ncolors);
 
 	// do the color shift - while storing the original colors too
-	for (int i = 0; i < _surface->format->palette->ncolors; i++)
+	for (int i = 0; i < ncolors; i++)
 	{
+		int inverseOffset = mid ? 2 * (mid - i) : 0;
+		int j = (i * mul + off + inverseOffset + ncolors) % ncolors;
+
 		_originalColors[i].r = getPalette()[i].r;
 		_originalColors[i].g = getPalette()[i].g;
 		_originalColors[i].b = getPalette()[i].b;
-		if (i * mul + off < _surface->format->palette->ncolors)
-		{
-			newColors[i].r = getPalette()[i * mul + off].r;
-			newColors[i].g = getPalette()[i * mul + off].g;
-			newColors[i].b = getPalette()[i * mul + off].b;
-		}
+		newColors[i].r = getPalette()[j].r;
+		newColors[i].g = getPalette()[j].g;
+		newColors[i].b = getPalette()[j].b;
 	}
 
 	// assign it and free it

--- a/src/Engine/Surface.h
+++ b/src/Engine/Surface.h
@@ -115,8 +115,8 @@ public:
 	void lock();
 	/// Unlocks the surface.
 	void unlock();
-	/// Offsets the surface palette's colors by a set amount.
-	void paletteShift(int off, int mul);
+	/// Offsets and optionally inverts the surface palette's colors by a set amount.
+	void paletteShift(int off, int mul, int mid = 0);
 	/// Restores the original palette.
 	void paletteRestore();
 	/// Specific blit function to blit battlescape terrain data in different shades in a fast way.

--- a/src/Interface/Text.cpp
+++ b/src/Interface/Text.cpp
@@ -402,7 +402,10 @@ void Text::draw()
 		mul = 3;
 	}
 
-	font->getSurface()->paletteShift(color, mul);
+	// Invert text by inverting the font palette on index 3 (font palettes use indices 1-5)
+	int mid = _invert ? 3 : 0;
+
+	font->getSurface()->paletteShift(color, mul, mid);
 
 	// Draw each letter one by one
 	for (std::wstring::iterator c = s->begin(); c != s->end(); ++c)
@@ -431,14 +434,14 @@ void Text::draw()
 			{
 				font->getSurface()->paletteRestore();
 				font = _small;
-				font->getSurface()->paletteShift(color, mul);
+				font->getSurface()->paletteShift(color, mul, mid);
 			}
 		}
 		else if (*c == 1)
 		{
 			font->getSurface()->paletteRestore();
 			color = (color == _color ? _color2 : _color);
-			font->getSurface()->paletteShift(color, mul);
+			font->getSurface()->paletteShift(color, mul, mid);
 		}
 		else
 		{
@@ -448,10 +451,6 @@ void Text::draw()
 			chr->blit(this);
 			x += chr->getCrop()->w + font->getSpacing();
 		}
-	}
-	if (_invert)
-	{
-		this->invert(_color + 3 * mul);
 	}
 
 	// Revert text color


### PR DESCRIPTION
Button text isn't rendering properly in the down state because the palette on this screen contains two identical colors.
see http://openxcom.jimu.net/button_palette.shtml
