### PR TITLE
Stop throwing exception when deleting saves on non-Windows platforms.

### DIFF
--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -471,7 +471,7 @@ bool deleteFile(const std::string &path)
     MultiByteToWideChar(CP_UTF8, 0, &path[0], (int)path.size(), &wstr[0], size);
 	return (DeleteFileW(wstr.c_str()) != 0);
 #else
-	return (remove(path.c_str()) != 0);
+	return (remove(path.c_str()) == 0);
 #endif
 }
 


### PR DESCRIPTION
remove() returns zero if successful, non-zero otherwise.
