### PR TITLE
Load options.cfg with -user parameter

### DIFF
--- a/src/Engine/Options.h
+++ b/src/Engine/Options.h
@@ -57,8 +57,10 @@ namespace Options
 	std::vector<std::string> *getDataList();
 	/// Gets the game's user folder.
 	std::string getUserFolder();
-	/// Sets the game's user folder.
-	void setUserFolder();
+	/// Sets the game's data, user and config folders.
+	void setFolders();
+	/// Update game options from config file and command line.
+	void updateOptions();
 	/// Gets a string option.
 	std::string getString(const std::string& id);
 	/// Gets an integer option.


### PR DESCRIPTION
options.cfg outside of default locations is being ignored (bug 157)

Ensure we set up data, user and config folders after creating default
options and before loading options from file and command line.
