### PR TITLE
Fix Medi-Kit exploit.

### DIFF
--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -1870,6 +1870,8 @@ void BattleUnit::heal(int part, int healAmount, int healthAmount)
 		return;
 	_fatalWounds[part] -= healAmount;
 	_health += healthAmount;
+	if (_health > getStats()->health)
+		_health = getStats()->health;
 }
 
 /**
@@ -1884,6 +1886,7 @@ void BattleUnit::painKillers ()
 	_needPainKiller = false;
 	int lostHealth = getStats()->health - _health;
 	_morale += lostHealth;
+	if (_morale > 100) _morale = 100;
 }
 
 /**
@@ -1894,6 +1897,8 @@ void BattleUnit::painKillers ()
 void BattleUnit::stimulant (int energy, int s)
 {
 	_energy += energy;
+	if (_energy > getStats()->stamina)
+		_energy = getStats()->stamina;
 	healStun (s);
 }
 


### PR DESCRIPTION
In CE Xcom, you cannot exceed maximum health.
In early DOS versions, it was sometimes possible to overflow the health stat so the soldier would be healthier after healing than he started before he was shot.
http://ufopaedia.org/index.php?title=Medi-Kit_(EU)
