### PR TITLE
messed-up Sectopod weapon fire and hit sounds, fixed

### DIFF
--- a/bin/data/Ruleset/Xcom1Ruleset.rul
+++ b/bin/data/Ruleset/Xcom1Ruleset.rul
@@ -2880,7 +2880,8 @@ items:
     bigSprite: 32
     floorSprite: 31
     handSprite: 104
-    hitSound: 48
+    fireSound: 11
+    hitSound: 19
     hitAnimation: 36
     power: 100
     damageType: 4


### PR DESCRIPTION
They're supposed to be lasers as opposed to silence on fire and a zombie bite
on hit, I think...
