### PR TITLE
Fix for https://github.com/SupSuper/OpenXcom/issues/240 , misleading error message.

### DIFF
--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -387,7 +387,8 @@ std::vector<std::string> getFolderContents(const std::string &path, const std::s
 	DIR *dp = opendir(path.c_str());
 	if (dp == 0)
 	{
-		throw Exception("Failed to open saves directory");
+		std::string errorMessage("Failed to open directory: " + path);
+		throw Exception(errorMessage);
 	}
 
 	struct dirent *dirp;


### PR DESCRIPTION
Fix for https://github.com/SupSuper/OpenXcom/issues/240 . Builds a new string w/the path and throws that in the Exception, and I see it logged and printed to the screen when it's thrown.
