### PR TITLE
Bug Fix

### DIFF
--- a/src/Geoscape/UfoHyperDetectedState.cpp
+++ b/src/Geoscape/UfoHyperDetectedState.cpp
@@ -136,6 +136,10 @@ UfoHyperDetectedState::UfoHyperDetectedState(Game *game, Ufo *ufo, GeoscapeState
 			set = true;
 		}
 	}
+	if(!set)
+	{
+		_lstInfo2->addRow(2, _game->getLanguage()->getString("STR_ZONE").c_str(), _game->getLanguage()->getString("STR_UNKNOWN").c_str());
+	}
 	_lstInfo2->setCellColor(3, 1, Palette::blockOffset(8)+10);
 }
 


### PR DESCRIPTION
Ufos with random waypoints may not always return a region,
in which case, the game crashes.
this fix sets the text to "unknown" if no region is found.
