### PR TITLE
if LBM files missing

### DIFF
--- a/src/Engine/Surface.cpp
+++ b/src/Engine/Surface.cpp
@@ -127,7 +127,8 @@ void Surface::loadLbm(const std::string &filename)
 	std::ifstream imgFile (filename.c_str(), std::ios::in | std::ios::binary);
 	if (!imgFile)
 	{
-		throw Exception("Failed to load LBM");
+		imgFile.close();
+		return;
 	}
 
 	// Lock the surface


### PR DESCRIPTION
Some folks (me!) deleted some of their LBM files decades ago. Game should not raise an exception if they are missing.
