### PR TITLE
fix: Not restored the button "NewBase" when you delete the 8th base.

### DIFF
--- a/src/Basescape/BasescapeState.cpp
+++ b/src/Basescape/BasescapeState.cpp
@@ -245,10 +245,7 @@ void BasescapeState::init()
 	s += Text::formatFunding(_game->getSavedGame()->getFunds());
 	_txtFunds->setText(s);
 
-	if (_game->getSavedGame()->getBases()->size() == 8)
-	{
-		_btnNewBase->setVisible(false);
-	}
+	_btnNewBase->setVisible(_game->getSavedGame()->getBases()->size() < 8);
 }
 
 /**


### PR DESCRIPTION
rare bug: If you have 8 bases and you delete one, the button "Build new base" will not restored.
