### PR TITLE
Stop crashing on invalid save files

### DIFF
--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -200,6 +200,10 @@ void SavedGame::load(const std::string &filename, Ruleset *rule)
 {
 	std::string s = Options::getUserFolder() + filename + ".sav";
 	std::vector<YAML::Node> file = YAML::LoadAllFromFile(s);
+	if (file.empty())
+	{
+		throw Exception(filename + " is not a vaild save file");
+	}
 
 	// Get brief save info
 	YAML::Node brief = file[0];


### PR DESCRIPTION
If a player, perhaps perversely, attempts to load a file with no YAML
nodes in it at all then the game crashes.

This fix replaces the crash with an error message.
