### PR TITLE
Remove unnecessary distance check

### DIFF
--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -564,10 +564,8 @@ bool TileEngine::visible(BattleUnit *currentUnit, Tile *tile)
 		return false;
 	}
 
-	// aliens can see in the dark, xcom can see at a distance of 9 or less, further if there's enough light.
-	if (currentUnit->getFaction() == FACTION_PLAYER &&
-		distance(currentUnit->getPosition(), tile->getPosition()) > 9 &&
-		tile->getShade() > MAX_DARKNESS_TO_SEE_UNITS)
+	// aliens can see in the dark, xcom can't see if there's not enough light.
+	if (currentUnit->getFaction() == FACTION_PLAYER && tile->getShade() > MAX_DARKNESS_TO_SEE_UNITS)
 	{
 		return false;
 	}


### PR DESCRIPTION
Xcom units light sources will light up tiles within 9 squares of them so they can spot units, no need to check for distance. See: http://www.ufopaedia.org/index.php?title=File:FlarePattern.png
