### PR TITLE
Fix for "extra qualification error" in gcc

### DIFF
--- a/src/Interface/TextList.h
+++ b/src/Interface/TextList.h
@@ -167,7 +167,7 @@ public:
 	/// Special handling for mouse hovering out.
 	void mouseOut(Action *action, State *state);
 	/// get the scroll depth
-	int TextList::getScroll();
+	int getScroll();
 };
 
 }


### PR DESCRIPTION
gcc produce error on TextList::getScroll from src/Interface/TextList.h. This pull request fixes it.
