### PR TITLE
code clean to remove some warning

### DIFF
--- a/src/Makefile.simple
+++ b/src/Makefile.simple
@@ -20,7 +20,7 @@ BIN = openxcom
 endif
 
 # Compiler settings
-CXXFLAGS ?= -Wall -O2 -rdynamic
+CXXFLAGS ?= -Wall -Wextra -O2 -rdynamic
 CXXFLAGS += $(addprefix -D,$(TARGET))
 CXXFLAGS += $(shell $(PKG-CONFIG) --cflags sdl yaml-cpp)
 

--- a/src/Ruleset/RuleAlienMission.cpp
+++ b/src/Ruleset/RuleAlienMission.cpp
@@ -140,7 +140,7 @@ RuleAlienMission::~RuleAlienMission()
 /**
  * Return the Alien score for this mission.
  */
-const int RuleAlienMission::getPoints() const
+int RuleAlienMission::getPoints() const
 {
 	return _points;
 }

--- a/src/Ruleset/RuleAlienMission.h
+++ b/src/Ruleset/RuleAlienMission.h
@@ -81,7 +81,7 @@ public:
 	/// Gets the full wave information.
 	const MissionWave &getWave(unsigned index) const { return _waves[index]; }
 	/// Gets the score for this mission.
-	const int getPoints() const;
+	int getPoints() const;
 private:
 	/// The mission's type ID.
 	std::string _type;


### PR DESCRIPTION
this commit remove this warning
In file included from Ruleset/RuleAlienMission.cpp:19:0:
Ruleset/RuleAlienMission.h:84:24: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
Ruleset/RuleAlienMission.cpp:143:41: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]

In file included from Ruleset/Ruleset.cpp:52:0:
Ruleset/RuleAlienMission.h:84:24: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]

In file included from Savegame/AlienMission.cpp:27:0:
Savegame/../Ruleset/RuleAlienMission.h:84:24: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]

also i add Wextra to makefile to enable all warning
