### PR TITLE
Map generator bug fix

### DIFF
--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -1293,17 +1293,20 @@ void BattlescapeGenerator::loadRMP(MapBlock *mapblock, int xoff, int yoff, int s
 
 	while (mapFile.read((char*)&value, sizeof(value)))
 	{
-		Node *node = new Node(nodeOffset + id, Position(xoff + ((int)value[1] / 2), yoff + ((int)value[0] / 2), mapblock->getHeight() - 1 - (int)value[2]), segment, (int)value[19], (int)value[20], (int)value[21], (int)value[22], (int)value[23]);
-		for (int j=0;j<5;++j)
+		if( (int)value[0] < mapblock->getLength() && (int)value[1] < mapblock->getWidth() && (int)value[2] < _height )
 		{
-			int connectID = (int)((signed char)value[4 + j*3]);
-			if (connectID > -1)
+			Node *node = new Node(nodeOffset + id, Position(xoff + (int)value[1], yoff + (int)value[0], mapblock->getHeight() - 1 - (int)value[2]), segment, (int)value[19], (int)value[20], (int)value[21], (int)value[22], (int)value[23]);
+			for (int j=0;j<5;++j)
 			{
-				connectID += nodeOffset;
+				int connectID = (int)((signed char)value[4 + j*3]);
+				if (connectID > -1)
+				{
+					connectID += nodeOffset;
+				}
+				node->assignNodeLink(new NodeLink(connectID, (int)value[5 + j*3], (int)value[6 + j*3]), j);
 			}
-			node->assignNodeLink(new NodeLink(connectID, (int)value[5 + j*3], (int)value[6 + j*3]), j);
+			_save->getNodes()->push_back(node);
 		}
-		_save->getNodes()->push_back(node);
 		id++;
 	}
 


### PR DESCRIPTION
Drops erroneous nodes that fall outside of the map (section) area.

Example is MOUNT05.RMP and MOUNT05.MAP where there's an extra node in position 10,5,0; the map is only a 10x10x1 area, so the max co-ordinate is 9,5,0. It looks like a "blank" node anyway, because it has not permissions or links assigned to it.
