### PR TITLE
Fixes bug 208

### DIFF
--- a/src/Battlescape/UnitDieBState.cpp
+++ b/src/Battlescape/UnitDieBState.cpp
@@ -115,7 +115,7 @@ void UnitDieBState::think()
 	{
 		_unit->keepFalling();
 	}
-	else
+	else if (!_unit->isOut())
 	{
 		_unit->startFalling();
 
@@ -125,7 +125,7 @@ void UnitDieBState::think()
 		}
 	}
 
-	if (_unit->getStatus() == STATUS_DEAD || _unit->getStatus() == STATUS_UNCONSCIOUS)
+	if (_unit->isOut())
 	{
 		if (!_noSound && _damageType == DT_HE && _unit->getStatus() != STATUS_UNCONSCIOUS)
 		{


### PR DESCRIPTION
UnitDieBState is expecting units to be turning, collapsing, or standing.
If a unit is facing direction 3 then it does not turn for a death
animation so the unit keeps its current state; if this state is a non
standing state then UnitDieBState::think() cannot end so the game hangs.

Fix it so that all non collapsing and non turning units are treated as
dying.
