### PR TITLE
Add cancel button to New Game State menu

### DIFF
--- a/src/Menu/MainMenuState.cpp
+++ b/src/Menu/MainMenuState.cpp
@@ -122,7 +122,7 @@ void MainMenuState::init()
  */
 void MainMenuState::btnNewGameClick(Action *)
 {
-	_game->setState(new NewGameState(_game));
+	_game->pushState(new NewGameState(_game));
 }
 
 /**

--- a/src/Menu/NewGameState.cpp
+++ b/src/Menu/NewGameState.cpp
@@ -40,12 +40,13 @@ NewGameState::NewGameState(Game *game) : State(game)
 {
 	// Create objects
 	_window = new Window(this, 192, 180, 64, 10, POPUP_VERTICAL);
-	_btnBeginner = new TextButton(160, 18, 80, 55);
-	_btnExperienced = new TextButton(160, 18, 80, 80);
-	_btnVeteran = new TextButton(160, 18, 80, 105);
-	_btnGenius = new TextButton(160, 18, 80, 130);
-	_btnSuperhuman = new TextButton(160, 18, 80, 155);
-	_txtTitle = new Text(192, 10, 64, 30);
+	_btnBeginner = new TextButton(160, 18, 80, 30);
+	_btnExperienced = new TextButton(160, 18, 80, 55);
+	_btnVeteran = new TextButton(160, 18, 80, 80);
+	_btnGenius = new TextButton(160, 18, 80, 105);
+	_btnSuperhuman = new TextButton(160, 18, 80, 130);
+	_btnCancel = new TextButton(160, 18, 80, 155);
+	_txtTitle = new Text(192, 10, 64, 17);
 
 	add(_window);
 	add(_btnBeginner);
@@ -53,6 +54,7 @@ NewGameState::NewGameState(Game *game) : State(game)
 	add(_btnVeteran);
 	add(_btnGenius);
 	add(_btnSuperhuman);
+	add(_btnCancel);
 	add(_txtTitle);
 
 	// Set up objects
@@ -78,6 +80,10 @@ NewGameState::NewGameState(Game *game) : State(game)
 	_btnSuperhuman->setColor(Palette::blockOffset(8)+5);
 	_btnSuperhuman->setText(_game->getLanguage()->getString("STR_5_SUPERHUMAN"));
 	_btnSuperhuman->onMouseClick((ActionHandler)&NewGameState::btnSuperhumanClick);
+
+	_btnCancel->setColor(Palette::blockOffset(8)+5);
+	_btnCancel->setText(_game->getLanguage()->getString("STR_CANCEL_UC"));
+	_btnCancel->onMouseClick((ActionHandler)&NewGameState::btnCancelClick);
 
 	_txtTitle->setColor(Palette::blockOffset(8)+10);
 	_txtTitle->setAlign(ALIGN_CENTER);
@@ -155,6 +161,16 @@ void NewGameState::btnGeniusClick(Action *)
 void NewGameState::btnSuperhumanClick(Action *)
 {
 	newGame(DIFF_SUPERHUMAN);
+}
+
+/**
+ * Returns to the previous screen.
+ * @param action Pointer to an action.
+ */
+void NewGameState::btnCancelClick(Action *)
+{
+	_game->setSavedGame(0);
+	_game->popState();
 }
 
 }

--- a/src/Menu/NewGameState.h
+++ b/src/Menu/NewGameState.h
@@ -37,7 +37,8 @@ class Text;
 class NewGameState : public State
 {
 private:
-	TextButton *_btnBeginner, *_btnExperienced, *_btnVeteran, *_btnGenius, *_btnSuperhuman;
+	TextButton *_btnBeginner, *_btnExperienced, *_btnVeteran;
+	TextButton *_btnGenius, *_btnSuperhuman, *_btnCancel;
 	Window *_window;
 	Text *_txtTitle;
 public:
@@ -57,6 +58,8 @@ public:
 	void btnGeniusClick(Action *action);
 	/// Handler for clicking the Superhuman button.
 	void btnSuperhumanClick(Action *action);
+	/// Handler for clicking the cancel button.
+	void btnCancelClick(Action *);
 };
 
 }


### PR DESCRIPTION
This is my first attempt at contributing to an open source project so shoot me if it's trivial :), but I figured this cancel button is nice because I used to hate (still do with OpenXcom) when I mis-clicked New Game when I meant to do Load Game because I had to do the following:

Click a difficulty
Click a place on the map
Enter a bogus name
Hit Enter
Click Options
Click Abandon Game or click Load Game
Click new game to load or OK if Abandon game...

just to get back to the main menu or load the game I meant to.
