### PR TITLE
Missing libraries in x64 VS2010

### DIFF
--- a/src/OpenXcom.2010.sln
+++ b/src/OpenXcom.2010.sln
@@ -13,10 +13,12 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D8F55ED4-1A4E-4111-8E83-153CF91FE25A}.Debug|Win32.ActiveCfg = Debug|Win32
 		{D8F55ED4-1A4E-4111-8E83-153CF91FE25A}.Debug|Win32.Build.0 = Debug|Win32
-		{D8F55ED4-1A4E-4111-8E83-153CF91FE25A}.Debug|x64.ActiveCfg = Debug|Win32
+		{D8F55ED4-1A4E-4111-8E83-153CF91FE25A}.Debug|x64.ActiveCfg = Debug|x64
+		{D8F55ED4-1A4E-4111-8E83-153CF91FE25A}.Debug|x64.Build.0 = Debug|x64
 		{D8F55ED4-1A4E-4111-8E83-153CF91FE25A}.Release|Win32.ActiveCfg = Release|Win32
 		{D8F55ED4-1A4E-4111-8E83-153CF91FE25A}.Release|Win32.Build.0 = Release|Win32
-		{D8F55ED4-1A4E-4111-8E83-153CF91FE25A}.Release|x64.ActiveCfg = Release|Win32
+		{D8F55ED4-1A4E-4111-8E83-153CF91FE25A}.Release|x64.ActiveCfg = Release|x64
+		{D8F55ED4-1A4E-4111-8E83-153CF91FE25A}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/OpenXcom.2010.vcxproj
+++ b/src/OpenXcom.2010.vcxproj
@@ -125,7 +125,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>yaml-cppd.lib;SDL_mixer.lib;SDL_gfx.lib;SDLmain.lib;SDL.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>yaml-cppd.lib;SDL_image.lib;SDL_mixer.lib;SDL_gfx.lib;SDLmain.lib;SDL.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ProjectDir)..\deps\lib\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
@@ -181,7 +181,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>yaml-cpp.lib;SDL_mixer.lib;SDL_gfx.lib;SDLmain.lib;SDL.lib;SDL_gfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>yaml-cpp.lib;SDL_image.lib;SDL_mixer.lib;SDL_gfx.lib;SDLmain.lib;SDL.lib;SDL_gfx.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\deps\lib\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
SDL_image.lib and opengl32.lib need to be added to both Debug and Release x64 for VS2010
