### PR TITLE
New: AutoSell Production Option.

### DIFF
--- a/src/Basescape/ManufactureState.cpp
+++ b/src/Basescape/ManufactureState.cpp
@@ -34,6 +34,8 @@
 #include "../Savegame/Production.h"
 #include "NewManufactureListState.h"
 #include "ManufactureInfoState.h"
+#include "../Engine/Options.h"
+#include <limits>
 
 namespace OpenXcom
 {
@@ -193,13 +195,18 @@ void ManufactureState::fillProductionList()
 		std::wstringstream s2;
 		s2 << (*iter)->getAmountProduced();
 		std::wstringstream s3;
-		s3 << (*iter)->getAmountTotal();
+		if (Options::getBool("allowAutoSellProduction") && (*iter)->getAmountTotal() == std::numeric_limits<int>::max())
+			s3 << "$$$";
+		else s3 << (*iter)->getAmountTotal();
 		std::wstringstream s4;
 		s4 << Text::formatFunding((*iter)->getRules()->getManufactureCost());
 		std::wstringstream s5;
 		if ((*iter)->getAssignedEngineers() > 0)
 		{
-			int timeLeft = (*iter)->getAmountTotal () * (*iter)->getRules()->getManufactureTime() - (*iter)->getTimeSpent ();
+			int timeLeft;
+			if (Options::getBool("allowAutoSellProduction") && (*iter)->getAmountTotal() == std::numeric_limits<int>::max())
+				timeLeft = ((*iter)->getAmountProduced()+1) * (*iter)->getRules()->getManufactureTime() - (*iter)->getTimeSpent ();
+			else timeLeft = (*iter)->getAmountTotal () * (*iter)->getRules()->getManufactureTime() - (*iter)->getTimeSpent ();
 			timeLeft /= (*iter)->getAssignedEngineers();
 			float dayLeft = timeLeft / 24.0f;
 			int hours = (dayLeft - static_cast<int>(dayLeft)) * 24;

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -91,6 +91,7 @@ void createDefault()
 	setBool("aggressiveRetaliation", false);
 	setBool("strafe", false);
 	setBool("battleNotifyDeath", false);
+	setBool("allowAutoSellProduction", false);
 	// controls
 	setInt("keyOk", SDLK_RETURN);
 	setInt("keyCancel", SDLK_ESCAPE);

--- a/src/Savegame/Production.cpp
+++ b/src/Savegame/Production.cpp
@@ -23,6 +23,9 @@
 #include "ItemContainer.h"
 #include "Craft.h"
 #include "../Ruleset/Ruleset.h"
+#include "../Ruleset/RuleItem.h"
+#include "../Engine/Options.h"
+#include <limits>
 
 namespace OpenXcom
 {
@@ -74,7 +77,10 @@ productionProgress_e Production::step(Base * b, SavedGame * g, const Ruleset *r)
 		}
 		else
 		{
-			b->getItems ()->addItem(_rules->getName (), 1);
+			if (Options::getBool("allowAutoSellProduction") && getAmountTotal() == std::numeric_limits<int>::max())
+				g->setFunds(g->getFunds() + r->getItem(_rules->getName())->getSellCost());
+			else
+				b->getItems()->addItem(_rules->getName(), 1);
 		}
 	}
 	if (getAmountProduced () >= _amount)


### PR DESCRIPTION
This feature can be turned on/off with allowAutoSellProduction in options.cfg.
Default is OFF!
It can be activated with a right-click on the UP-arrow-button when assigning "Total to Produce" on the Manufacture-screen. Its state is showed by $$$. When a new item is built, it will be sold immediately. The time-left column on the Manufacture-screen shows the time left to complete one new item.
