### PR TITLE
use locale-appropriate symbol to separate thousands in funds

### DIFF
--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -464,26 +464,6 @@ void GeoscapeState::think()
 }
 
 /**
- * Converts an int into the given stringstream, grouped by thousands.
- * @param out The stringstream which takes the converted value.
- * @param n The int to be converted.
- */
-void GeoscapeState::intToStringStreamGrouped(std::stringstream &out, int n)
-{
-  if (n < 0)
-	{
-    out << "-";
-    intToStringStreamGrouped(out, -n);
-  }
-	else if (n < 1000) out << n;
-  else
-	{
-    intToStringStreamGrouped(out, n / 1000);
-    out << "." << std::setw(3) << std::setfill('0') << (n % 1000);
-  }
-}
-
-/**
  * Updates the Geoscape clock with the latest
  * game time and date in human-readable format. (+Funds)
  */
@@ -494,9 +474,7 @@ void GeoscapeState::timeDisplay()
 
 	if (_showFundsOnGeoscape)
 	{
-		std::stringstream ss6;
-		intToStringStreamGrouped(ss6,_game->getSavedGame()->getFunds());
-		_txtFunds->setText(Language::utf8ToWstr("$"+ss6.str()));
+		_txtFunds->setText(Text::formatFunding(_game->getSavedGame()->getFunds()));
 	}
 
 	ss << std::setfill('0') << std::setw(2) << _game->getSavedGame()->getTime()->getSecond();

--- a/src/Geoscape/GeoscapeState.h
+++ b/src/Geoscape/GeoscapeState.h
@@ -68,8 +68,6 @@ public:
 	void init();
 	/// Runs the timer.
 	void think();
-	/// Converts an int into the given stringstream, grouped by thousands.
-	void static intToStringStreamGrouped(std::stringstream &out, int n);
 	/// Displays the game time/date. (+Funds)
 	void timeDisplay();
 	/// Advances the game timer.

--- a/src/Interface/Text.cpp
+++ b/src/Interface/Text.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 #include "../Engine/Font.h"
 #include "../Engine/Options.h"
+#include "../Engine/Language.h"
 
 namespace OpenXcom
 {
@@ -51,6 +52,11 @@ Text::~Text()
  */
 std::wstring Text::formatFunding(int funds)
 {
+	setlocale (LC_MONETARY,""); // see http://www.cplusplus.com/reference/clocale/localeconv/
+	struct lconv * lc;
+	lc=localeconv();
+	std::wstring thousands_sep = Language::cpToWstr(lc->mon_thousands_sep);
+
 	bool negative = false;
 	if (funds < 0)
 	{
@@ -63,7 +69,7 @@ std::wstring Text::formatFunding(int funds)
 	size_t spacer = s.size() - 3;
 	while (spacer > 0 && spacer < s.size())
 	{
-		s.insert(spacer, L" ");
+		s.insert(spacer, thousands_sep);
 		spacer -= 3;
 	}
 	s.insert(0, L"$");


### PR DESCRIPTION
also use formatFunding() to format funding on geoscape and remove the unique function that was used for the purpose previously
