### PR TITLE
fix for mouse press action?

### DIFF
--- a/src/Engine/InteractiveSurface.cpp
+++ b/src/Engine/InteractiveSurface.cpp
@@ -232,7 +232,7 @@ void InteractiveSurface::unpress(State *state)
  */
 void InteractiveSurface::mousePress(Action *action, State *state)
 {
-	std::map<Uint8, ActionHandler>::iterator allHandler = _press.find(0);
+	std::map<Uint8, ActionHandler>::iterator allHandler = _press.begin();
 	std::map<Uint8, ActionHandler>::iterator oneHandler = _press.find(action->getDetails()->button.button);
 	if (allHandler != _press.end())
 	{


### PR DESCRIPTION
battlescape drag-scroll was completely broken because _press.find was only
returning anything meaningful for LMB behaviour. (yes, even _press.find(0))
the change is fairly simple and doesn't really need explaining, but i have
my doubts as to whether or not this is the behaviour you intended.
