### PR TITLE
fix: rare crash placing new bases

### DIFF
--- a/src/Geoscape/BaseNameState.cpp
+++ b/src/Geoscape/BaseNameState.cpp
@@ -143,7 +143,7 @@ void BaseNameState::edtNameKeyPress(Action *action)
  */
 void BaseNameState::btnOkClick(Action *)
 {
-	_globe->onMouseOver((ActionHandler)&BuildNewBaseState::emptyHandler);
+	_globe->onMouseOver(0);
 	nameBase();
 }
 

--- a/src/Geoscape/BaseNameState.h
+++ b/src/Geoscape/BaseNameState.h
@@ -21,7 +21,6 @@
 
 #include "../Engine/State.h"
 #include "Globe.h"
-#include "BuildNewBaseState.h"
 
 namespace OpenXcom
 {

--- a/src/Geoscape/BuildNewBaseState.cpp
+++ b/src/Geoscape/BuildNewBaseState.cpp
@@ -371,13 +371,4 @@ void BuildNewBaseState::btnCancelClick(Action *)
 	_game->popState();
 }
 
-/**
- * Suppresses mouse-hover events.
- */
-void BuildNewBaseState::emptyHandler()
-{
-	return;
-}
-
-
 }

--- a/src/Geoscape/BuildNewBaseState.h
+++ b/src/Geoscape/BuildNewBaseState.h
@@ -93,8 +93,6 @@ public:
 	void btnZoomOutRightClick(Action *action);
 	/// Handler for clicking the Cancel button.
 	void btnCancelClick(Action *action);
-	/// Handler for suppressing mouse-hover events.
-	void emptyHandler();
 };
 
 }

--- a/src/Geoscape/ConfirmNewBaseState.cpp
+++ b/src/Geoscape/ConfirmNewBaseState.cpp
@@ -72,7 +72,7 @@ ConfirmNewBaseState::ConfirmNewBaseState(Game *game, Base *base, Globe *globe) :
 	_btnOk->setColor(Palette::blockOffset(15)-1);
 	_btnOk->setText(_game->getLanguage()->getString("STR_OK"));
 	_btnOk->onMouseClick((ActionHandler)&ConfirmNewBaseState::btnOkClick);
-	_btnOk->onKeyboardPress((ActionHandler)&ConfirmNewBaseState::btnCancelClick, (SDLKey)Options::getInt("keyOk"));
+	_btnOk->onKeyboardPress((ActionHandler)&ConfirmNewBaseState::btnOkClick, (SDLKey)Options::getInt("keyOk"));
 
 	_btnCancel->setColor(Palette::blockOffset(15)-1);
 	_btnCancel->setText(_game->getLanguage()->getString("STR_CANCEL_UC"));
@@ -134,7 +134,7 @@ void ConfirmNewBaseState::btnOkClick(Action *)
  */
 void ConfirmNewBaseState::btnCancelClick(Action *)
 {
-	_globe->onMouseOver((ActionHandler)&BuildNewBaseState::emptyHandler);
+	_globe->onMouseOver(0);
 	_game->popState();
 }
 


### PR DESCRIPTION
Crashes can occur in two cases:
1) If a mouseover triggers between base being named and
BuildNewBaseState destructor call.
2) If a mouseover triggers between confirm new base cancellation and
BuildNewBaseState destructor call.

Solution is to swap between globeHover handler and an empty handler as
necessary.
