### PR TITLE
If deleting last save from load menu, don't show it any more.

### DIFF
--- a/src/Menu/SavedGameState.cpp
+++ b/src/Menu/SavedGameState.cpp
@@ -190,6 +190,7 @@ void SavedGameState::updateList()
 {
 	_lstSaves->clearList();
 	SavedGame::getList(_lstSaves, _game->getLanguage());
+	_lstSaves->draw();
 }
 
 /**


### PR DESCRIPTION
No longer shows last save game from load game menu after deleting it.
