### PR TITLE
feat163: show tank icons before equipment icons

### DIFF
--- a/src/Basescape/CraftInfoState.cpp
+++ b/src/Basescape/CraftInfoState.cpp
@@ -205,16 +205,16 @@ void CraftInfoState::init()
 			frame1->blit(_crew);
 		}
 
-		Surface *frame2 = texture->getFrame(39);
+		Surface *frame2 = texture->getFrame(40);
 		frame2->setY(0);
 		int x = 0;
-		for (int i = 0; i < c->getNumEquipment(); i += 4, x += 10)
+		for (int i = 0; i < c->getNumVehicles(); ++i, x += 10)
 		{
 			frame2->setX(x);
 			frame2->blit(_equip);
 		}
-		Surface *frame3 = texture->getFrame(40);
-		for (int i = 0; i < c->getNumVehicles(); ++i, x += 10)
+		Surface *frame3 = texture->getFrame(39);
+		for (int i = 0; i < c->getNumEquipment(); i += 4, x += 10)
 		{
 			frame3->setX(x);
 			frame3->blit(_equip);


### PR DESCRIPTION
on craft equipment screen

implements feature request 163 as documented here:
http://openxcom.org/bugs/openxcom/issues/163
