### PR TITLE
Stop civilians moving on autoend

### DIFF
--- a/src/Battlescape/UnitDieBState.cpp
+++ b/src/Battlescape/UnitDieBState.cpp
@@ -190,7 +190,7 @@ void UnitDieBState::think()
 
 			if (liveAliens == 0 || liveSoldiers == 0)
 			{
-				_parent->statePushBack(0);
+				_parent->requestEndTurn();
 			}
 		}
 	}


### PR DESCRIPTION
as currently, on disabling the last alien with autoend enabled,
civilians are still taking their turn before the mission autoends.
This conforms to the behaviour with autoend disabled.
