### PR TITLE
Fixed data install dir and data dir lookup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,11 +7,11 @@ doc_DATA = \
 pkgdata_DATA = \
 	bin/data/README.txt
 
-rulesetdir =  $(pkgdatadir)/Ruleset
+rulesetdir =  $(pkgdatadir)/data/Ruleset
 ruleset_DATA = \
 	bin/data/Ruleset/Xcom1Ruleset.rul
 
-languagedir = $(pkgdatadir)/Language
+languagedir = $(pkgdatadir)/data/Language
 language_DATA = \
 	bin/data/Language/Big.fnt \
 	bin/data/Language/Bulgarian.geo \
@@ -49,7 +49,7 @@ language_DATA = \
 	bin/data/Language/Ukrainian.geo \
 	bin/data/Language/Ukrainian.lng
 
-namedir = $(pkgdatadir)/SoldierName
+namedir = $(pkgdatadir)/data/SoldierName
 name_DATA = \
 	bin/data/SoldierName/American.nam \
 	bin/data/SoldierName/British.nam \
@@ -68,7 +68,7 @@ name_DATA = \
 	bin/data/SoldierName/Spanish.nam \
 	bin/data/SoldierName/Swedish.nam
 	
-shaderdir = $(pkgdatadir)/Shaders
+shaderdir = $(pkgdatadir)/data/Shaders
 shader_DATA = \
 	bin/data/Shaders/CRT.OpenGL.shader \
 	bin/data/Shaders/CRT-interlaced.OpenGL.shader \

--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -304,6 +304,46 @@ std::string caseInsensitive(const std::string &base, const std::string &path)
 }
 
 /**
+ * Takes a path and tries to find it based on the
+ * system's case-sensitivity.
+ * @param base Base unaltered path.
+ * @param path Full path to check for casing.
+ * @return Correct foldername or "" if it doesn't exist.
+ * @note There's no actual method for figuring out the correct
+ * foldername on case-sensitive systems, this is just a workaround.
+ */
+std::string caseInsensitiveFolder(const std::string &base, const std::string &path)
+{
+	std::string fullPath = base + path, newPath = path;
+
+	// Try all various case mutations
+	// Normal unmangled
+	if (folderExists(fullPath.c_str()))
+	{
+		return fullPath;
+	}
+
+	// UPPERCASE
+	std::transform(newPath.begin(), newPath.end(), newPath.begin(), toupper);
+	fullPath = base + newPath;
+	if (folderExists(fullPath.c_str()))
+	{
+		return fullPath;
+	}
+
+	// lowercase
+	std::transform(newPath.begin(), newPath.end(), newPath.begin(), tolower);
+	fullPath = base + newPath;
+	if (folderExists(fullPath.c_str()))
+	{
+		return fullPath;
+	}
+
+	// If we got here nothing can help us
+	return "";
+}
+
+/**
  * Takes a filename and tries to find it in the game's Data folders,
  * accounting for the system's case-sensitivity and path style.
  * @param filename Original filename.
@@ -337,6 +377,42 @@ std::string getDataFile(const std::string &filename)
 
 	// Give up
 	return filename;
+}
+
+/**
+ * Takes a foldername and tries to find it in the game's Data folders,
+ * accounting for the system's case-sensitivity and path style.
+ * @param foldername Original foldername.
+ * @return Correct foldername or "" if it doesn't exist.
+ */
+std::string getDataFolder(const std::string &foldername)
+{
+	// Correct folder separator
+	std::string name = foldername;
+#ifdef _WIN32
+	std::replace(name.begin(), name.end(), '/', PATH_SEPARATOR);
+#endif
+
+	// Check current data path
+	std::string path = caseInsensitiveFolder(Options::getDataFolder(), name);
+	if (path != "")
+	{
+		return path;
+	}
+
+	// Check every other path
+	for (std::vector<std::string>::iterator i = Options::getDataList()->begin(); i != Options::getDataList()->end(); ++i)
+	{
+		std::string path = caseInsensitiveFolder(*i, name);
+		if (path != "")
+		{
+			Options::setDataFolder(*i);
+			return path;
+		}
+	}
+
+	// Give up
+	return foldername;
 }
 
 /**

--- a/src/Engine/CrossPlatform.h
+++ b/src/Engine/CrossPlatform.h
@@ -41,6 +41,8 @@ namespace CrossPlatform
 	std::string findConfigFolder();
 	/// Gets the path for a data file.
 	std::string getDataFile(const std::string &filename);
+    /// Gets the path for a data folder
+	std::string getDataFolder(const std::string &foldername);
 	/// Creates a folder.
 	bool createFolder(const std::string &path);
 	/// Terminates a path.

--- a/src/Engine/Language.cpp
+++ b/src/Engine/Language.cpp
@@ -464,7 +464,7 @@ void Language::replace(std::wstring &str, const std::wstring &find, const std::w
  */
 std::vector<std::string> Language::getList(TextList *list)
 {
-	std::vector<std::string> langs = CrossPlatform::getFolderContents(Options::getDataFolder() + "Language/", "lng");
+	std::vector<std::string> langs = CrossPlatform::getFolderContents(CrossPlatform::getDataFolder("Language/"), "lng");
 
 	for (std::vector<std::string>::iterator i = langs.begin(); i != langs.end();)
 	{

--- a/src/Menu/OptionsState.cpp
+++ b/src/Menu/OptionsState.cpp
@@ -252,7 +252,7 @@ OptionsState::OptionsState(Game *game) : State(game)
 	_filterPaths.push_back("");
 	_filterPaths.push_back("");
 
-	std::vector<std::string> filters = CrossPlatform::getFolderContents(Options::getDataFolder() + GL_FOLDER, GL_EXT);
+	std::vector<std::string> filters = CrossPlatform::getFolderContents(CrossPlatform::getDataFolder(GL_FOLDER), GL_EXT);
 	for (std::vector<std::string>::iterator i = filters.begin(); i != filters.end(); ++i)
 	{
 		std::string file = (*i);

--- a/src/Ruleset/Ruleset.cpp
+++ b/src/Ruleset/Ruleset.cpp
@@ -63,8 +63,10 @@ namespace OpenXcom
  */
 Ruleset::Ruleset() : _costSoldier(0), _costEngineer(0), _costScientist(0), _timePersonnel(0)
 {
+    // Check in which data dir the folder is stored
+    std::string path = CrossPlatform::getDataFolder("SoldierName/");
 	// Add soldier names
-	std::vector<std::string> names = CrossPlatform::getFolderContents(Options::getDataFolder() + "SoldierName/", "nam");
+	std::vector<std::string> names = CrossPlatform::getFolderContents(path, "nam");
 
 	for (std::vector<std::string>::iterator i = names.begin(); i != names.end(); ++i)
 	{
@@ -172,9 +174,9 @@ Ruleset::~Ruleset()
  */
 void Ruleset::load(const std::string &source)
 {
-	std::string dirname = Options::getDataFolder() + "Ruleset/" + source + '/';
+	std::string dirname = CrossPlatform::getDataFolder("Ruleset/" + source + '/');
 	if (!CrossPlatform::folderExists(dirname))
-		loadFile(Options::getDataFolder() + "Ruleset/" + source + ".rul");
+		loadFile(CrossPlatform::getDataFile("Ruleset/" + source + ".rul"));
 	else
 		loadFiles(dirname);
 }
@@ -641,7 +643,7 @@ void Ruleset::loadFiles(const std::string &dirname)
  */
 void Ruleset::save(const std::string &filename) const
 {
-	std::string s = Options::getDataFolder() + "Ruleset/" + filename + ".rul";
+	std::string s = CrossPlatform::getDataFile("Ruleset/" + filename + ".rul");
 	std::ofstream sav(s.c_str());
 	if (!sav)
 	{


### PR DESCRIPTION
Previously the openxcom data was installed in /usr/share/openxcom/ and
not the correct /usr/share/openxcom/data/ dir when doing "make install".
This is now fixed.

You can now also have data spread out in the valid list of data
dirs. For example the openxcom data files in /usr/share/openxcom/data/
and the original xcom datafiles in ~/.local/share/openxcom/data
