### PR TITLE
Exception proofing of load() member functions.

### DIFF
--- a/src/Savegame/Base.cpp
+++ b/src/Savegame/Base.cpp
@@ -97,9 +97,9 @@ void Base::load(const YAML::Node &node, SavedGame *save, bool newGame)
 		{
 			std::string type;
 			(*i)["type"] >> type;
-			BaseFacility *f = new BaseFacility(_rule->getBaseFacility(type), this);
+			std::auto_ptr<BaseFacility> f(new BaseFacility(_rule->getBaseFacility(type), this));
 			f->load(*i);
-			_facilities.push_back(f);
+			_facilities.push_back(f.release());
 		}
 	}
 
@@ -107,14 +107,14 @@ void Base::load(const YAML::Node &node, SavedGame *save, bool newGame)
 	{
 		std::string type;
 		(*i)["type"] >> type;
-		Craft *c = new Craft(_rule->getCraft(type), this);
+		std::auto_ptr<Craft> c(new Craft(_rule->getCraft(type), this));
 		c->load(*i, _rule, save);		
-		_crafts.push_back(c);
+		_crafts.push_back(c.release());
 	}
 
 	for (YAML::Iterator i = node["soldiers"].begin(); i != node["soldiers"].end(); ++i)
 	{
-		Soldier *s = new Soldier(_rule->getSoldier("XCOM"), _rule->getArmor("STR_NONE_UC"));
+		std::auto_ptr<Soldier> s(new Soldier(_rule->getSoldier("XCOM"), _rule->getArmor("STR_NONE_UC")));
 		s->load(*i, _rule);
 		if (const YAML::Node *pName = (*i).FindValue("craft"))
 		{
@@ -135,7 +135,7 @@ void Base::load(const YAML::Node &node, SavedGame *save, bool newGame)
 		{
 			s->setCraft(0);
 		}
-		_soldiers.push_back(s);
+		_soldiers.push_back(s.release());
 	}
 
 	_items->load(node["items"]);
@@ -147,27 +147,27 @@ void Base::load(const YAML::Node &node, SavedGame *save, bool newGame)
 	{
 		int hours;
 		(*i)["hours"] >> hours;
-		Transfer *t = new Transfer(hours);
+		std::auto_ptr<Transfer> t(new Transfer(hours));
 		t->load(*i, this, _rule);
-		_transfers.push_back(t);
+		_transfers.push_back(t.release());
 	}
 
 	for (YAML::Iterator i = node["research"].begin(); i != node["research"].end(); ++i)
 	{
 		std::string research;
 		(*i)["project"] >> research;
-		ResearchProject *r = new ResearchProject(_rule->getResearch(research));
+		std::auto_ptr<ResearchProject> r(new ResearchProject(_rule->getResearch(research)));
 		r->load(*i);
-		_research.push_back(r);
+		_research.push_back(r.release());
 	}
 
 	for (YAML::Iterator i = node["productions"].begin(); i != node["productions"].end(); ++i)
 	{
 		std::string item;
 		(*i)["item"] >> item;
-		Production *p = new Production(_rule->getManufacture(item), 0);
+		std::auto_ptr<Production> p(new Production(_rule->getManufacture(item), 0));
 		p->load(*i);
-		_productions.push_back(p);
+		_productions.push_back(p.release());
 	}
 
 	if (const YAML::Node *pNode = node.FindValue("retaliationTarget"))

--- a/src/Savegame/Craft.cpp
+++ b/src/Savegame/Craft.cpp
@@ -139,9 +139,9 @@ void Craft::load(const YAML::Node &node, const Ruleset *rule, SavedGame *save)
 		(*i)["type"] >> type;
 		if (type != "0")
 		{
-			CraftWeapon *w = new CraftWeapon(rule->getCraftWeapon(type), 0);
+			std::auto_ptr<CraftWeapon> w(new CraftWeapon(rule->getCraftWeapon(type), 0));
 			w->load(*i);
-			_weapons[j++] = w;
+			_weapons[j++] = w.release();
 		}
 	}
 
@@ -150,9 +150,9 @@ void Craft::load(const YAML::Node &node, const Ruleset *rule, SavedGame *save)
 	{
 		std::string type;
 		(*i)["type"] >> type;
-		Vehicle *v = new Vehicle(rule->getItem(type), 0);
+		std::auto_ptr<Vehicle> v(new Vehicle(rule->getItem(type), 0));
 		v->load(*i);
-		_vehicles.push_back(v);
+		_vehicles.push_back(v.release());
 	}
 	node["status"] >> _status;
 	node["lowFuel"] >> _lowFuel;

--- a/src/Savegame/Node.cpp
+++ b/src/Savegame/Node.cpp
@@ -79,8 +79,9 @@ void Node::load(const YAML::Node &node)
 	for (int i=0; i < 5; i++)
 	{
 		node["links"][i]["connectedNodeId"] >> a;
-		_nodeLinks[i] = new NodeLink(a, 0, 0);
-		_nodeLinks[i]->load(node["links"][i]);
+		std::auto_ptr<NodeLink> n(new NodeLink(a, 0, 0));
+		n->load(node["links"][i]);
+		_nodeLinks[i] = n.release();
 	}
 }
 

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -247,26 +247,26 @@ void SavedGame::load(const std::string &filename, Ruleset *rule)
 	{
 		std::string type;
 		(*i)["type"] >> type;
-		Country *c = new Country(rule->getCountry(type), false);
+		std::auto_ptr<Country> c(new Country(rule->getCountry(type), false));
 		c->load(*i);
-		_countries.push_back(c);
+		_countries.push_back(c.release());
 	}
 
 	for (YAML::Iterator i = doc["regions"].begin(); i != doc["regions"].end(); ++i)
 	{
 		std::string type;
 		(*i)["type"] >> type;
-		Region *r = new Region(rule->getRegion(type));
+		std::auto_ptr<Region> r(new Region(rule->getRegion(type)));
 		r->load(*i);
-		_regions.push_back(r);
+		_regions.push_back(r.release());
 	}
 
 	// Alien bases must be loaded before alien missions
 	for (YAML::Iterator i = doc["alienBases"].begin(); i != doc["alienBases"].end(); ++i)
 	{
-		AlienBase *b = new AlienBase();
+		std::auto_ptr<AlienBase> b(new AlienBase());
 		b->load(*i);
-		_alienBases.push_back(b);
+		_alienBases.push_back(b.release());
 	}
 
 	// Missions must be loaded before UFOs.
@@ -285,30 +285,30 @@ void SavedGame::load(const std::string &filename, Ruleset *rule)
 	{
 		std::string type;
 		(*i)["type"] >> type;
-		Ufo *u = new Ufo(rule->getUfo(type));
+		std::auto_ptr<Ufo> u(new Ufo(rule->getUfo(type)));
 		u->load(*i, *rule, *this);
-		_ufos.push_back(u);
+		_ufos.push_back(u.release());
 	}
 
 	for (YAML::Iterator i = doc["waypoints"].begin(); i != doc["waypoints"].end(); ++i)
 	{
-		Waypoint *w = new Waypoint();
+		std::auto_ptr<Waypoint> w(new Waypoint());
 		w->load(*i);
-		_waypoints.push_back(w);
+		_waypoints.push_back(w.release());
 	}
 
 	for (YAML::Iterator i = doc["terrorSites"].begin(); i != doc["terrorSites"].end(); ++i)
 	{
-		TerrorSite *t = new TerrorSite();
+		std::auto_ptr<TerrorSite> t(new TerrorSite());
 		t->load(*i);
-		_terrorSites.push_back(t);
+		_terrorSites.push_back(t.release());
 	}
 
 	for (YAML::Iterator i = doc["bases"].begin(); i != doc["bases"].end(); ++i)
 	{
-		Base *b = new Base(rule);
+		std::auto_ptr<Base> b(new Base(rule));
 		b->load(*i, this, false);
-		_bases.push_back(b);
+		_bases.push_back(b.release());
 	}
 
 	for(YAML::Iterator it=doc["discovered"].begin();it!=doc["discovered"].end();++it)
@@ -322,8 +322,9 @@ void SavedGame::load(const std::string &filename, Ruleset *rule)
 
 	if (const YAML::Node *pName = doc.FindValue("battleGame"))
 	{
-		_battleGame = new SavedBattleGame();
-		_battleGame->load(*pName, rule, this);
+		std::auto_ptr<SavedBattleGame> guard(new SavedBattleGame());
+		guard->load(*pName, rule, this);
+		_battleGame = guard.release();
 	}
 
 	fin.close();

--- a/src/Savegame/Transfer.cpp
+++ b/src/Savegame/Transfer.cpp
@@ -56,28 +56,31 @@ Transfer::~Transfer()
 void Transfer::load(const YAML::Node &node, Base *base, const Ruleset *rule)
 {
 	node["hours"] >> _hours;
-	if (const YAML::Node *pName = node.FindValue("soldier"))
+	const YAML::Node *pName;
+	if ((pName = node.FindValue("soldier")))
 	{
-		_soldier = new Soldier(rule->getSoldier("XCOM"), rule->getArmor("STR_NONE_UC"));
-		_soldier->load(*pName, rule);
+		std::auto_ptr<Soldier> s(new Soldier(rule->getSoldier("XCOM"), rule->getArmor("STR_NONE_UC")));
+		s->load(*pName, rule);
+		_soldier = s.release();
 	}
-	else if (const YAML::Node *pName = node.FindValue("craft"))
+	else if ((pName = node.FindValue("craft")))
 	{
 		std::string type;
 		(*pName)["type"] >> type;
-		_craft = new Craft(rule->getCraft(type), base);
-		_craft->load(*pName, rule, 0);
+		std::auto_ptr<Craft> c(new Craft(rule->getCraft(type), base));
+		c->load(*pName, rule, 0);
+		_craft = c.release();
 	}
-	else if (const YAML::Node *pName = node.FindValue("itemId"))
+	else if ((pName = node.FindValue("itemId")))
 	{
 		*pName >> _itemId;
 		node["itemQty"] >> _itemQty;
 	}
-	else if (const YAML::Node *pName = node.FindValue("scientists"))
+	else if ((pName = node.FindValue("scientists")))
 	{
 		*pName >> _scientists;
 	}
-	else if (const YAML::Node *pName = node.FindValue("engineers"))
+	else if ((pName = node.FindValue("engineers")))
 	{
 		*pName >> _engineers;
 	}


### PR DESCRIPTION
Using std::auto_ptr<> avoids leaking memory from damaged save files.
Bonus: Fixed warnings from Transfer::load().

I know the game comes crashing down on a failed load _now_, but this ensures that if we change this behaviour we won't leak memory!
