### PR TITLE
Implemented ammo calculations.

### DIFF
--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -18,6 +18,7 @@
  */
 #include "DebriefingState.h"
 #include <sstream>
+#include <map>
 #include "../Engine/Game.h"
 #include "../Resource/ResourcePack.h"
 #include "../Engine/Language.h"
@@ -595,6 +596,7 @@ void DebriefingState::reequipCraft(Base *base, Craft *craft)
 /* converts battlescape inventory into geoscape itemcontainer */
 void DebriefingState::recoverItems(std::vector<BattleItem*> *from, Base *base)
 {
+	std::map<RuleItem*, int> rounds;
 	for (std::vector<BattleItem*>::iterator it = from->begin(); it != from->end(); ++it)
 	{
 		if ((*it)->getRules()->getName() == "STR_ELERIUM_115")
@@ -619,17 +621,38 @@ void DebriefingState::recoverItems(std::vector<BattleItem*> *from, Base *base)
 			// put items back in the base
 			if ((*it)->getRules()->isRecoverable() && !(*it)->getRules()->isFixed())
 			{
-				base->getItems()->addItem((*it)->getRules()->getType(), 1);
-				if ((*it)->getAmmoItem())
+				switch ((*it)->getRules()->getBattleType())
 				{
-					base->getItems()->addItem((*it)->getAmmoItem()->getRules()->getType(), 1);
-					// TODO: account for ammo remaining in the clip
+					case BT_AMMO:
+						// It's a clip, count any rounds left.
+						rounds[(*it)->getRules()] += (*it)->getAmmoQuantity();
+						break;
+					case BT_FIREARM:
+					case BT_MELEE:
+						// It's a weapon, count any rounds left in the clip.
+						{
+							BattleItem *clip = (*it)->getAmmoItem();
+							if (clip)
+							{
+								rounds[clip->getRules()] += clip->getAmmoQuantity();
+							}
+						}
+						// Fall-through, to recover the weapon itself.
+					default:
+						base->getItems()->addItem((*it)->getRules()->getType(), 1);
 				}
 			}
 		}
 	}
-}
 
+	// Now calculate the clips for each type based on the recovered rounds.
+	for (std::map<RuleItem*, int>::const_iterator rl = rounds.begin(); rl != rounds.end(); ++rl)
+	{
+		//Count half-full clips as full.
+		int total_clips = (rl->second + rl->first->getClipSize()/2) / rl->first->getClipSize();
+		base->getItems()->addItem(rl->first->getType(), total_clips);
+	}
+}
 
 
 }


### PR DESCRIPTION
All rounds of each type are counted and the clips get recalculated,
rounding half-filled clips up. This way we lose / gain at most half a
clip for each ammo time.

Right now this also affects unresearched alien ammo.

This closes the TODO item in Battlescape/DebriefingState.cpp
