### PR TITLE
insufferable clicks and pops in samples from MS-DOS version .CAT files (fixed)

### DIFF
--- a/src/Engine/SoundSet.cpp
+++ b/src/Engine/SoundSet.cpp
@@ -65,7 +65,7 @@ void SoundSet::loadCat(const std::string &filename, bool wav)
 	for (int i = 0; i < sndFile.getAmount(); ++i)
 	{
 		// Read WAV chunk
-		char *sound = sndFile.load(i);
+		unsigned char *sound = (unsigned char*) sndFile.load(i);
 		unsigned int size = sndFile.getObjectSize(i);
 
 		// If there's no WAV header (44 bytes), add it
@@ -76,6 +76,11 @@ void SoundSet::loadCat(const std::string &filename, bool wav)
 			char header[] = {'R', 'I', 'F', 'F', 0x00, 0x00, 0x00, 0x00, 'W', 'A', 'V', 'E', 'f', 'm', 't', ' ',
 							 0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x40, 0x1f, 0x00, 0x00, 0x40, 0x1f, 0x00, 0x00, 0x01, 0x00, 0x08, 0x00,
 							 'd', 'a', 't', 'a', 0x00, 0x00, 0x00, 0x00};
+
+            for (int n = 0; n < size; ++n) sound[n] *= 4; // scale to 8 bits
+            if (size > 5) size -= 5; // skip 5 garbage name bytes at beginning
+            if (size) size--; // omit trailing null byte
+
 			int headersize = size + 36;
 			int soundsize = size;
 			memcpy(header + 4, &headersize, sizeof(headersize));
@@ -83,7 +88,7 @@ void SoundSet::loadCat(const std::string &filename, bool wav)
 
 			newsound = new char[44 + size];
 			memcpy(newsound, header, 44);
-			memcpy(newsound + 44, sound, size);
+			if (size) memcpy(newsound + 44, sound+5, size);
 		}
 
 		Sound *s = new Sound();


### PR DESCRIPTION
I found several problems affecting samples from .CAT files that resulted in terrible clicks and pops. These were audible at the beginning and end of every sound that played ever.

First, the sound data was not actually 8-bit samples but rather 6-bit. Weird, right? However, it was pretty clear from hex dumps that silence in the data was 0x20 (as opposed to ~0x80 as one would expect for an 8-bit sample.) The result was pops at the beginning and end of samples. It also caused all sounds to play at 1/4 volume. Perhaps this was done to simplify mixing in the original game? 

Second, there were five bytes of garbage at the beginning of every sample. The decat.exe tool from tttools.zip found at http://www.ttdpatch.net/chris_becke_ttdlx.html seems to think that these bytes are meant to be four name bytes and a terminating null bytes. 

Finally, there's a trailing null byte for no good reason at all.

With those things resolved, the game sounds great!

(This is probably where I find out that it already sounded fine to everyone else and I have some weird version of the data files...)
