### PR TITLE
New option in options.cfg: canConvertAmmoToElerium

### DIFF
--- a/src/Engine/Game.cpp
+++ b/src/Engine/Game.cpp
@@ -418,7 +418,7 @@ void Game::loadLanguage(const std::string &filename)
 	std::stringstream ss, ss2;
 	ss << "Language/" << filename << ".lng";
 	ss2 << "Language/" << filename << ".geo";
-	_lang->loadLng(CrossPlatform::getDataFile(ss.str()));
+	_lang->loadLng(CrossPlatform::getDataFile(ss.str()), _rules);
 
 	std::auto_ptr<Surface> sidebar(new Surface(64, 154));
 	if (CrossPlatform::getDataFile(ss2.str()) != "")

--- a/src/Engine/Language.h
+++ b/src/Engine/Language.h
@@ -28,6 +28,7 @@ namespace OpenXcom
 {
 
 class TextList;
+class Ruleset;
 
 /**
  * Contains strings used throughout the game for localization.
@@ -56,7 +57,7 @@ public:
 	/// Gets list of languages in the data directory.
 	static std::vector<std::string> getList(TextList *list);
 	/// Loads an OpenXcom language file.
-	void loadLng(const std::string &filename);
+	void loadLng(const std::string &filename, const Ruleset * ruleset);
 	/// Gets the language's name.
 	std::wstring getName() const;
 	/// Outputs the language to a HTML file.

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -103,6 +103,7 @@ void createDefault()
 	setInt("pauseMode", 0);
 	setBool("alienContainmentHasUpperLimit", false);
 	setBool("canSellLiveAliens", false);
+	setBool("canConvertAmmoToElerium", false);
 	setBool("customInitialBase", false);
 	setBool("aggressiveRetaliation", false);
 	setBool("strafe", false);

--- a/src/Geoscape/NewPossibleManufactureState.cpp
+++ b/src/Geoscape/NewPossibleManufactureState.cpp
@@ -20,6 +20,7 @@
 #include "../Engine/Game.h"
 #include "../Engine/Palette.h"
 #include "../Engine/Language.h"
+#include "../Engine/Options.h"
 #include "../Resource/ResourcePack.h"
 #include "../Interface/TextButton.h"
 #include "../Interface/Window.h"
@@ -75,9 +76,11 @@ NewPossibleManufactureState::NewPossibleManufactureState(Game * game, Base * bas
 	_lstPossibilities->setColumns(1, 288);
 	_lstPossibilities->setBig();
 	_lstPossibilities->setAlign(ALIGN_CENTER);
+	bool canConvertAmmoToElerium = Options::getBool("canConvertAmmoToElerium");
 	for(std::vector<RuleManufacture *>::const_iterator iter = possibilities.begin (); iter != possibilities.end (); ++iter)
 	{
-		_lstPossibilities->addRow (1, _game->getLanguage()->getString((*iter)->getName ()).c_str());
+		if (canConvertAmmoToElerium || (*iter)->getName() == (*iter)->getProducedItem())
+			_lstPossibilities->addRow (1, _game->getLanguage()->getString((*iter)->getName()).c_str());
 	}
 }
 

--- a/src/Ruleset/RuleManufacture.cpp
+++ b/src/Ruleset/RuleManufacture.cpp
@@ -24,7 +24,22 @@ namespace OpenXcom
  * Create a new Manufacture
  * @param name The unique manufacture name
 */
-RuleManufacture::RuleManufacture(const std::string &name) : _name(name), _space(0), _time(0), _cost(0)
+RuleManufacture::RuleManufacture(const std::string &name) : _name(name), _producedItem(name), _space(0), _time(0), _cost(0), _produceQty(1)
+{
+}
+
+/**
+ * Create a new Manufacture
+ * @param name The unique manufacture name
+ * @param category The category type
+ * @param requires The required research
+ * @param space The required workshop space
+ * @param time The required time to produce one unit
+ * @param cost The required money
+ * @param requiredItems The required materials
+*/
+RuleManufacture::RuleManufacture(const std::string &name, const std::string &producedItem, const std::string &category, const std::vector<std::string> &requires, int space, int time, int cost, int produceQty, const std::map<std::string, int> &requiredItems) :
+	_name(name), _producedItem(producedItem), _category(category), _requires(requires), _space(space), _time(time), _cost(cost), _produceQty(produceQty), _requiredItems(requiredItems)
 {
 }
 
@@ -96,6 +111,15 @@ std::string RuleManufacture::getName () const
 }
 
 /**
+ * Get the name of the produced item (it is the same as getName in most cases)
+ * @return the name
+*/
+std::string RuleManufacture::getProducedItem() const
+{
+	return _producedItem;
+}
+
+/**
  * Get the category shown in the manufacture list
  * @return the category
 */
@@ -140,6 +164,15 @@ int RuleManufacture::getManufactureTime () const
 int RuleManufacture::getManufactureCost () const
 {
 	return _cost;
+}
+
+/**
+ * Get the number of objects to manufacture instead of one (it is 1 in most cases)
+ * @return the number
+*/
+int RuleManufacture::getProduceQty() const
+{
+	return _produceQty;
 }
 
 /**

--- a/src/Ruleset/RuleManufacture.h
+++ b/src/Ruleset/RuleManufacture.h
@@ -31,19 +31,23 @@ namespace OpenXcom
 class RuleManufacture
 {
 private:
-	std::string _name, _category;
+	std::string _name, _producedItem, _category;
 	std::vector<std::string> _requires;
-	int _space, _time, _cost;
+	int _space, _time, _cost, _produceQty;
 	std::map<std::string, int> _requiredItems;
 public:
 	/// Create ManufactureInfo
 	RuleManufacture(const std::string &name);
+	/// Create ManufactureInfo
+	RuleManufacture(const std::string &name, const std::string &producedItem, const std::string &category, const std::vector<std::string> &requires, int space, int time, int cost, int produceQty, const std::map<std::string, int> &requiredItems);
 	/// Loads the manufacture from YAML.
 	void load(const YAML::Node& node);
 	/// Saves the manufacture to YAML.
 	void save(YAML::Emitter& out) const;
 	///Get the manufacture name
 	std::string getName () const;
+	///Get the name of the produced item (it is the same as getName in most cases)
+	std::string getProducedItem() const;
 	///Get the manufacture category
 	std::string getCategory () const;
 	/// Gets the manufacture's requirements.
@@ -54,6 +58,8 @@ public:
 	int getManufactureTime () const;
 	///Get the cost of manufacturing one object
 	int getManufactureCost () const;
+	///Get the number of objects to manufacture instead of one (it is 1 in most cases)
+	int getProduceQty() const;
 	///Get the list of items required to manufacture one object
 	const std::map<std::string, int> & getRequiredItems() const;
 };

--- a/src/Ruleset/Ruleset.cpp
+++ b/src/Ruleset/Ruleset.cpp
@@ -176,6 +176,23 @@ void Ruleset::load(const std::string &source)
 		loadFile(Options::getDataFolder() + "Ruleset/" + source + ".rul");
 	else
 		loadFiles(dirname);
+	// This is needed for canConvertAmmoToElerium:
+	for (std::map<std::string, RuleManufacture *>::const_iterator i = _manufacture.begin (); i != _manufacture.end (); ++i)
+	{
+		if ("STR_AMMUNITION" != i->second->getCategory() && "STR_WEAPON" != i->second->getCategory()
+		|| 0 >= i->second->getRequiredItems().size())
+			continue;
+		std::map<std::string, int>::const_iterator requiredItem = i->second->getRequiredItems().begin();
+		if ("STR_WEAPON" == i->second->getCategory() && _manufacture.find(requiredItem->first) != _manufacture.end()) continue; // We want the Alien Grenade only :)
+		std::string type = requiredItem->first + "_" + i->first;
+		std::map<std::string, int> requiredItems;
+		requiredItems[i->first] = 1;
+		RuleManufacture *rule = new RuleManufacture(type, requiredItem->first, "STR_UFO_COMPONENT",
+			i->second->getRequirements(), i->second->getRequiredSpace(), i->second->getManufactureTime()/2, 0,
+			requiredItem->second, requiredItems);
+		_manufacture[type] = rule;
+		_manufactureIndex.push_back(type);
+	}
 }
 
 /**

--- a/src/Savegame/Production.cpp
+++ b/src/Savegame/Production.cpp
@@ -78,9 +78,9 @@ productionProgress_e Production::step(Base * b, SavedGame * g, const Ruleset *r)
 		else
 		{
 			if (Options::getBool("allowAutoSellProduction") && getAmountTotal() == std::numeric_limits<int>::max())
-				g->setFunds(g->getFunds() + r->getItem(_rules->getName())->getSellCost());
+				g->setFunds(g->getFunds() + (r->getItem(_rules->getProducedItem())->getSellCost() * _rules->getProduceQty()));
 			else
-				b->getItems()->addItem(_rules->getName(), 1);
+				b->getItems()->addItem(_rules->getProducedItem(), _rules->getProduceQty());
 		}
 	}
 	if (getAmountProduced () >= _amount)

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -880,12 +880,17 @@ void SavedGame::getAvailableProductions (std::vector<RuleManufacture *> & produc
 {
 	const std::vector<std::string> &items = ruleset->getManufactureList ();
 	const std::vector<Production *> baseProductions (base->getProductions ());
+	bool canConvertAmmoToElerium = Options::getBool("canConvertAmmoToElerium");
 
 	for(std::vector<std::string>::const_iterator iter = items.begin ();
 		iter != items.end ();
 		++iter)
 	{
 		RuleManufacture *m = ruleset->getManufacture(*iter);
+		if (!canConvertAmmoToElerium && m->getName() != m->getProducedItem())
+		{
+		 	continue;
+		}
 		if(!isResearched(m->getRequirements()))
 		{
 		 	continue;

--- a/src/Ufopaedia/Ufopaedia.cpp
+++ b/src/Ufopaedia/Ufopaedia.cpp
@@ -255,12 +255,12 @@ namespace OpenXcom
 	 */
 	void Ufopaedia::runStandalone(Game *game)
 	{
-		// set game language
-		game->loadLanguage("English");
-
 		// init game
 		game->loadRuleset();
 		game->setSavedGame(game->getRuleset()->newSave());
+
+		// set game language
+		game->loadLanguage("English");
 
 		// open Ufopaedia
 		open(game);


### PR DESCRIPTION
Default: OFF

Have you ever dreamed that you can convert your elerium-based ammunition back to elerium? :) Which you got a lot from UFOs of course.

Think about it. The gunpowder can be extracted from a bullet, why can't we simple extract elerium from the elerium-based ammo too?

Now you can do this. :)
Just turn on canConvertAmmoToElerium in options.cfg, and you can manufacture Elerium-115 from Plasma Pistol Clip, Plasma Rifle Clip, etc., and from Alien Grenade. (of course the clip/grenade must be researched first to convert back)
The manufacture time-cost is half of the clip's manufacture time-cost, and money cost is 0 of course. (since we just disassemblying the ammo)
