### PR TITLE
New option in options.cfg: canTransferCraftsInAirborne

### DIFF
--- a/src/Basescape/TransferItemsState.h
+++ b/src/Basescape/TransferItemsState.h
@@ -57,6 +57,7 @@ private:
 	double _distance;
 	Timer *_timerInc, *_timerDec;
 	int _changeValueByMouseWheel;
+	bool _canTransferCraftsInAirborne; // this is a cache for Options::getBool("canTransferCraftsInAirborne")
 	/// Gets selected cost.
 	int getCost();
 	/// Gets selected quantity.

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -103,6 +103,7 @@ void createDefault()
 	setInt("pauseMode", 0);
 	setBool("alienContainmentHasUpperLimit", false);
 	setBool("canSellLiveAliens", false);
+	setBool("canTransferCraftsInAirborne", false); // When the craft can reach the destination base with its fuel
 	setBool("canManufactureMoreItemsPerHour", false);
 	setBool("customInitialBase", false);
 	setBool("aggressiveRetaliation", false);

--- a/src/Savegame/Craft.cpp
+++ b/src/Savegame/Craft.cpp
@@ -323,6 +323,15 @@ void Craft::setBase(Base *base)
 }
 
 /**
+ * Changes the base the craft belongs to. (without setting the craft's coordinates)
+ * @param base Pointer to base.
+ */
+void Craft::setBaseOnly(Base *base)
+{
+	_base = base;
+}
+
+/**
  * Returns the current status of the craft.
  * @return Status string.
  */
@@ -585,7 +594,17 @@ int Craft::getFuelConsumption() const
  */
 int Craft::getFuelLimit() const
 {
-	return (int)floor(getFuelConsumption() * getDistanceFromBase() / (_speedRadian * 120));
+	return getFuelLimit(_base);
+}
+
+/**
+ * Returns the minimum required fuel for the
+ * craft to go to a base.
+ * @return Fuel amount.
+ */
+int Craft::getFuelLimit(Base *base) const
+{
+	return (int)floor(getFuelConsumption() * getDistance(base) / (_speedRadian * 120));
 }
 
 /**

--- a/src/Savegame/Craft.h
+++ b/src/Savegame/Craft.h
@@ -80,6 +80,8 @@ public:
 	Base *getBase() const;
 	/// Sets the craft's base.
 	void setBase(Base *base);
+	/// Sets the craft's base. (without setting the craft's coordinates)
+	void setBaseOnly(Base *base);
 	/// Gets the craft's status.
 	std::string getStatus() const;
 	/// Sets the craft's status.
@@ -124,6 +126,8 @@ public:
 	int getFuelConsumption() const;
 	/// Gets the craft's minimum fuel limit.
 	int getFuelLimit() const;
+	/// Gets the craft's minimum fuel limit to go to a base.
+	int getFuelLimit(Base *base) const;
 	/// Returns the craft to its base.
 	void returnToBase();
 	/// Checks if a target is detected by the craft's radar.


### PR DESCRIPTION
Default: OFF

Have you ever dreamed that you can transfer a craft while it is airborne? I mean when there is a base - with a free hangar - it can reach with fuel, which is closer then the original base. And this way the craft does not have to reserve much fuel, so it can use the remaining fuel for intercepting.

Now you can do this. :)
Just turn on canTransferCraftsInAirborne in options.cfg, and you can transfer that craft to ANY base it can reach with its remaining fuel.
Of course if a craft can't reach the selected destination base, it won't show up in the transfer-items-screen.
And of course transfer can only be done if the destination base have a free hangar. (not momentarily-free, completely-free!)
These type of transfers does not cost money, since the craft goes using its own fuel. :)
Crafts currently on the base are not affected, the normal rules applies to them.

EDIT: I've rebased this, so it can be auto-merged now, without any conflicts.
