### PR TITLE
Add keyOk and keyCancel to more screens

### DIFF
--- a/src/Basescape/MonthlyCostsState.cpp
+++ b/src/Basescape/MonthlyCostsState.cpp
@@ -83,6 +83,7 @@ MonthlyCostsState::MonthlyCostsState(Game *game, Base *base) : State(game), _bas
 	_btnOk->setColor(Palette::blockOffset(15)+1);
 	_btnOk->setText(_game->getLanguage()->getString("STR_OK"));
 	_btnOk->onMouseClick((ActionHandler)&MonthlyCostsState::btnOkClick);
+	_btnOk->onKeyboardPress((ActionHandler)&MonthlyCostsState::btnOkClick, (SDLKey)Options::getInt("keyOk"));
 	_btnOk->onKeyboardPress((ActionHandler)&MonthlyCostsState::btnOkClick, (SDLKey)Options::getInt("keyCancel"));
 
 	_txtTitle->setColor(Palette::blockOffset(15)+1);

--- a/src/Basescape/StoresState.cpp
+++ b/src/Basescape/StoresState.cpp
@@ -72,6 +72,7 @@ StoresState::StoresState(Game *game, Base *base) : State(game), _base(base)
 	_btnOk->setColor(Palette::blockOffset(13)+10);
 	_btnOk->setText(_game->getLanguage()->getString("STR_OK"));
 	_btnOk->onMouseClick((ActionHandler)&StoresState::btnOkClick);
+	_btnOk->onKeyboardPress((ActionHandler)&StoresState::btnOkClick, (SDLKey)Options::getInt("keyOk"));
 	_btnOk->onKeyboardPress((ActionHandler)&StoresState::btnOkClick, (SDLKey)Options::getInt("keyCancel"));
 
 	_txtTitle->setColor(Palette::blockOffset(13)+10);

--- a/src/Basescape/TransfersState.cpp
+++ b/src/Basescape/TransfersState.cpp
@@ -73,6 +73,7 @@ TransfersState::TransfersState(Game *game, Base *base) : State(game), _base(base
 	_btnOk->setText(_game->getLanguage()->getString("STR_OK"));
 	_btnOk->onMouseClick((ActionHandler)&TransfersState::btnOkClick);
 	_btnOk->onKeyboardPress((ActionHandler)&TransfersState::btnOkClick, (SDLKey)Options::getInt("keyOk"));
+	_btnOk->onKeyboardPress((ActionHandler)&TransfersState::btnOkClick, (SDLKey)Options::getInt("keyCancel"));
 
 	_txtTitle->setColor(Palette::blockOffset(15)+6);
 	_txtTitle->setBig();

--- a/src/Geoscape/ConfirmNewBaseState.cpp
+++ b/src/Geoscape/ConfirmNewBaseState.cpp
@@ -72,7 +72,7 @@ ConfirmNewBaseState::ConfirmNewBaseState(Game *game, Base *base, Globe *globe) :
 	_btnOk->setColor(Palette::blockOffset(15)-1);
 	_btnOk->setText(_game->getLanguage()->getString("STR_OK"));
 	_btnOk->onMouseClick((ActionHandler)&ConfirmNewBaseState::btnOkClick);
-	_btnOk->onKeyboardPress((ActionHandler)&ConfirmNewBaseState::btnCancelClick, (SDLKey)Options::getInt("keyOk"));
+	_btnOk->onKeyboardPress((ActionHandler)&ConfirmNewBaseState::btnOkClick, (SDLKey)Options::getInt("keyOk"));
 
 	_btnCancel->setColor(Palette::blockOffset(15)-1);
 	_btnCancel->setText(_game->getLanguage()->getString("STR_CANCEL_UC"));

--- a/src/Ufopaedia/ArticleState.cpp
+++ b/src/Ufopaedia/ArticleState.cpp
@@ -21,6 +21,7 @@
 #include <sstream>
 #include "ArticleState.h"
 #include "../Engine/Game.h"
+#include "../Engine/Options.h"
 #include "../Engine/Surface.h"
 #include "../Engine/Language.h"
 #include "../Resource/ResourcePack.h"
@@ -63,6 +64,8 @@ namespace OpenXcom
 
 		_btnOk->setText(_game->getLanguage()->getString("STR_OK"));
 		_btnOk->onMouseClick((ActionHandler)&ArticleState::btnOkClick);
+		_btnOk->onKeyboardPress((ActionHandler)&ArticleState::btnOkClick,(SDLKey)Options::getInt("keyOk"));
+		_btnOk->onKeyboardPress((ActionHandler)&ArticleState::btnOkClick,(SDLKey)Options::getInt("keyCancel"));
 		_btnPrev->setText(L"<<");
 		_btnPrev->onMouseClick((ActionHandler)&ArticleState::btnPrevClick);
 		_btnNext->setText(L">>");

--- a/src/Ufopaedia/UfopaediaSelectState.cpp
+++ b/src/Ufopaedia/UfopaediaSelectState.cpp
@@ -22,6 +22,7 @@
 #include "../Ruleset/ArticleDefinition.h"
 #include "ArticleState.h"
 #include "../Engine/Game.h"
+#include "../Engine/Options.h"
 #include "../Engine/Palette.h"
 #include "../Engine/Surface.h"
 #include "../Engine/Language.h"
@@ -69,6 +70,7 @@ namespace OpenXcom
 		_btnOk->setColor(Palette::blockOffset(15)-1);
 		_btnOk->setText(_game->getLanguage()->getString("STR_OK"));
 		_btnOk->onMouseClick((ActionHandler)&UfopaediaSelectState::btnOkClick);
+		_btnOk->onKeyboardPress((ActionHandler)&UfopaediaSelectState::btnOkClick,(SDLKey)Options::getInt("keyCancel"));
 
 		_lstSelection->setColor(Palette::blockOffset(8)+5);
 		_lstSelection->setArrowColor(Palette::blockOffset(15)-1);

--- a/src/Ufopaedia/UfopaediaStartState.cpp
+++ b/src/Ufopaedia/UfopaediaStartState.cpp
@@ -23,6 +23,7 @@
 #include "../Ruleset/ArticleDefinition.h"
 #include "../Engine/Game.h"
 #include "../Engine/Action.h"
+#include "../Engine/Options.h"
 #include "../Engine/Palette.h"
 #include "../Engine/Surface.h"
 #include "../Engine/Language.h"
@@ -93,6 +94,7 @@ namespace OpenXcom
 		_btnOk->setColor(Palette::blockOffset(8)+5);
 		_btnOk->setText(_game->getLanguage()->getString("STR_OK"));
 		_btnOk->onMouseClick((ActionHandler)&UfopaediaStartState::btnOkClick);
+		_btnOk->onKeyboardPress((ActionHandler)&UfopaediaStartState::btnOkClick, (SDLKey)Options::getInt("keyCancel"));
 	}
 
 	UfopaediaStartState::~UfopaediaStartState()


### PR DESCRIPTION
Adds escape and/or ok key bindings to perhaps better meet user
expectations in ufopaedia, geoscape and baseinfo screens.
