### PR TITLE
Fixes rare crash when deleting facility in the middle of base

### DIFF
--- a/src/Basescape/BasescapeState.cpp
+++ b/src/Basescape/BasescapeState.cpp
@@ -418,7 +418,7 @@ void BasescapeState::viewClick(Action *)
 void BasescapeState::viewMouseOver(Action *)
 {
 	BaseFacility *f = _view->getSelectedFacility();
-	if (f == 0)
+	if (f == 0 || f->getX() < 0 || f->getX() > 5 || f->getY() < 0 || f->getY() > 5)
 		_txtFacility->setText(L"");
 	else
 		_txtFacility->setText(_game->getLanguage()->getString(f->getRules()->getType()));


### PR DESCRIPTION
Deleting a base facility at x=2 y=3, so roughly where the ok button is
in the confirm deletion box, can occasionally cause a viewMouseOver
event to fire where the facility just was.  As the facility no longer
exists its coordinates are no longer reliable.  Checking the coordinates
are sane avoids a potential crash.
