### PR TITLE
Improvement the Sack button

### DIFF
--- a/src/Basescape/SoldierInfoState.cpp
+++ b/src/Basescape/SoldierInfoState.cpp
@@ -419,6 +419,8 @@ void SoldierInfoState::init()
 	_btnArmor->setText(wsArmor);
 //	_txtArmor->setText(_game->getLanguage()->getString(s->getArmor()->getType()));
 
+	_btnSack->setVisible(!(s->getCraft() && s->getCraft()->getStatus() == "STR_OUT"));
+
 	std::wstringstream ss9;
 	ss9 << _game->getLanguage()->getString("STR_RANK_") << L'\x01' << _game->getLanguage()->getString(s->getRankString());
 	_txtRank->setText(ss9.str());


### PR DESCRIPTION
Adding the Sack button in the soldier info screen is perfect idea, but not the best solution interface. I understand, on the screen not enough free space. Therefore suggest the another solution. Of course, this option can be disabled via advanced option screen.

Current interface:
![screen048](https://f.cloud.github.com/assets/3616568/830582/797dbf2c-f160-11e2-8c15-83e8703d12de.png)

The suggestion:
![screen012](https://f.cloud.github.com/assets/3616568/830587/c642c564-f160-11e2-8ea5-ab5922d03d42.png)
![screen009](https://f.cloud.github.com/assets/3616568/830589/d56f7b22-f160-11e2-88f8-a9991a9ef35b.png)

Long armor names in other languages:
![screen010](https://f.cloud.github.com/assets/3616568/830592/08798440-f161-11e2-9253-69d2084abaee.png)
![screen013](https://f.cloud.github.com/assets/3616568/830610/0cb25810-f162-11e2-8db5-a7cca3e3fdd7.png)
