### PR TITLE
defer palette update until SDL_Flip()

### DIFF
--- a/src/Engine/Screen.cpp
+++ b/src/Engine/Screen.cpp
@@ -52,6 +52,8 @@ Screen::Screen(int width, int height, int bpp, bool fullscreen) : _bpp(bpp), _sc
 		_flags |= SDL_FULLSCREEN;
 	}
 	setResolution(width, height);
+	memset(deferredPalette, 256, sizeof(SDL_Color));
+	_numColors = _firstColor = 0;
 }
 
 /**
@@ -249,6 +251,16 @@ void Screen::flip()
 		SDL_BlitSurface(_surface->getSurface(), 0, _screen, 0);
 	}
 
+	// perform any requested palette update
+	if (_numColors)
+	{
+		if (SDL_SetColors(_screen, deferredPalette, _firstColor, _numColors) == 0)
+		{
+			Log(LOG_ERROR) << "Display palette doesn't match requested palette";
+		}
+		_numColors = 0;
+	}
+
 	if (SDL_Flip(_screen) == -1)
 	{
 		throw Exception(SDL_GetError());
@@ -277,11 +289,28 @@ void Screen::clear()
  */
 void Screen::setPalette(SDL_Color* colors, int firstcolor, int ncolors)
 {
-	_surface->setPalette(colors, firstcolor, ncolors);
-	if (SDL_SetColors(_screen, colors, firstcolor, ncolors) == 0)
+	if (_numColors && ncolors < 256)
 	{
-		Log(LOG_ERROR) << "Display palette doesn't match requested palette";
+		// an initial palette setup has not been comitted to the screen yet
+		// just update it with whatever colors are being sent now
+		memcpy(&(deferredPalette[firstcolor]), colors, sizeof(SDL_Color)*ncolors);
+		_numColors = 256; // all the use cases are just a full palette with a single 16-color follow-up
+		_firstColor = 0;
+	} else
+	{
+		memcpy(deferredPalette, colors, sizeof(SDL_Color) * ncolors);
+		_numColors = ncolors;
+		_firstColor = firstcolor;
 	}
+
+	_surface->setPalette(colors, firstcolor, ncolors);
+
+	// defer actual update of screen until SDL_Flip()
+	//if (SDL_SetColors(_screen, colors, firstcolor, ncolors) == 0)
+	//{
+	//	Log(LOG_ERROR) << "Display palette doesn't match requested palette";
+	//}
+
 	// Sanity check
 	/*
 	SDL_Color *newcolors = _screen->format->palette->colors;

--- a/src/Engine/Screen.h
+++ b/src/Engine/Screen.h
@@ -47,6 +47,8 @@ private:
 	Uint32 _flags;
 	bool _fullscreen;
 	int _zoomSurfaceY(SDL_Surface * src, SDL_Surface * dst, int flipx, int flipy);
+	SDL_Color deferredPalette[256];
+	int _numColors, _firstColor;
 public:
 	/// Creates a new display screen with the specified resolution.
 	Screen(int width, int height, int bpp, bool fullscreen);


### PR DESCRIPTION
this cuts way down on the ugly palette swap artefacts that have been present
ref: http://openxcom.org/forum/index.php/topic,875.0.html
