### PR TITLE
UI improvements: CraftEquipmentState 

### DIFF
--- a/src/Basescape/CraftEquipmentState.cpp
+++ b/src/Basescape/CraftEquipmentState.cpp
@@ -60,13 +60,14 @@ CraftEquipmentState::CraftEquipmentState(Game *game, Base *base, size_t craft) :
 	_changeValueByMouseWheel = Options::getInt("changeValueByMouseWheel");
 	_allowChangeListValuesByMouseWheel = (Options::getBool("allowChangeListValuesByMouseWheel") && _changeValueByMouseWheel);
 	Craft *c = _base->getCrafts()->at(_craft);
-	bool isInvBtnVisible = c->getNumSoldiers() > 0;
+	bool craftHasACrew = c->getNumSoldiers() > 0;
+	bool isNewBattle = game->getSavedGame()->getMonthsPassed() == -1;
 
 	// Create objects
 	_window = new Window(this, 320, 200, 0, 0);
-	_btnOk = new TextButton(isInvBtnVisible? 148:288, 16, isInvBtnVisible? 164:16, 176); // (90, 16, 210, 176);
-//	_btnClear = new TextButton(90, 16, 112, 176);
-	_btnInventory = new TextButton(148, 16, 8, 176); // (90, 16, 16, 176);
+	_btnOk = new TextButton((craftHasACrew || isNewBattle)? 148:288, 16, (craftHasACrew || isNewBattle)? 164:16, 176);
+	_btnClear = new TextButton(148, 16, 8, 176);
+	_btnInventory = new TextButton(148, 16, 8, 176);
 	_txtTitle = new Text(300, 16, 16, 7);
 	_txtItem = new Text(144, 9, 16, 32);
 	_txtStores = new Text(150, 9, 160, 32);
@@ -81,7 +82,7 @@ CraftEquipmentState::CraftEquipmentState(Game *game, Base *base, size_t craft) :
 
 	add(_window);
 	add(_btnOk);
-//	add(_btnClear);
+	add(_btnClear);
 	add(_btnInventory);
 	add(_txtTitle);
 	add(_txtItem);
@@ -102,14 +103,15 @@ CraftEquipmentState::CraftEquipmentState(Game *game, Base *base, size_t craft) :
 	_btnOk->onMouseClick((ActionHandler)&CraftEquipmentState::btnOkClick);
 	_btnOk->onKeyboardPress((ActionHandler)&CraftEquipmentState::btnOkClick, (SDLKey)Options::getInt("keyCancel"));
 
-//	_btnClear->setColor(Palette::blockOffset(15)+1);
-//	_btnClear->setText(_game->getLanguage()->getString("STR_UNLOAD"));
-//	_btnClear->onMouseClick((ActionHandler)&CraftEquipmentState::btnClearClick);
+	_btnClear->setColor(Palette::blockOffset(15)+1);
+	_btnClear->setText(_game->getLanguage()->getString("STR_UNLOAD"));
+	_btnClear->onMouseClick((ActionHandler)&CraftEquipmentState::btnClearClick);
+	_btnClear->setVisible(isNewBattle);
 
 	_btnInventory->setColor(Palette::blockOffset(15) + 1);
 	_btnInventory->setText(_game->getLanguage()->getString("STR_INVENTORY"));
 	_btnInventory->onMouseClick((ActionHandler)&CraftEquipmentState::btnInventoryClick);
-	_btnInventory->setVisible(isInvBtnVisible);
+	_btnInventory->setVisible(craftHasACrew && !isNewBattle);
 
 	_txtTitle->setColor(Palette::blockOffset(15)+1);
 	_txtTitle->setBig();


### PR DESCRIPTION
As I understood, the "Unload" button useful for New Battle and almost useless for main game (because each player uses his own favorite arsenal).
In opposite, the "Inventory" button useful for main game and almost useless for new battle (because, anyway, next stage - equipment before battle).

I suggest do adaptive interface.
CraftEquipmentState for New Battle:
![screen029](https://f.cloud.github.com/assets/3616568/1025135/66cf39f8-0e3b-11e3-8d6f-5e6bb53bc177.png)

CraftEquipmentState for main game:
![screen030](https://f.cloud.github.com/assets/3616568/1025137/77f1f4d2-0e3b-11e3-8359-c40493194c8b.png)

Bonus! If craft has no crew, this screen has vanilla like interface. The problem with "craft has no crew" is nicely solved.
![screen031](https://f.cloud.github.com/assets/3616568/1025168/4ee3533c-0e3c-11e3-9c86-65b6a9bd0420.png)
