### PR TITLE
Subfolder Support

### DIFF
--- a/src/Engine/CrossPlatform.h
+++ b/src/Engine/CrossPlatform.h
@@ -37,7 +37,7 @@ namespace CrossPlatform
 	/// Displays an error message.
 	void showError(const std::wstring &error);
 	/// Finds the game's data folder in the system.
-	std::string findDataFolder(bool exists);
+	std::string findDataFolder(bool exists, std::string &subfolder);
 	/// Finds the game's user folder in the system.
 	std::string findUserFolder(bool exists);
 	/// Creates a folder.

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -61,6 +61,7 @@ void createDefault()
 	// set to true if you want to play with the alternative grenade handling
 	setBool("battleAltGrenade", false);
 	setBool("fpsCounter", false);
+	setString("modFolder", "");
 }
 
 /**
@@ -112,7 +113,7 @@ void init(int argc, char** args)
 	loadArgs(argc, args);
 	if (_dataFolder == "")
 	{
-		_dataFolder = CrossPlatform::findDataFolder(true);
+		_dataFolder = CrossPlatform::findDataFolder(true, _options["modFolder"]);
 		// Missing data folder is handled in StartState
 	}
 	if (_userFolder == "")
@@ -129,6 +130,10 @@ void init(int argc, char** args)
 		else
 		{
 			load();
+			if (_options["modFolder"] != "")
+			{
+				_dataFolder = CrossPlatform::findDataFolder(true, _options["modFolder"]);
+			}
 		}
 	}
 }
@@ -157,6 +162,10 @@ void load(const std::string &filename)
 		i.second() >> value;
 		_options[key] = value;
 	}
+
+	//check for empty directory
+	if (_options["modFolder"].c_str()[0] == L'\x7E')
+		_options["modFolder"] = "";
 
 	fin.close();
 }


### PR DESCRIPTION
Hi, SupSuper. This is my first piece of code send this way. Hope I did it right.
You wrote on forum about extracting some code to external files. I think this will help:
I've added support for maintaining subfolders in 'DATA' directory. In the 'options.cfg' file you will see 'modfolder' entry. Writing folder name (eg. 'ufo') makes the game to search ALL the files (including 'research.dat') in 'DATA/UFO' subfolder. This way future mods will keep their data separate. Tested on Windows and Linux (don't have Mac).
Hope this helps.
