### PR TITLE
option to turn off getError() for OpenGL, warnings

### DIFF
--- a/src/Engine/OpenGL.cpp
+++ b/src/Engine/OpenGL.cpp
@@ -19,6 +19,8 @@
 
 namespace OpenXcom 
 {
+	
+bool OpenGL::checkErrors = true;
 
 std::string strGLError(GLenum glErr)
 {
@@ -202,7 +204,7 @@ Uint32 (APIENTRYP wglSwapIntervalEXT)(int interval);
       vertexshader = 0;
     }
 
-    if(source_yaml_filename) {
+    if(source_yaml_filename && strlen(source_yaml_filename)) {
       std::ifstream fin(source_yaml_filename);
       YAML::Parser parser(fin);
       YAML::Node document;
@@ -215,7 +217,7 @@ Uint32 (APIENTRYP wglSwapIntervalEXT)(int interval);
 	  is_glsl = (s == "GLSL");
 
 
-      document["linear"] >> linear; // seemingly pointless!
+      document["linear"] >> linear; // some shaders want texture linear interpolation and some don't
       std::string fragment_source;
       std::string vertex_source;
 	  if (const YAML::Node *pFrag = document.FindValue("fragment")) *pFrag >> fragment_source;
@@ -300,12 +302,12 @@ Uint32 (APIENTRYP wglSwapIntervalEXT)(int interval);
 
 			if (drawable) {
 				glXSwapIntervalEXT(dpy, drawable, interval);
-				Log(LOG_INFO) << "Made an attempt to set vsync via GLX.";
+				// Log(LOG_INFO) << "Made an attempt to set vsync via GLX.";
 			}
 		} else if (wglSwapIntervalEXT)
 		{
 			wglSwapIntervalEXT(interval);
-			Log(LOG_INFO) << "Made an attempt to set vsync via WGL.";
+			// Log(LOG_INFO) << "Made an attempt to set vsync via WGL.";
 		}
 	}
 

--- a/src/Engine/OpenGL.h
+++ b/src/Engine/OpenGL.h
@@ -38,16 +38,16 @@ extern PFNGLUNIFORM4FVPROC glUniform4fv;
 std::string strGLError(GLenum glErr);
 
 #define glErrorCheck() {\
-	static bool reported##__LINE__ = false;\
-	GLenum glErr##__LINE__;\
-	if ((glErr##__LINE__ = glGetError()) != GL_NO_ERROR && !reported##__LINE__)\
+	static bool reported = false;\
+	GLenum glErr;\
+	if (OpenGL::checkErrors && !reported && (glErr = glGetError()) != GL_NO_ERROR)\
 	{\
-		reported##__LINE__ = true;\
+		reported = true;\
 		\
 		do \
 		{ \
-			Log(LOG_WARNING) << __FILE__ << ":" << __LINE__ << ": glGetError() complaint: " << strGLError(glErr##__LINE__);\
-		} while (((glErr##__LINE__ = glGetError()) != GL_NO_ERROR));\
+			Log(LOG_WARNING) << __FILE__ << ":" << __LINE__ << ": glGetError() complaint: " << strGLError(glErr);\
+		} while (((glErr = glGetError()) != GL_NO_ERROR));\
 	}\
 }
 
@@ -64,6 +64,8 @@ public:
   uint32_t *buffer;
   Surface *buffer_surface;
   unsigned iwidth, iheight, iformat, ibpp;
+
+  static bool checkErrors;
 
   /// call to resize internal buffer; internal use
   void resize(unsigned width, unsigned height);

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -70,6 +70,7 @@ void createDefault()
 	setBool("useScaleFilter", false);
 	setBool("useHQXFilter", false);
 	setBool("useOpenGL", false);
+	setBool("checkOpenGLErrors", false);
 	setString("useOpenGLShader", "Shaders/CRT-interlaced.OpenGL.shader");
 	setBool("vSyncForOpenGL", false);
 	setBool("useOpenGLSmoothing", true);

--- a/src/Engine/Screen.cpp
+++ b/src/Engine/Screen.cpp
@@ -287,6 +287,7 @@ void Screen::setResolution(int width, int height)
 		glOutput.linear = Options::getBool("useOpenGLSmoothing"); // setting from shader file will override this, though
 		glOutput.set_shader(CrossPlatform::getDataFile(Options::getString("useOpenGLShader")).c_str());
 		glOutput.setVSync(Options::getBool("vSyncForOpenGL"));
+		OpenGL::checkErrors = Options::getBool("checkOpenGLErrors");
 	}
 
 	Log(LOG_INFO) << "Display set to " << _screen->w << "x" << _screen->h << "x" << (int)_screen->format->BitsPerPixel << ".";

--- a/src/Geoscape/BaseDefenseState.cpp
+++ b/src/Geoscape/BaseDefenseState.cpp
@@ -142,6 +142,8 @@ void BaseDefenseState::think()
 			_btnOk->setVisible(true);
 			_thinkcycles = -1;
 			return;
+		default:
+			break;
 		}
 
 		if (_attacks == _defenses && _passes == _gravShields)
@@ -196,6 +198,8 @@ void BaseDefenseState::think()
 				_action = BDA_NONE;
 			++_attacks;
 			return;
+		default:
+			break;
 		}
 	}
 }


### PR DESCRIPTION
clang complains when you don't handle all the possible values of an enum in a
switch
