### PR TITLE
Savegame file names must have .sav at the *end*.

### DIFF
--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -140,7 +140,7 @@ void SavedGame::getList(TextList *list, Language *lang)
 	{
 		std::string file = dirp->d_name;
 		// Check if it's a valid save
-		if (file.find(".sav") == std::string::npos)
+		if (file.size() < 4 || file.rfind(".sav") != file.size() - 4)
 		{
 			continue;
 		}


### PR DESCRIPTION
openxcom died on me when I tried to save my game while having a savegame open in vim, because it tried to read vim's .mysavegame.sav.swp file as a savegame to extract the game time, because it still had .sav in the filename.

I think the file name filter could stand to be a tad more strict, and require that .sav is at the end of the filename and not just somewhere inbetween.
