### PR TITLE
Fixed some compiler warnings.

### DIFF
--- a/src/Engine/Action.cpp
+++ b/src/Engine/Action.cpp
@@ -156,7 +156,7 @@ double Action::getRelativeYMouse() const
  * this action (the sender).
  * @return Pointer to interactive surface.
  */
-InteractiveSurface *const Action::getSender() const
+InteractiveSurface *Action::getSender() const
 {
 	return _sender;
 }
@@ -175,7 +175,7 @@ void Action::setSender(InteractiveSurface *sender)
  * Returns the details about this action.
  * @return Pointer to SDL_event.
  */
-SDL_Event *const Action::getDetails() const
+SDL_Event *Action::getDetails() const
 {
 	return _ev;
 }

--- a/src/Engine/Action.h
+++ b/src/Engine/Action.h
@@ -64,11 +64,11 @@ public:
 	/// Gets the mouse's relative Y position.
 	double getRelativeYMouse() const;
 	/// Gets the sender of the action.
-	InteractiveSurface *const getSender() const;
+	InteractiveSurface *getSender() const;
 	/// Sets the sender of the action.
 	void setSender(InteractiveSurface *sender);
 	/// Gets the details of the action.
-	SDL_Event *const getDetails() const;
+	SDL_Event *getDetails() const;
 };
 
 }

--- a/src/Engine/Font.cpp
+++ b/src/Engine/Font.cpp
@@ -131,7 +131,7 @@ void Font::loadIndex(const std::string &filename)
  * @return Pointer to the font's surface with the respective
  * cropping rectangle set up.
  */
-Surface *const Font::getChar(wchar_t c)
+Surface *Font::getChar(wchar_t c)
 {
 	if (_chars.find(c) == _chars.end())
 	{
@@ -177,7 +177,7 @@ int Font::getSpacing() const
  * actual graphic into the font.
  * @return Pointer to the internal surface.
  */
-Surface *const Font::getSurface() const
+Surface *Font::getSurface() const
 {
 	return _surface;
 }

--- a/src/Engine/Font.h
+++ b/src/Engine/Font.h
@@ -53,7 +53,7 @@ public:
 	/// Loads the character index for every font.
 	static void loadIndex(const std::string &filename);
 	/// Gets a particular character from the font, with its real size.
-	Surface *const getChar(wchar_t c);
+	Surface *getChar(wchar_t c);
 	/// Gets the font's character width.
 	int getWidth() const;
 	/// Gets the font's character height.
@@ -61,7 +61,7 @@ public:
 	/// Gets the horizontal spacing between characters.
 	int getSpacing() const;
 	/// Gets the font's surface.
-	Surface *const getSurface() const;
+	Surface *getSurface() const;
 };
 
 }

--- a/src/Engine/Game.cpp
+++ b/src/Engine/Game.cpp
@@ -291,7 +291,7 @@ void Game::setVolume(int sound, int music)
  * Returns the display screen used by the game.
  * @return Pointer to the screen.
  */
-Screen *const Game::getScreen() const
+Screen *Game::getScreen() const
 {
 	return _screen;
 }
@@ -300,7 +300,7 @@ Screen *const Game::getScreen() const
  * Returns the mouse cursor used by the game.
  * @return Pointer to the cursor.
  */
-Cursor *const Game::getCursor() const
+Cursor *Game::getCursor() const
 {
 	return _cursor;
 }
@@ -309,7 +309,7 @@ Cursor *const Game::getCursor() const
  * Returns the FpsCounter used by the game.
  * @return Pointer to the FpsCounter.
  */
-FpsCounter *const Game::getFpsCounter() const
+FpsCounter *Game::getFpsCounter() const
 {
 	return _fpsCounter;
 }
@@ -379,7 +379,7 @@ void Game::popState()
  * Returns the language currently in use by the game.
  * @return Pointer to the language.
  */
-Language *const Game::getLanguage() const
+Language *Game::getLanguage() const
 {
 	return _lang;
 }
@@ -412,7 +412,7 @@ void Game::loadLanguage(const std::string &filename)
  * Returns the resource pack currently in use by the game.
  * @return Pointer to the resource pack.
  */
-ResourcePack *const Game::getResourcePack() const
+ResourcePack *Game::getResourcePack() const
 {
 	return _res;
 }
@@ -430,7 +430,7 @@ void Game::setResourcePack(ResourcePack *res)
  * Returns the saved game currently in use by the game.
  * @return Pointer to the saved game.
  */
-SavedGame *const Game::getSavedGame() const
+SavedGame *Game::getSavedGame() const
 {
 	return _save;
 }
@@ -449,7 +449,7 @@ void Game::setSavedGame(SavedGame *save)
  * Returns the ruleset currently in use by the game.
  * @return Pointer to the ruleset.
  */
-Ruleset *const Game::getRuleset() const
+Ruleset *Game::getRuleset() const
 {
 	return _rules;
 }

--- a/src/Engine/Game.h
+++ b/src/Engine/Game.h
@@ -67,11 +67,11 @@ public:
 	/// Sets the game's audio volume.
 	void setVolume(int sound, int music);
 	/// Gets the game's display screen.
-	Screen *const getScreen() const;
+	Screen *getScreen() const;
 	/// Gets the game's cursor.
-	Cursor *const getCursor() const;
+	Cursor *getCursor() const;
 	/// Gets the FpsCounter.
-	FpsCounter *const getFpsCounter() const;
+	FpsCounter *getFpsCounter() const;
 	/// Sets the game's 8bpp palette.
 	void setPalette(SDL_Color *colors, int firstcolor = 0, int ncolors = 256);
 	/// Resets the state stack to a new state.
@@ -81,19 +81,19 @@ public:
 	/// Pops the last state from the state stack.
 	void popState();
 	/// Gets the currently loaded language.
-	Language *const getLanguage() const;
+	Language *getLanguage() const;
 	/// Loads a new language for the game.
 	void loadLanguage(const std::string &filename);
 	/// Gets the currently loaded resource pack.
-	ResourcePack *const getResourcePack() const;
+	ResourcePack *getResourcePack() const;
 	/// Sets a new resource pack for the game.
 	void setResourcePack(ResourcePack *res);
 	/// Gets the currently loaded saved game.
-	SavedGame *const getSavedGame() const;
+	SavedGame *getSavedGame() const;
 	/// Sets a new saved game for the game.
 	void setSavedGame(SavedGame *save);
 	/// Gets the currently loaded ruleset.
-	Ruleset *const getRuleset() const;
+	Ruleset *getRuleset() const;
 	/// Loads a new ruleset for the game.
 	void loadRuleset();
 	/// Sets whether the mouse cursor is activated.

--- a/src/Engine/Palette.cpp
+++ b/src/Engine/Palette.cpp
@@ -81,7 +81,7 @@ void Palette::loadDat(const std::string &filename, int ncolors, int offset)
  * @param offset Offset to a specific color.
  * @return Pointer to the requested SDL_Color.
  */
-SDL_Color *const Palette::getColors(int offset) const
+SDL_Color *Palette::getColors(int offset) const
 {
 	return _colors + offset;
 }

--- a/src/Engine/Palette.h
+++ b/src/Engine/Palette.h
@@ -42,7 +42,7 @@ public:
 	/// Loads the colors from an X-Com palette.
 	void loadDat(const std::string &filename, int ncolors, int offset = 0);
 	// Gets a certain color from the palette.
-	SDL_Color *const getColors(int offset = 0) const;
+	SDL_Color *getColors(int offset = 0) const;
 
 	/// Converts a given color into a RGBA color value.
 	static Uint32 getRGBA(SDL_Color* pal, Uint8 color);

--- a/src/Engine/Screen.cpp
+++ b/src/Engine/Screen.cpp
@@ -68,7 +68,7 @@ Screen::~Screen()
  * contents that need to be shown will be blitted to this.
  * @return Pointer to the buffer surface.
  */
-Surface *const Screen::getSurface() const
+Surface *Screen::getSurface() const
 {
 	return _surface;
 }
@@ -304,7 +304,7 @@ void Screen::setPalette(SDL_Color* colors, int firstcolor, int ncolors)
  * Returns the screen's 8bpp palette.
  * @return Pointer to the palette's colors.
  */
-SDL_Color *const Screen::getPalette() const
+SDL_Color *Screen::getPalette() const
 {
 	return _surface->getPalette();
 }

--- a/src/Engine/Screen.h
+++ b/src/Engine/Screen.h
@@ -53,7 +53,7 @@ public:
 	/// Cleans up the display screen.
 	~Screen();
 	/// Gets the internal buffer.
-	Surface *const getSurface() const;
+	Surface *getSurface() const;
 	/// Handles keyboard events.
 	void handle(Action *action);
 	/// Renders the screen onto the game window.
@@ -63,7 +63,7 @@ public:
 	/// Sets the screen's 8bpp palette.
 	void setPalette(SDL_Color *colors, int firstcolor = 0, int ncolors = 256);
 	/// Gets the screen's 8bpp palette.
-	SDL_Color *const getPalette() const;
+	SDL_Color *getPalette() const;
 	/// Gets the screen's width.
 	int getWidth() const;
 	/// Gets the screen's height.

--- a/src/Engine/SoundSet.cpp
+++ b/src/Engine/SoundSet.cpp
@@ -118,7 +118,7 @@ void SoundSet::loadCat(const std::string &filename, bool wav)
  * @param i Sound number in the set.
  * @return Pointer to the respective sound.
  */
-Sound *const SoundSet::getSound(unsigned int i) const
+Sound *SoundSet::getSound(unsigned int i) const
 {
 	if (i >= _sounds.size())
 	{

--- a/src/Engine/SoundSet.h
+++ b/src/Engine/SoundSet.h
@@ -44,7 +44,7 @@ public:
 	/// Loads an X-Com CAT set of sound files.
 	void loadCat(const std::string &filename, bool wav = true);
 	/// Gets a particular sound from the set.
-	Sound *const getSound(unsigned int i) const;
+	Sound *getSound(unsigned int i) const;
 	/// Gets the total sounds in the set.
 	size_t getTotalSounds() const;
 };

--- a/src/Engine/Surface.cpp
+++ b/src/Engine/Surface.cpp
@@ -495,7 +495,7 @@ void Surface::setPalette(SDL_Color *colors, int firstcolor, int ncolors)
  * Returns the surface's 8bpp palette.
  * @return Pointer to the palette's colors.
  */
-SDL_Color *const Surface::getPalette() const
+SDL_Color *Surface::getPalette() const
 {
 	return _surface->format->palette->colors;
 }
@@ -554,7 +554,7 @@ Uint8 Surface::getPixel(int x, int y) const
  * Returns the internal SDL_Surface for SDL calls.
  * @return Pointer to the surface.
  */
-SDL_Surface *const Surface::getSurface() const
+SDL_Surface *Surface::getSurface() const
 {
 	return _surface;
 }

--- a/src/Engine/Surface.h
+++ b/src/Engine/Surface.h
@@ -80,7 +80,7 @@ public:
 	/// Sets the surface's palette.
 	virtual void setPalette(SDL_Color *colors, int firstcolor = 0, int ncolors = 256);
 	/// Gets the surface's palette.
-	SDL_Color *const getPalette() const;
+	SDL_Color *getPalette() const;
 	/// Sets the X position of the surface.
 	void setX(int x);
 	/// Gets the X position of the surface.
@@ -104,7 +104,7 @@ public:
 	/// Gets a pixel of the surface.
 	Uint8 getPixel(int x, int y) const;
 	/// Gets the internal SDL surface.
-	SDL_Surface *const getSurface() const;
+	SDL_Surface *getSurface() const;
 	/// Gets the surface's width.
 	int getWidth() const;
 	/// Gets the surface's height.

--- a/src/Engine/SurfaceSet.cpp
+++ b/src/Engine/SurfaceSet.cpp
@@ -207,7 +207,7 @@ void SurfaceSet::loadDat(const std::string &filename)
  * @param i Frame number in the set.
  * @return Pointer to the respective surface.
  */
-Surface *const SurfaceSet::getFrame(int i) const
+Surface *SurfaceSet::getFrame(int i) const
 {
 	return _frames[i];
 }

--- a/src/Engine/SurfaceSet.h
+++ b/src/Engine/SurfaceSet.h
@@ -51,7 +51,7 @@ public:
 	/// Loads an X-Com DAT image file.
 	void loadDat(const std::string &filename);
 	/// Gets a particular frame from the set.
-	Surface *const getFrame(int i) const;
+	Surface *getFrame(int i) const;
 	/// Gets the width of all frames.
 	int getWidth() const;
 	/// Gets the height of all frames.

--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -1489,7 +1489,7 @@ void GeoscapeState::popup(State *state)
  * access by other substates.
  * @return Pointer to globe.
  */
-Globe *const GeoscapeState::getGlobe() const
+Globe *GeoscapeState::getGlobe() const
 {
 	return _globe;
 }

--- a/src/Geoscape/GeoscapeState.h
+++ b/src/Geoscape/GeoscapeState.h
@@ -87,7 +87,7 @@ public:
 	/// Displays a popup window.
 	void popup(State *state);
 	/// Gets the Geoscape globe.
-	Globe *const getGlobe() const;
+	Globe *getGlobe() const;
 	/// Handler for clicking the globe.
 	void globeClick(Action *action);
 	/// Handler for clicking the Intercept button.

--- a/src/Interface/Text.cpp
+++ b/src/Interface/Text.cpp
@@ -100,7 +100,7 @@ void Text::setSmall()
  * Returns the font currently used by the text.
  * @return Pointer to font.
  */
-Font *const Text::getFont() const
+Font *Text::getFont() const
 {
 	return _font;
 }

--- a/src/Interface/Text.h
+++ b/src/Interface/Text.h
@@ -64,7 +64,7 @@ public:
 	/// Sets the text size to small.
 	void setSmall();
 	/// Gets the text's current font.
-	Font *const getFont() const;
+	Font *getFont() const;
 	/// Sets the text's various fonts.
 	void setFonts(Font *big, Font *small);
 	/// Sets the text's string.

--- a/src/Resource/ResourcePack.cpp
+++ b/src/Resource/ResourcePack.cpp
@@ -81,7 +81,7 @@ ResourcePack::~ResourcePack()
  * @param name Name of the font.
  * @return Pointer to the font.
  */
-Font *const ResourcePack::getFont(const std::string &name) const
+Font *ResourcePack::getFont(const std::string &name) const
 {
 	return _fonts.find(name)->second;
 }
@@ -91,7 +91,7 @@ Font *const ResourcePack::getFont(const std::string &name) const
  * @param name Name of the surface.
  * @return Pointer to the surface.
  */
-Surface *const ResourcePack::getSurface(const std::string &name) const
+Surface *ResourcePack::getSurface(const std::string &name) const
 {
 	return _surfaces.find(name)->second;
 }
@@ -101,7 +101,7 @@ Surface *const ResourcePack::getSurface(const std::string &name) const
  * @param name Name of the surface set.
  * @return Pointer to the surface set.
  */
-SurfaceSet *const ResourcePack::getSurfaceSet(const std::string &name) const
+SurfaceSet *ResourcePack::getSurfaceSet(const std::string &name) const
 {
 	return _sets.find(name)->second;
 }
@@ -110,7 +110,7 @@ SurfaceSet *const ResourcePack::getSurfaceSet(const std::string &name) const
  * Returns the list of polygons in the resource set.
  * @return Pointer to the list of polygons.
  */
-std::list<Polygon*> *const ResourcePack::getPolygons()
+std::list<Polygon*> *ResourcePack::getPolygons()
 {
 	return &_polygons;
 }
@@ -119,7 +119,7 @@ std::list<Polygon*> *const ResourcePack::getPolygons()
  * Returns the list of polylines in the resource set.
  * @return Pointer to the list of polylines.
  */
-std::list<Polyline*> *const ResourcePack::getPolylines()
+std::list<Polyline*> *ResourcePack::getPolylines()
 {
 	return &_polylines;
 }
@@ -129,7 +129,7 @@ std::list<Polyline*> *const ResourcePack::getPolylines()
  * @param name Name of the music.
  * @return Pointer to the music.
  */
-Music *const ResourcePack::getMusic(const std::string &name) const
+Music *ResourcePack::getMusic(const std::string &name) const
 {
 	return _musics.find(name)->second;
 }
@@ -139,7 +139,7 @@ Music *const ResourcePack::getMusic(const std::string &name) const
  * @param name Name of the sound set.
  * @return Pointer to the sound set.
  */
-SoundSet *const ResourcePack::getSoundSet(const std::string &name) const
+SoundSet *ResourcePack::getSoundSet(const std::string &name) const
 {
 	return _sounds.find(name)->second;
 }
@@ -149,7 +149,7 @@ SoundSet *const ResourcePack::getSoundSet(const std::string &name) const
  * @param name Name of the palette.
  * @return Pointer to the palette.
  */
-Palette *const ResourcePack::getPalette(const std::string &name) const
+Palette *ResourcePack::getPalette(const std::string &name) const
 {
 	return _palettes.find(name)->second;
 }
@@ -180,7 +180,7 @@ void ResourcePack::setPalette(SDL_Color *colors, int firstcolor, int ncolors)
  * Returns the list of voxeldata in the resource set.
  * @return Pointer to the list of voxeldata.
  */
-std::vector<Uint16> *const ResourcePack::getVoxelData()
+std::vector<Uint16> *ResourcePack::getVoxelData()
 {
 	return &_voxelData;
 }

--- a/src/Resource/ResourcePack.h
+++ b/src/Resource/ResourcePack.h
@@ -67,25 +67,25 @@ public:
 	/// Cleans up the resource pack.
 	virtual ~ResourcePack();
 	/// Gets a particular font.
-	Font *const getFont(const std::string &name) const;
+	Font *getFont(const std::string &name) const;
 	/// Gets a particular surface.
-	Surface *const getSurface(const std::string &name) const;
+	Surface *getSurface(const std::string &name) const;
 	/// Gets a particular surface set.
-	SurfaceSet *const getSurfaceSet(const std::string &name) const;
+	SurfaceSet *getSurfaceSet(const std::string &name) const;
 	/// Gets the list of world polygons.
-	std::list<Polygon*> *const getPolygons();
+	std::list<Polygon*> *getPolygons();
 	/// Gets the list of world polylines.
-	std::list<Polyline*> *const getPolylines();
+	std::list<Polyline*> *getPolylines();
 	/// Gets a particular music.
-	Music *const getMusic(const std::string &name) const;
+	Music *getMusic(const std::string &name) const;
 	/// Gets a particular sound set.
-	SoundSet *const getSoundSet(const std::string &name) const;
+	SoundSet *getSoundSet(const std::string &name) const;
 	/// Gets a particular palette.
-	Palette *const getPalette(const std::string &name) const;
+	Palette *getPalette(const std::string &name) const;
 	/// Sets a new palette.
 	void setPalette(SDL_Color *colors, int firstcolor, int ncolors);
 	/// Gets list of voxel data.
-	std::vector<Uint16> *const getVoxelData();
+	std::vector<Uint16> *getVoxelData();
 };
 
 }

--- a/src/Ruleset/RuleInventory.cpp
+++ b/src/Ruleset/RuleInventory.cpp
@@ -147,7 +147,7 @@ InventoryType RuleInventory::getType() const
  * Gets all the slots in the inventory section.
  * @return List of slots.
  */
-std::vector<struct RuleSlot> *const RuleInventory::getSlots()
+std::vector<struct RuleSlot> *RuleInventory::getSlots()
 {
 	return &_slots;
 }

--- a/src/Ruleset/RuleInventory.h
+++ b/src/Ruleset/RuleInventory.h
@@ -71,7 +71,7 @@ public:
 	/// Gets the inventory type.
 	InventoryType getType() const;
 	/// Gets all the slots in the inventory.
-	std::vector<struct RuleSlot> *const getSlots();
+	std::vector<struct RuleSlot> *getSlots();
 	/// Checks for a slot in a certain position.
 	bool checkSlotInPosition(int *x, int *y) const;
 	/// Checks if an item fits in a slot.

--- a/src/Ruleset/RuleRegion.cpp
+++ b/src/Ruleset/RuleRegion.cpp
@@ -160,7 +160,7 @@ bool RuleRegion::insideRegion(double lon, double lat) const
  * Returns the list of cities contained.
  * @return Pointer to list.
  */
-std::vector<City*> *const RuleRegion::getCities()
+std::vector<City*> *RuleRegion::getCities()
 {
 	return &_cities;
 }

--- a/src/Ruleset/RuleRegion.h
+++ b/src/Ruleset/RuleRegion.h
@@ -56,7 +56,7 @@ public:
 	/// Checks if a point is inside the region.
 	bool insideRegion(double lon, double lat) const;
 	/// Gets the cities in this region.
-	std::vector<City*> *const getCities();
+	std::vector<City*> *getCities();
 };
 
 }

--- a/src/Ruleset/Ruleset.cpp
+++ b/src/Ruleset/Ruleset.cpp
@@ -785,7 +785,7 @@ SavedGame *Ruleset::newSave() const
  * Returns the list of soldier name pools.
  * @return Pointer to soldier name pool list.
  */
-std::vector<SoldierNamePool*> *const Ruleset::getPools()
+std::vector<SoldierNamePool*> *Ruleset::getPools()
 {
 	return &_names;
 }
@@ -795,7 +795,7 @@ std::vector<SoldierNamePool*> *const Ruleset::getPools()
  * @param id Country type.
  * @return Rules for the country.
  */
-RuleCountry *const Ruleset::getCountry(const std::string &id) const
+RuleCountry *Ruleset::getCountry(const std::string &id) const
 {
 	return _countries.find(id)->second;
 }
@@ -815,7 +815,7 @@ std::vector<std::string> Ruleset::getCountriesList() const
  * @param id Region type.
  * @return Rules for the region.
  */
-RuleRegion *const Ruleset::getRegion(const std::string &id) const
+RuleRegion *Ruleset::getRegion(const std::string &id) const
 {
 	return _regions.find(id)->second;
 }
@@ -835,7 +835,7 @@ std::vector<std::string> Ruleset::getRegionsList() const
  * @param id Facility type.
  * @return Rules for the facility.
  */
-RuleBaseFacility *const Ruleset::getBaseFacility(const std::string &id) const
+RuleBaseFacility *Ruleset::getBaseFacility(const std::string &id) const
 {
 	return _facilities.find(id)->second;
 }
@@ -855,7 +855,7 @@ std::vector<std::string> Ruleset::getBaseFacilitiesList() const
  * @param id Craft type.
  * @return Rules for the craft.
  */
-RuleCraft *const Ruleset::getCraft(const std::string &id) const
+RuleCraft *Ruleset::getCraft(const std::string &id) const
 {
 	return _crafts.find(id)->second;
 }
@@ -875,7 +875,7 @@ std::vector<std::string> Ruleset::getCraftsList() const
  * @param id Craft weapon type.
  * @return Rules for the craft weapon.
  */
-RuleCraftWeapon *const Ruleset::getCraftWeapon(const std::string &id) const
+RuleCraftWeapon *Ruleset::getCraftWeapon(const std::string &id) const
 {
 	return _craftWeapons.find(id)->second;
 }
@@ -895,7 +895,7 @@ std::vector<std::string> Ruleset::getCraftWeaponsList() const
  * @param id Item type.
  * @return Rules for the item. Or 0 when the item is not found.
  */
-RuleItem *const Ruleset::getItem(const std::string &id) const
+RuleItem *Ruleset::getItem(const std::string &id) const
 {
 	if (_items.find(id) != _items.end())
 		return _items.find(id)->second;
@@ -918,7 +918,7 @@ std::vector<std::string> Ruleset::getItemsList() const
  * @param id UFO type.
  * @return Rules for the UFO.
  */
-RuleUfo *const Ruleset::getUfo(const std::string &id) const
+RuleUfo *Ruleset::getUfo(const std::string &id) const
 {
 	return _ufos.find(id)->second;
 }
@@ -938,7 +938,7 @@ std::vector<std::string> Ruleset::getUfosList() const
  * @param name terrain name.
  * @return Rules for the terrain.
  */
-RuleTerrain *const Ruleset::getTerrain(const std::string &name) const
+RuleTerrain *Ruleset::getTerrain(const std::string &name) const
 {
 	return _terrains.find(name)->second;
 }
@@ -948,7 +948,7 @@ RuleTerrain *const Ruleset::getTerrain(const std::string &name) const
  * @param name datafile name.
  * @return Rules for the datafile.
  */
-MapDataSet *const Ruleset::getMapDataSet(const std::string &name)
+MapDataSet *Ruleset::getMapDataSet(const std::string &name)
 {
 	std::map<std::string, MapDataSet*>::iterator map = _mapDataSets.find(name);
 	if (map == _mapDataSets.end())
@@ -968,7 +968,7 @@ MapDataSet *const Ruleset::getMapDataSet(const std::string &name)
  * @param name Unit name.
  * @return Rules for the units.
  */
-RuleSoldier *const Ruleset::getSoldier(const std::string &name) const
+RuleSoldier *Ruleset::getSoldier(const std::string &name) const
 {
 	return _soldiers.find(name)->second;
 }
@@ -978,7 +978,7 @@ RuleSoldier *const Ruleset::getSoldier(const std::string &name) const
  * @param name Unit name.
  * @return Rules for the units.
  */
-Unit *const Ruleset::getUnit(const std::string &name) const
+Unit *Ruleset::getUnit(const std::string &name) const
 {
 	return _units.find(name)->second;
 }
@@ -988,7 +988,7 @@ Unit *const Ruleset::getUnit(const std::string &name) const
  * @param name Race name.
  * @return Rules for the race.
  */
-AlienRace *const Ruleset::getAlienRace(const std::string &name) const
+AlienRace *Ruleset::getAlienRace(const std::string &name) const
 {
 	return _alienRaces.find(name)->second;
 }
@@ -1008,7 +1008,7 @@ std::vector<std::string> Ruleset::getAlienRacesList() const
  * @param name Deployment name.
  * @return Rules for the deployment.
  */
-AlienDeployment *const Ruleset::getDeployment(const std::string &name) const
+AlienDeployment *Ruleset::getDeployment(const std::string &name) const
 {
 	return _alienDeployments.find(name)->second;
 }
@@ -1028,7 +1028,7 @@ std::vector<std::string> Ruleset::getDeploymentsList() const
  * @param name Armor name.
  * @return Rules for the armor.
  */
-Armor *const Ruleset::getArmor(const std::string &name) const
+Armor *Ruleset::getArmor(const std::string &name) const
 {
 	return _armors.find(name)->second;
 }
@@ -1088,7 +1088,7 @@ int Ruleset::getPersonnelTime() const
  * @param name Article name.
  * @return Article definition.
  */
-ArticleDefinition *const Ruleset::getUfopaediaArticle(const std::string &name) const
+ArticleDefinition *Ruleset::getUfopaediaArticle(const std::string &name) const
 {
 	return _ufopaediaArticles.find(name)->second;
 }
@@ -1107,7 +1107,7 @@ std::vector<std::string> Ruleset::getUfopaediaList() const
  * Returns the list of inventories.
  * @return Pointer to inventory list.
  */
-std::map<std::string, RuleInventory*> *const Ruleset::getInventories()
+std::map<std::string, RuleInventory*> *Ruleset::getInventories()
 {
 	return &_invs;
 }
@@ -1117,7 +1117,7 @@ std::map<std::string, RuleInventory*> *const Ruleset::getInventories()
  * @param id Inventory type.
  * @return Inventory ruleset.
  */
-RuleInventory *const Ruleset::getInventory(const std::string &id) const
+RuleInventory *Ruleset::getInventory(const std::string &id) const
 {
 	return _invs.find(id)->second;
 }

--- a/src/Ruleset/Ruleset.h
+++ b/src/Ruleset/Ruleset.h
@@ -98,63 +98,63 @@ public:
 	/// Generates the starting saved game.
 	virtual SavedGame *newSave() const;
 	/// Gets the pool list for soldier names.
-	std::vector<SoldierNamePool*> *const getPools();
+	std::vector<SoldierNamePool*> *getPools();
 	/// Gets the ruleset for a country type.
-	RuleCountry *const getCountry(const std::string &id) const;
+	RuleCountry *getCountry(const std::string &id) const;
 	/// Gets the available countries.
 	std::vector<std::string> getCountriesList() const;
 	/// Gets the ruleset for a region type.
-	RuleRegion *const getRegion(const std::string &id) const;
+	RuleRegion *getRegion(const std::string &id) const;
 	/// Gets the available regions.
 	std::vector<std::string> getRegionsList() const;
 	/// Gets the ruleset for a facility type.
-	RuleBaseFacility *const getBaseFacility(const std::string &id) const;
+	RuleBaseFacility *getBaseFacility(const std::string &id) const;
 	/// Gets the available facilities.
 	std::vector<std::string> getBaseFacilitiesList() const;
 	/// Gets the ruleset for a craft type.
-	RuleCraft *const getCraft(const std::string &id) const;
+	RuleCraft *getCraft(const std::string &id) const;
 	/// Gets the available crafts.
 	std::vector<std::string> getCraftsList() const;
 	/// Gets the ruleset for a craft weapon type.
-	RuleCraftWeapon *const getCraftWeapon(const std::string &id) const;
+	RuleCraftWeapon *getCraftWeapon(const std::string &id) const;
 	/// Gets the available craft weapons.
 	std::vector<std::string> getCraftWeaponsList() const;
 	/// Gets the ruleset for an item type.
-	RuleItem *const getItem(const std::string &id) const;
+	RuleItem *getItem(const std::string &id) const;
 	/// Gets the available items.
 	std::vector<std::string> getItemsList() const;
 	/// Gets the ruleset for a UFO type.
-	RuleUfo *const getUfo(const std::string &id) const;
+	RuleUfo *getUfo(const std::string &id) const;
 	/// Gets the available UFOs.
 	std::vector<std::string> getUfosList() const;
 	/// Gets terrains for battlescape games.
-	RuleTerrain *const getTerrain(const std::string &name) const;
+	RuleTerrain *getTerrain(const std::string &name) const;
 	/// Gets mapdatafile for battlescape games.
-	MapDataSet *const getMapDataSet(const std::string &name);
+	MapDataSet *getMapDataSet(const std::string &name);
 	/// Gets soldier unit rules.
-	RuleSoldier *const getSoldier(const std::string &name) const;
+	RuleSoldier *getSoldier(const std::string &name) const;
 	/// Gets generated unit rules.
-	Unit *const getUnit(const std::string &name) const;
+	Unit *getUnit(const std::string &name) const;
 	/// Gets alien race rules.
-	AlienRace *const getAlienRace(const std::string &name) const;
+	AlienRace *getAlienRace(const std::string &name) const;
 	/// Gets the available alien races.
 	std::vector<std::string> getAlienRacesList() const;
 	/// Gets deployment rules.
-	AlienDeployment *const getDeployment(const std::string &name) const;
+	AlienDeployment *getDeployment(const std::string &name) const;
 	/// Gets the available alien deployments.
 	std::vector<std::string> getDeploymentsList() const;
 	/// Gets armor rules.
-	Armor *const getArmor(const std::string &name) const;
+	Armor *getArmor(const std::string &name) const;
 	/// Gets the available armors.
 	std::vector<std::string> getArmorsList() const;
 	/// Gets Ufopaedia article definition.
-	ArticleDefinition *const getUfopaediaArticle(const std::string &name) const;
+	ArticleDefinition *getUfopaediaArticle(const std::string &name) const;
 	/// Gets the available articles.
 	std::vector<std::string> getUfopaediaList() const;
 	/// Gets the inventory list.
-	std::map<std::string, RuleInventory*> *const getInventories();
+	std::map<std::string, RuleInventory*> *getInventories();
 	/// Gets the ruleset for a specific inventory.
-	RuleInventory *const getInventory(const std::string &id) const;
+	RuleInventory *getInventory(const std::string &id) const;
 	/// Gets the cost of a soldier.
 	int getSoldierCost() const;
 	/// Gets the cost of an engineer.

--- a/src/Savegame/Base.cpp
+++ b/src/Savegame/Base.cpp
@@ -266,7 +266,7 @@ void Base::setName(const std::wstring &name)
  * Returns the list of facilities in the base.
  * @return Pointer to the facility list.
  */
-std::vector<BaseFacility*> *const Base::getFacilities()
+std::vector<BaseFacility*> *Base::getFacilities()
 {
 	return &_facilities;
 }
@@ -275,7 +275,7 @@ std::vector<BaseFacility*> *const Base::getFacilities()
  * Returns the list of soldiers in the base.
  * @return Pointer to the soldier list.
  */
-std::vector<Soldier*> *const Base::getSoldiers()
+std::vector<Soldier*> *Base::getSoldiers()
 {
 	return &_soldiers;
 }
@@ -284,7 +284,7 @@ std::vector<Soldier*> *const Base::getSoldiers()
  * Returns the list of crafts in the base.
  * @return Pointer to the craft list.
  */
-std::vector<Craft*> *const Base::getCrafts()
+std::vector<Craft*> *Base::getCrafts()
 {
 	return &_crafts;
 }
@@ -294,7 +294,7 @@ std::vector<Craft*> *const Base::getCrafts()
  * to this base.
  * @return Pointer to the transfer list.
  */
-std::vector<Transfer*> *const Base::getTransfers()
+std::vector<Transfer*> *Base::getTransfers()
 {
 	return &_transfers;
 }
@@ -303,7 +303,7 @@ std::vector<Transfer*> *const Base::getTransfers()
  * Returns the list of items in the base.
  * @return Pointer to the item list.
  */
-ItemContainer *const Base::getItems()
+ItemContainer *Base::getItems()
 {
 	return _items;
 }

--- a/src/Savegame/Base.h
+++ b/src/Savegame/Base.h
@@ -73,15 +73,15 @@ public:
 	/// Sets the base's name.
 	void setName(const std::wstring &name);
 	/// Gets the base's facilities.
-	std::vector<BaseFacility*> *const getFacilities();
+	std::vector<BaseFacility*> *getFacilities();
 	/// Gets the base's soldiers.
-	std::vector<Soldier*> *const getSoldiers();
+	std::vector<Soldier*> *getSoldiers();
 	/// Gets the base's crafts.
-	std::vector<Craft*> *const getCrafts();
+	std::vector<Craft*> *getCrafts();
 	/// Gets the base's transfers.
-	std::vector<Transfer*> *const getTransfers();
+	std::vector<Transfer*> *getTransfers();
 	/// Gets the base's items.
-	ItemContainer *const getItems();
+	ItemContainer *getItems();
 	/// Gets the base's scientists.
 	int getScientists() const;
 	/// Sets the base's scientists.

--- a/src/Savegame/BaseFacility.cpp
+++ b/src/Savegame/BaseFacility.cpp
@@ -68,7 +68,7 @@ void BaseFacility::save(YAML::Emitter &out) const
  * Returns the ruleset for the base facility's type.
  * @return Pointer to ruleset.
  */
-RuleBaseFacility *const BaseFacility::getRules() const
+RuleBaseFacility *BaseFacility::getRules() const
 {
 	return _rules;
 }

--- a/src/Savegame/BaseFacility.h
+++ b/src/Savegame/BaseFacility.h
@@ -50,7 +50,7 @@ public:
 	/// Saves the base facility to YAML.
 	void save(YAML::Emitter& out) const;
 	/// Gets the facility's ruleset.
-	RuleBaseFacility *const getRules() const;
+	RuleBaseFacility *getRules() const;
 	/// Gets the facility's X position.
 	int getX() const;
 	/// Sets the facility's X position.

--- a/src/Savegame/BattleItem.cpp
+++ b/src/Savegame/BattleItem.cpp
@@ -141,7 +141,7 @@ void BattleItem::save(YAML::Emitter &out) const
  * Returns the ruleset for the item's type.
  * @return Pointer to ruleset.
  */
-RuleItem *const BattleItem::getRules() const
+RuleItem *BattleItem::getRules() const
 {
 	return _rules;
 }

--- a/src/Savegame/BattleItem.h
+++ b/src/Savegame/BattleItem.h
@@ -61,7 +61,7 @@ public:
 	/// Saves the item to YAML.
 	void save(YAML::Emitter& out) const;
 	/// Gets the item's ruleset.
-	RuleItem *const getRules() const;
+	RuleItem *getRules() const;
 	/// Gets the item's ammo quantity
 	int getAmmoQuantity() const;
 	/// Sets the item's ammo quantity.

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -1019,7 +1019,7 @@ bool BattleUnit::addToVisibleUnits(BattleUnit *unit)
  * Get the pointer to the vector of visible units.
  * @return pointer to vector.
  */
-std::vector<BattleUnit*> *const BattleUnit::getVisibleUnits()
+std::vector<BattleUnit*> *BattleUnit::getVisibleUnits()
 {
 	return &_visibleUnits;
 }
@@ -1047,7 +1047,7 @@ bool BattleUnit::addToVisibleTiles(Tile *tile)
  * Get the pointer to the vector of visible tiles.
  * @return pointer to vector.
  */
-std::vector<Tile*> *const BattleUnit::getVisibleTiles()
+std::vector<Tile*> *BattleUnit::getVisibleTiles()
 {
 	return &_visibleTiles;
 }
@@ -1303,7 +1303,7 @@ int BattleUnit::getFire() const
  * Get the pointer to the vector of inventory items.
  * @return pointer to vector.
  */
-std::vector<BattleItem*> *const BattleUnit::getInventory()
+std::vector<BattleItem*> *BattleUnit::getInventory()
 {
 	return &_inventory;
 }

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -197,13 +197,13 @@ public:
 	/// Add unit to visible units.
 	bool addToVisibleUnits(BattleUnit *unit);
 	/// Get the list of visible units.
-	std::vector<BattleUnit*> *const getVisibleUnits();
+	std::vector<BattleUnit*> *getVisibleUnits();
 	/// Clear visible units.
 	void clearVisibleUnits();
 	/// Add unit to visible tiles.
 	bool addToVisibleTiles(Tile *tile);
 	/// Get the list of visible tiles.
-	std::vector<Tile*> *const getVisibleTiles();
+	std::vector<Tile*> *getVisibleTiles();
 	/// Clear visible tiles.
 	void clearVisibleTiles();
 	/// Calculate firing accuracy.
@@ -233,7 +233,7 @@ public:
 	/// Get fire.
 	int getFire() const;
 	/// Get the list of items in the inventory.
-	std::vector<BattleItem*> *const getInventory();
+	std::vector<BattleItem*> *getInventory();
 	/// Let AI do their thing.
 	void think(BattleAction *action);
 	/// Get current AI state.

--- a/src/Savegame/Country.cpp
+++ b/src/Savegame/Country.cpp
@@ -76,7 +76,7 @@ void Country::save(YAML::Emitter &out) const
  * Returns the ruleset for the country's type.
  * @return Pointer to ruleset.
  */
-RuleCountry *const Country::getRules() const
+RuleCountry *Country::getRules() const
 {
 	return _rules;
 }

--- a/src/Savegame/Country.h
+++ b/src/Savegame/Country.h
@@ -47,7 +47,7 @@ public:
 	/// Saves the country to YAML.
 	void save(YAML::Emitter& out) const;
 	/// Gets the country's ruleset.
-	RuleCountry *const getRules() const;
+	RuleCountry *getRules() const;
 	/// Gets the country's funding.
 	std::vector<int>  getFunding() const;
 	/// Sets the country's funding.

--- a/src/Savegame/Craft.cpp
+++ b/src/Savegame/Craft.cpp
@@ -221,7 +221,7 @@ void Craft::saveId(YAML::Emitter &out) const
  * Returns the ruleset for the craft's type.
  * @return Pointer to ruleset.
  */
-RuleCraft *const Craft::getRules() const
+RuleCraft *Craft::getRules() const
 {
 	return _rules;
 }
@@ -267,7 +267,7 @@ std::wstring Craft::getName(Language *lang) const
  * Returns the base the craft belongs to.
  * @return Pointer to base.
  */
-Base *const Craft::getBase() const
+Base *Craft::getBase() const
 {
 	return _base;
 }
@@ -402,7 +402,7 @@ int Craft::getNumVehicles() const
  * in the craft.
  * @return Pointer to weapon list.
  */
-std::vector<CraftWeapon*> *const Craft::getWeapons()
+std::vector<CraftWeapon*> *Craft::getWeapons()
 {
 	return &_weapons;
 }
@@ -411,7 +411,7 @@ std::vector<CraftWeapon*> *const Craft::getWeapons()
  * Returns the list of items in the craft.
  * @return Pointer to the item list.
  */
-ItemContainer *const Craft::getItems()
+ItemContainer *Craft::getItems()
 {
 	return _items;
 }
@@ -421,7 +421,7 @@ ItemContainer *const Craft::getItems()
  * in the craft.
  * @return Pointer to vehicle list.
  */
-std::vector<Vehicle*> *const Craft::getVehicles()
+std::vector<Vehicle*> *Craft::getVehicles()
 {
 	return &_vehicles;
 }

--- a/src/Savegame/Craft.h
+++ b/src/Savegame/Craft.h
@@ -66,7 +66,7 @@ public:
 	/// Saves the craft's ID to YAML.
 	void saveId(YAML::Emitter& out) const;
 	/// Gets the craft's ruleset.
-	RuleCraft *const getRules() const;
+	RuleCraft *getRules() const;
 	/// Sets the craft's ruleset.
 	void setRules(RuleCraft *rules);
 	/// Gets the craft's ID.
@@ -74,7 +74,7 @@ public:
 	/// Gets the craft's name.
 	std::wstring getName(Language *lang) const;
 	/// Gets the craft's base.
-	Base *const getBase() const;
+	Base *getBase() const;
 	/// Sets the craft's base.
 	void setBase(Base *base);
 	/// Gets the craft's status.
@@ -94,11 +94,11 @@ public:
 	/// Gets the craft's amount of vehicles.
 	int getNumVehicles() const;
 	/// Gets the craft's weapons.
-	std::vector<CraftWeapon*> *const getWeapons();
+	std::vector<CraftWeapon*> *getWeapons();
 	/// Gets the craft's items.
-	ItemContainer *const getItems();
+	ItemContainer *getItems();
 	/// Gets the craft's vehicles.
-	std::vector<Vehicle*> *const getVehicles();
+	std::vector<Vehicle*> *getVehicles();
 	/// Gets the craft's amount of fuel.
 	int getFuel() const;
 	/// Sets the craft's amount of fuel.

--- a/src/Savegame/CraftWeapon.cpp
+++ b/src/Savegame/CraftWeapon.cpp
@@ -66,7 +66,7 @@ void CraftWeapon::save(YAML::Emitter &out) const
  * Returns the ruleset for the craft weapon's type.
  * @return Pointer to ruleset.
  */
-RuleCraftWeapon *const CraftWeapon::getRules() const
+RuleCraftWeapon *CraftWeapon::getRules() const
 {
 	return _rules;
 }

--- a/src/Savegame/CraftWeapon.h
+++ b/src/Savegame/CraftWeapon.h
@@ -49,7 +49,7 @@ public:
 	/// Saves the craft weapon to YAML.
 	void save(YAML::Emitter& out) const;
 	/// Gets the craft weapon's ruleset.
-	RuleCraftWeapon *const getRules() const;
+	RuleCraftWeapon *getRules() const;
 	/// Gets the craft weapon's ammo.
 	int getAmmo() const;
 	/// Sets the craft weapon's ammo.

--- a/src/Savegame/ItemContainer.cpp
+++ b/src/Savegame/ItemContainer.cpp
@@ -150,7 +150,7 @@ double ItemContainer::getTotalSize(const Ruleset *rule) const
  * Returns all the items currently contained within.
  * @return List of contents.
  */
-std::map<std::string, int> *const ItemContainer::getContents()
+std::map<std::string, int> *ItemContainer::getContents()
 {
 	return &_qty;
 }

--- a/src/Savegame/ItemContainer.h
+++ b/src/Savegame/ItemContainer.h
@@ -57,7 +57,7 @@ public:
 	/// Gets the total size of items in the container.
 	double getTotalSize(const Ruleset *rule) const;
 	/// Gets all the items in the container.
-	std::map<std::string, int> *const getContents();
+	std::map<std::string, int> *getContents();
 };
 
 }

--- a/src/Savegame/MovingTarget.cpp
+++ b/src/Savegame/MovingTarget.cpp
@@ -69,7 +69,7 @@ void MovingTarget::save(YAML::Emitter &out) const
  * Returns the destination the moving target is heading to.
  * @return Pointer to destination.
  */
-Target *const MovingTarget::getDestination() const
+Target *MovingTarget::getDestination() const
 {
 	return _dest;
 }

--- a/src/Savegame/MovingTarget.h
+++ b/src/Savegame/MovingTarget.h
@@ -49,7 +49,7 @@ public:
 	/// Saves the moving target to YAML.
 	virtual void save(YAML::Emitter& out) const;
 	/// Gets the moving target's destination.
-	Target *const getDestination() const;
+	Target *getDestination() const;
 	/// Sets the moving target's destination.
 	virtual void setDestination(Target *dest);
 	/// Gets the moving target's speed.

--- a/src/Savegame/Region.cpp
+++ b/src/Savegame/Region.cpp
@@ -66,7 +66,7 @@ void Region::save(YAML::Emitter &out) const
  * Returns the ruleset for the region's type.
  * @return Pointer to ruleset.
  */
-RuleRegion *const Region::getRules() const
+RuleRegion *Region::getRules() const
 {
 	return _rules;
 }

--- a/src/Savegame/Region.h
+++ b/src/Savegame/Region.h
@@ -47,7 +47,7 @@ public:
 	/// Saves the region to YAML.
 	void save(YAML::Emitter& out) const;
 	/// Gets the region's ruleset.
-	RuleRegion *const getRules() const;
+	RuleRegion *getRules() const;
 	/// add xcom activity in this region
 	void addActivityXcom(int activity);
 	/// add alien activity in this region

--- a/src/Savegame/SavedBattleGame.cpp
+++ b/src/Savegame/SavedBattleGame.cpp
@@ -625,7 +625,7 @@ BattleUnit *SavedBattleGame::selectUnit(const Position& pos)
  * Gets the list of nodes.
  * @return pointer to the list of nodes
  */
-std::vector<Node*> *const SavedBattleGame::getNodes()
+std::vector<Node*> *SavedBattleGame::getNodes()
 {
 	return &_nodes;
 }
@@ -634,7 +634,7 @@ std::vector<Node*> *const SavedBattleGame::getNodes()
  * Gets the list of units.
  * @return pointer to the list of units
  */
-std::vector<BattleUnit*> *const SavedBattleGame::getUnits()
+std::vector<BattleUnit*> *SavedBattleGame::getUnits()
 {
 	return &_units;
 }
@@ -643,7 +643,7 @@ std::vector<BattleUnit*> *const SavedBattleGame::getUnits()
  * Gets the list of items.
  * @return pointer to the list of items
  */
-std::vector<BattleItem*> *const SavedBattleGame::getItems()
+std::vector<BattleItem*> *SavedBattleGame::getItems()
 {
 	return &_items;
 }
@@ -652,7 +652,7 @@ std::vector<BattleItem*> *const SavedBattleGame::getItems()
  * Get the pathfinding object.
  * @return pointer to the pathfinding object
  */
-Pathfinding *const SavedBattleGame::getPathfinding() const
+Pathfinding *SavedBattleGame::getPathfinding() const
 {
 	return _pathfinding;
 }
@@ -661,7 +661,7 @@ Pathfinding *const SavedBattleGame::getPathfinding() const
  * Get the terrain modifier object.
  * @return pointer to the terrain modifier object
  */
-TileEngine *const SavedBattleGame::getTileEngine() const
+TileEngine *SavedBattleGame::getTileEngine() const
 {
 	return _tileEngine;
 }
@@ -670,7 +670,7 @@ TileEngine *const SavedBattleGame::getTileEngine() const
 * gets a pointer to the array of mapblock
 * @return pointer to the array of mapblocks
 */
-std::vector<MapDataSet*> *const SavedBattleGame::getMapDataSets()
+std::vector<MapDataSet*> *SavedBattleGame::getMapDataSets()
 {
 	return &_mapDataSets;
 }

--- a/src/Savegame/SavedBattleGame.h
+++ b/src/Savegame/SavedBattleGame.h
@@ -89,7 +89,7 @@ public:
 	/// initialises pathfinding and tileengine
 	void initUtilities(ResourcePack *res);
 	/// Gets the game's mapdatafiles.
-	std::vector<MapDataSet*> *const getMapDataSets();
+	std::vector<MapDataSet*> *getMapDataSets();
 	/// Set the mission type.
 	void setMissionType(const std::string &missionType);
 	/// Get the mission type.
@@ -101,11 +101,11 @@ public:
 	/// Gets pointer to the tiles, a tile is the smallest component of battlescape.
 	Tile **getTiles() const;
 	/// Get pointer to the list of nodes.
-	std::vector<Node*> *const getNodes();
+	std::vector<Node*> *getNodes();
 	/// Get pointer to the list of items.
-	std::vector<BattleItem*> *const getItems();
+	std::vector<BattleItem*> *getItems();
 	/// Get pointer to the list of units.
-	std::vector<BattleUnit*> *const getUnits();
+	std::vector<BattleUnit*> *getUnits();
 	/// Gets terrain width.
 	int getWidth() const;
 	/// Gets terrain length.
@@ -131,9 +131,9 @@ public:
 	/// select unit with position on map
 	BattleUnit *selectUnit(Tile *tile);
 	/// get the pathfinding object
-	Pathfinding *const getPathfinding() const;
+	Pathfinding *getPathfinding() const;
 	/// get a pointer to the tileengine
-	TileEngine *const getTileEngine() const;
+	TileEngine *getTileEngine() const;
 	/// get the playing side
 	UnitFaction getSide() const;
 	/// get the turn number

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -505,7 +505,7 @@ void SavedGame::monthlyFunding()
  * Returns the current time of the game.
  * @return Pointer to the game time.
  */
-GameTime *const SavedGame::getTime() const
+GameTime *SavedGame::getTime() const
 {
 	return _time;
 }
@@ -536,7 +536,7 @@ void SavedGame::initIds(const std::map<std::string, int> &ids)
  * Returns the list of countries in the game world.
  * @return Pointer to country list.
  */
-std::vector<Country*> *const SavedGame::getCountries()
+std::vector<Country*> *SavedGame::getCountries()
 {
 	return &_countries;
 }
@@ -559,7 +559,7 @@ int SavedGame::getCountryFunding() const
  * Returns the list of world regions.
  * @return Pointer to region list.
  */
-std::vector<Region*> *const SavedGame::getRegions()
+std::vector<Region*> *SavedGame::getRegions()
 {
 	return &_regions;
 }
@@ -568,7 +568,7 @@ std::vector<Region*> *const SavedGame::getRegions()
  * Returns the list of player bases.
  * @return Pointer to base list.
  */
-std::vector<Base*> *const SavedGame::getBases()
+std::vector<Base*> *SavedGame::getBases()
 {
 	return &_bases;
 }
@@ -591,7 +591,7 @@ int SavedGame::getBaseMaintenance() const
  * Returns the list of alien UFOs.
  * @return Pointer to UFO list.
  */
-std::vector<Ufo*> *const SavedGame::getUfos()
+std::vector<Ufo*> *SavedGame::getUfos()
 {
 	return &_ufos;
 }
@@ -600,7 +600,7 @@ std::vector<Ufo*> *const SavedGame::getUfos()
  * Returns the list of craft waypoints.
  * @return Pointer to waypoint list.
  */
-std::vector<Waypoint*> *const SavedGame::getWaypoints()
+std::vector<Waypoint*> *SavedGame::getWaypoints()
 {
 	return &_waypoints;
 }
@@ -609,7 +609,7 @@ std::vector<Waypoint*> *const SavedGame::getWaypoints()
  * Returns the list of terror sites.
  * @return Pointer to terror site list.
  */
-std::vector<TerrorSite*> *const SavedGame::getTerrorSites()
+std::vector<TerrorSite*> *SavedGame::getTerrorSites()
 {
 	return &_terrorSites;
 }
@@ -618,7 +618,7 @@ std::vector<TerrorSite*> *const SavedGame::getTerrorSites()
  * Get pointer to the battleGame object.
  * @return Pointer to the battleGame object.
  */
-SavedBattleGame *const SavedGame::getBattleGame()
+SavedBattleGame *SavedGame::getBattleGame()
 {
 	return _battleGame;
 }
@@ -918,7 +918,7 @@ bool SavedGame::isResearched(const std::vector<std::string> &research) const
  * @param id A soldier's unique id.
  * @return Pointer to Soldier.
  */
-Soldier *const SavedGame::getSoldier(int id) const
+Soldier *SavedGame::getSoldier(int id) const
 {
 	for (std::vector<Base*>::const_iterator i = _bases.begin(); i != _bases.end(); ++i)
 	{
@@ -1022,7 +1022,7 @@ void SavedGame::inspectSoldiers(Soldier **highestRanked, size_t *total, int rank
   * Returns the list of alien bases.
   * @return Pointer to alien base list.
   */
-std::vector<AlienBase*> *const SavedGame::getAlienBases()
+std::vector<AlienBase*> *SavedGame::getAlienBases()
 {
 	return &_alienBases;
 }

--- a/src/Savegame/SavedGame.h
+++ b/src/Savegame/SavedGame.h
@@ -110,29 +110,29 @@ public:
 	/// Handles monthly funding.
 	void monthlyFunding();
 	/// Gets the current game time.
-	GameTime *const getTime() const;
+	GameTime *getTime() const;
 	/// Gets the current ID for an object.
 	int getId(const std::string &name);
 	/// Initializes te IDs list.
 	void initIds(const std::map<std::string, int> &ids);
 	/// Gets the list of countries.
-	std::vector<Country*> *const getCountries();
+	std::vector<Country*> *getCountries();
 	/// Gets the total country funding.
 	int getCountryFunding() const;
 	/// Gets the list of regions.
-	std::vector<Region*> *const getRegions();
+	std::vector<Region*> *getRegions();
 	/// Gets the list of bases.
-	std::vector<Base*> *const getBases();
+	std::vector<Base*> *getBases();
 	/// Gets the total base maintenance.
 	int getBaseMaintenance() const;
 	/// Gets the list of UFOs.
-	std::vector<Ufo*> *const getUfos();
+	std::vector<Ufo*> *getUfos();
 	/// Gets the list of waypoints.
-	std::vector<Waypoint*> *const getWaypoints();
+	std::vector<Waypoint*> *getWaypoints();
 	/// Gets the list of terror sites.
-	std::vector<TerrorSite*> *const getTerrorSites();
+	std::vector<TerrorSite*> *getTerrorSites();
 	/// Gets the current battle game.
-	SavedBattleGame *const getBattleGame();
+	SavedBattleGame *getBattleGame();
 	/// Sets the current battle game.
 	void setBattleGame(SavedBattleGame *battleGame);
 	/// Add a finished ResearchProject
@@ -152,13 +152,13 @@ public:
 	/// Gets if a list of research has been unlocked.
 	bool isResearched(const std::vector<std::string> &research) const;
 	/// Gets the soldier matching this ID.
-	Soldier *const getSoldier(int id) const;
+	Soldier *getSoldier(int id) const;
 	/// Handles the higher promotions.
 	bool handlePromotions();
 	/// Checks how many soldiers of a rank exist and which one has the highest score.
 	void inspectSoldiers(Soldier **highestRanked, size_t *total, int rank);
 	///  Returns the list of alien bases.
-	std::vector<AlienBase*> *const getAlienBases();
+	std::vector<AlienBase*> *getAlienBases();
 	/// Sets debug mode.
 	void setDebugMode();
 	/// Gets debug mode.

--- a/src/Savegame/Soldier.cpp
+++ b/src/Savegame/Soldier.cpp
@@ -174,7 +174,7 @@ void Soldier::setName(const std::wstring &name)
  * Returns the craft the soldier is assigned to.
  * @return Pointer to craft.
  */
-Craft *const Soldier::getCraft() const
+Craft *Soldier::getCraft() const
 {
 	return _craft;
 }
@@ -380,7 +380,7 @@ bool Soldier::isPromoted()
  * Returns the unit's current armor.
  * @return Pointer to armor data.
  */
-Armor *const Soldier::getArmor() const
+Armor *Soldier::getArmor() const
 {
 	return _armor;
 }
@@ -430,7 +430,7 @@ void Soldier::heal()
  * Returns the list of EquipmentLayoutItems of a soldier.
  * @return Pointer to the EquipmentLayoutItem list.
  */
-std::vector<EquipmentLayoutItem*> *const Soldier::getEquipmentLayout()
+std::vector<EquipmentLayoutItem*> *Soldier::getEquipmentLayout()
 {
 	return &_equipmentLayout;
 }

--- a/src/Savegame/Soldier.h
+++ b/src/Savegame/Soldier.h
@@ -72,7 +72,7 @@ public:
 	/// Sets the soldier's name.
 	void setName(const std::wstring &name);
 	/// Gets the soldier's craft.
-	Craft *const getCraft() const;
+	Craft *getCraft() const;
 	/// Sets the soldier's craft.
 	void setCraft(Craft *craft);
 	/// Gets the soldier's craft string.
@@ -108,7 +108,7 @@ public:
 	/// Get whether the unit was recently promoted.
 	bool isPromoted();
 	/// Gets the soldier armor.
-	Armor *const getArmor() const;
+	Armor *getArmor() const;
 	/// Sets the soldier armor.
 	void setArmor(Armor *armor);
 	/// Gets the soldier's wound recovery time.
@@ -118,7 +118,7 @@ public:
 	/// Heals wound recoveries.
 	void heal();
 	/// Gets the soldier's equipment-layout.
-	std::vector<EquipmentLayoutItem*> *const getEquipmentLayout();
+	std::vector<EquipmentLayoutItem*> *getEquipmentLayout();
 	/// Trains a soldier's psychic stats
 	void trainPsi();
 	/// Returns whether the unit is in psi training or not

--- a/src/Savegame/Ufo.cpp
+++ b/src/Savegame/Ufo.cpp
@@ -125,7 +125,7 @@ void Ufo::saveId(YAML::Emitter &out) const
  * Returns the ruleset for the UFO's type.
  * @return Pointer to ruleset.
  */
-RuleUfo *const Ufo::getRules() const
+RuleUfo *Ufo::getRules() const
 {
 	return _rules;
 }

--- a/src/Savegame/Ufo.h
+++ b/src/Savegame/Ufo.h
@@ -63,7 +63,7 @@ public:
 	/// Saves the UFO's ID to YAML.
 	void saveId(YAML::Emitter& out) const;
 	/// Gets the UFO's ruleset.
-	RuleUfo *const getRules() const;
+	RuleUfo *getRules() const;
 	/// Gets the UFO's ID.
 	int getId() const;
 	/// Sets the UFO's ID.

--- a/src/Savegame/Vehicle.cpp
+++ b/src/Savegame/Vehicle.cpp
@@ -63,7 +63,7 @@ void Vehicle::save(YAML::Emitter &out) const
  * Returns the ruleset for the vehicle's type.
  * @return Pointer to ruleset.
  */
-RuleItem *const Vehicle::getRules() const
+RuleItem *Vehicle::getRules() const
 {
 	return _rules;
 }

--- a/src/Savegame/Vehicle.h
+++ b/src/Savegame/Vehicle.h
@@ -47,7 +47,7 @@ public:
 	/// Saves the vehicle to YAML.
 	void save(YAML::Emitter& out) const;
 	/// Gets the vehicle's ruleset.
-	RuleItem *const getRules() const;
+	RuleItem *getRules() const;
 	/// Gets the vehicle's ammo.
 	int getAmmo() const;
 	/// Sets the vehicle's ammo.


### PR DESCRIPTION
Returning a const pointer (not a pointer to const) is not really useful, since
returns of scalar types are by value.

The warning was produced by g++ 4.7.2, using -Wignored-qualifiers.
