### PR TITLE
Remove duplicate code in UFO detection.

### DIFF
--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -964,15 +964,6 @@ void GeoscapeState::time30Minutes()
 						{
 							detected = true;
 						}
-						for (std::vector<Craft*>::iterator c = (*b)->getCrafts()->begin(); c != (*b)->getCrafts()->end() && !detected; ++c)
-						{
-							if ((*c)->getLongitude() == (*b)->getLongitude() && (*c)->getLatitude() == (*b)->getLatitude() && (*c)->getDestination() == 0)
-								continue;
-							if ((*c)->detect(*u))
-							{
-								detected = true;
-							}
-						}
 					}
 				}
 				if (detected)


### PR DESCRIPTION
The code was looping twice for Crafts, once inside the other. This was probably
a result of a bad automerge.
