### PR TITLE
Fixed display of recovery time.

### DIFF
--- a/src/Basescape/SoldierInfoState.cpp
+++ b/src/Basescape/SoldierInfoState.cpp
@@ -401,7 +401,7 @@ void SoldierInfoState::init()
 		ss12 << s->getCraft()->getName(_game->getLanguage());
 	_txtCraft->setText(ss12.str());
 
-	if (s->getWoundRecovery() > 1)
+	if (s->getWoundRecovery() > 0)
 	{
 		std::wstringstream ss13;
 		ss13 << _game->getLanguage()->getString("STR_WOUND_RECOVERY") << L'\x01' << s->getWoundRecovery();


### PR DESCRIPTION
The code would never display a recovery time of a single day. Fixed.
