### PR TITLE
Fix: teleportation of soldiers back to base.

### DIFF
--- a/src/Basescape/CraftArmorState.cpp
+++ b/src/Basescape/CraftArmorState.cpp
@@ -156,7 +156,9 @@ void CraftArmorState::btnOkClick(Action *)
  */
 void CraftArmorState::lstSoldiersClick(Action *)
 {
-	_game->pushState(new SoldierArmorState(_game, _base, _lstSoldiers->getSelectedRow()));
+	Soldier *s = _base->getSoldiers()->at(_lstSoldiers->getSelectedRow());
+	if (!(s->getCraft() && s->getCraft()->getStatus() == "STR_OUT"))
+		_game->pushState(new SoldierArmorState(_game, _base, _lstSoldiers->getSelectedRow()));
 }
 
 }

--- a/src/Basescape/CraftSoldiersState.cpp
+++ b/src/Basescape/CraftSoldiersState.cpp
@@ -262,6 +262,10 @@ void CraftSoldiersState::lstSoldiersClick(Action *action)
 		_lstSoldiers->setCellText(row, 2, _game->getLanguage()->getString("STR_NONE_UC"));
 		color = Palette::blockOffset(13)+10;
 	}
+	else if (s->getCraft() && s->getCraft()->getStatus() == "STR_OUT")
+	{
+		color = Palette::blockOffset(15)+6;
+	}
 	else if (c->getSpaceAvailable() > 0 && s->getWoundRecovery() == 0)
 	{
 		s->setCraft(c);


### PR DESCRIPTION
Fixed funny exploit, which allowed change the soldier's armor even if soldier on mission and teleport soldiers back to base.
If you have two (or more) transport crafts (for example Skyranger and Avenger) and send Skyranger to crash site, then Avenger's menu allows you to change armor of soldiers from Skyranger and teleport soldiers to Avenger, which stayed on the base.
