### PR TITLE
small UI change

### DIFF
--- a/src/Basescape/CraftSoldiersState.cpp
+++ b/src/Basescape/CraftSoldiersState.cpp
@@ -177,7 +177,14 @@ void CraftSoldiersState::lstItemsLeftArrowClick(Action *action)
 			{
 				_base->getSoldiers()->at(row) = _base->getSoldiers()->at(row-1);
 				_base->getSoldiers()->at(row-1) = s;
-				SDL_WarpMouse(action->getXMouse(), action->getYMouse() - (8 * action->getYScale()));
+				if (row != _lstSoldiers->getScroll())
+				{
+					SDL_WarpMouse(action->getXMouse(), action->getYMouse() - (8 * action->getYScale()));
+				}
+				else
+				{
+					_lstSoldiers->scrollUp(false);
+				}
 			}
 			else
 			{
@@ -206,7 +213,14 @@ void CraftSoldiersState::lstItemsRightArrowClick(Action *action)
 			{
 				_base->getSoldiers()->at(row) = _base->getSoldiers()->at(row+1);
 				_base->getSoldiers()->at(row+1) = s;
-				SDL_WarpMouse(action->getXMouse(), action->getYMouse() + (8 * action->getYScale()));
+				if (row != 15 + _lstSoldiers->getScroll())
+				{
+					SDL_WarpMouse(action->getXMouse(), action->getYMouse() + (8 * action->getYScale()));
+				}
+				else
+				{
+					_lstSoldiers->scrollDown(false);
+				}
 			}
 			else
 			{

--- a/src/Interface/TextList.cpp
+++ b/src/Interface/TextList.cpp
@@ -888,5 +888,13 @@ void TextList::mouseOut(Action *action, State *state)
 
 	InteractiveSurface::mouseOut(action, state);
 }
+/*
+ * get the scroll depth.
+ * @return scroll depth.
+ */
+int TextList::getScroll()
+{
+	return _scroll;
+}
 
 }

--- a/src/Interface/TextList.h
+++ b/src/Interface/TextList.h
@@ -166,7 +166,8 @@ public:
 	void mouseOver(Action *action, State *state);
 	/// Special handling for mouse hovering out.
 	void mouseOut(Action *action, State *state);
-
+	/// get the scroll depth
+	int TextList::getScroll();
 };
 
 }


### PR DESCRIPTION
when clicking the move up/down arrow on the craft soldier screen,
the mouse cursor will move up/down one line.
(applies to left click only)

not sure if this is the correct way to call SDL_WarpMouse(), or even if i'm
allowed to, but it works as far as i've tested*.

*this does not mean it works.
