### PR TITLE
Move check to correct tile in isBlocked()

### DIFF
--- a/src/Battlescape/Pathfinding.cpp
+++ b/src/Battlescape/Pathfinding.cpp
@@ -568,7 +568,7 @@ bool Pathfinding::isBlocked(Tile *startTile, Tile *endTile, const int direction,
 		if (isBlocked(endTile,MapData::O_NORTHWALL, missileTarget)) return true;
 		if (isBlocked(startTile,MapData::O_WESTWALL, missileTarget)) return true;
 		if (isBlocked(_save->getTile(pos1 + oneTileSouth),MapData::O_NORTHWALL, missileTarget)) return true;
-		if (isBlocked(_save->getTile(pos1 + oneTileWest),MapData::O_WESTWALL, missileTarget)) return true;
+		if (isBlocked(_save->getTile(pos1 + oneTileSouth),MapData::O_WESTWALL, missileTarget)) return true;
 		if (isBlocked(_save->getTile(pos1 + oneTileSouth),O_BIGWALL, missileTarget) 
       && isBlocked(_save->getTile(pos1 + oneTileWest),O_BIGWALL, missileTarget)) return true;
 		if (isBlocked(_save->getTile(pos1 + oneTileSouth),MapData::O_WESTWALL, missileTarget)


### PR DESCRIPTION
The southwest case had a check in the wrong tile.
