### PR TITLE
fixing compilation errors on Linux

### DIFF
--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -18,6 +18,7 @@
  */
 #include "CrossPlatform.h"
 #include <algorithm>
+#include <iostream>
 #include "../dirent.h"
 #include "Logger.h"
 #include "Exception.h"

--- a/src/Resource/XcomResourcePack.cpp
+++ b/src/Resource/XcomResourcePack.cpp
@@ -26,7 +26,7 @@
 #include "../Engine/Language.h"
 #include "../Engine/Music.h"
 #include "../Engine/GMCat.h"
-#include "../engine/SoundSet.h"
+#include "../Engine/SoundSet.h"
 #include "../Engine/Options.h"
 #include "../Geoscape/Globe.h"
 #include "../Geoscape/Polygon.h"


### PR DESCRIPTION
directory and file names are case sensitive!
std::cerr requires an #include
