### PR TITLE
Change: Show all radar-types' range on all bases in base building mode

### DIFF
--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -84,6 +84,7 @@ void createDefault()
 	setBool("fpsCounter", false);
 	setBool("craftLaunchAlways", false);
 	setBool("globeSeasons", false);
+	setBool("globeAllRadarsOnBaseBuild", true);
 	setInt("audioSampleRate", 22050);
 	setInt("audioBitDepth", 16);
 	setInt("pauseMode", 0);


### PR DESCRIPTION
It can be turned off to work in the old way by setting the globeAllRadarsOnBaseBuild setting in options.cfg to false.

It can be very useful if the player is building a new base before the previous new base's radar (its construction) is completed. (the player want to do optimal cover)
