### PR TITLE
Fix unlimited ammo items weighing double

### DIFF
--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -2318,7 +2318,7 @@ int BattleUnit::getCarriedWeight(BattleItem *draggingItem) const
 	{
 		if ((*i) == draggingItem) continue;
 		weight += (*i)->getRules()->getWeight();
-		if ((*i)->getAmmoItem()->getRules()->getClipSize() != -1 && 0 != (*i)->getAmmoItem()) weight += (*i)->getAmmoItem()->getRules()->getWeight(); // Hopefully this vaguely resembles checking for if an item uses itself as ammo.
+		if ((*i)->getAmmoItem() != (*i) && 0 != (*i)->getAmmoItem()) weight += (*i)->getAmmoItem()->getRules()->getWeight();
 	}
 	return weight;
 }


### PR DESCRIPTION
Items that are their own ammunition no longer count their clip weight.
