### PR TITLE
Hide MCed alien's psi button on turn end

### DIFF
--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -404,9 +404,6 @@ void BattlescapeGame::endTurn()
 	_debugPlay = false;
 	_currentAction.type = BA_NONE;
 
-	// in case the selected unit is a MCed alien with psi abilities
-	_save->getBattleState()->showPsiButton(false);
-
 	if (_save->getTileEngine()->closeUfoDoors())
 	{
 		getResourcePack()->getSound("BATTLE.CAT", 21)->play(); // ufo door closed

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -1009,6 +1009,7 @@ void BattlescapeState::updateSoldierInfo()
 	if (!playableUnit)
 	{
 		_txtName->setText(L"");
+		showPsiButton(false);
 		return;
 	}
 


### PR DESCRIPTION
Fix for bug 102  -  Psi-button of mind-controlled psi-capable alien
remains on screen after end of the turn
