### PR TITLE
UI improvements: fix for wide screens

### DIFF
--- a/src/Battlescape/BattlescapeMessage.cpp
+++ b/src/Battlescape/BattlescapeMessage.cpp
@@ -33,11 +33,11 @@ namespace OpenXcom
  */
 BattlescapeMessage::BattlescapeMessage(int width, int height, int x, int y) : Surface(width, height, x, y)
 {
-	_window = new Window(0, width, height, 0, 0, POPUP_NONE);
+	_window = new Window(0, width, height, x, y, POPUP_NONE);
 	_window->setColor(Palette::blockOffset(0));
 	_window->setHighContrast(true);
 
-	_text = new Text(width, height, 0, 0);
+	_text = new Text(width, height, x, y);
 	_text->setColor(Palette::blockOffset(0));
 	_text->setAlign(ALIGN_CENTER);
 	_text->setVerticalAlign(ALIGN_MIDDLE);

--- a/src/Battlescape/Map.cpp
+++ b/src/Battlescape/Map.cpp
@@ -86,7 +86,7 @@ Map::Map(Game *game, int width, int height, int x, int y, int visibleMapHeight) 
 	_spriteWidth = _res->getSurfaceSet("BLANKS.PCK")->getFrame(0)->getWidth();
 	_spriteHeight = _res->getSurfaceSet("BLANKS.PCK")->getFrame(0)->getHeight();
 	_save = _game->getSavedGame()->getSavedBattle();
-	_message = new BattlescapeMessage(width, visibleMapHeight, 0, 0);
+	_message = new BattlescapeMessage(320, visibleMapHeight, Screen::getDX(), Screen::getDY());
 	_camera = new Camera(_spriteWidth, _spriteHeight, _save->getMapSizeX(), _save->getMapSizeY(), _save->getMapSizeZ(), this, visibleMapHeight);
 	_scrollMouseTimer = new Timer(SCROLL_INTERVAL);
 	_scrollMouseTimer->onTimer((SurfaceHandler)&Map::scrollMouse);

--- a/src/Menu/SavedGameState.cpp
+++ b/src/Menu/SavedGameState.cpp
@@ -163,7 +163,7 @@ SavedGameState::SavedGameState(Game *game, bool geo, bool showMsg) : State(game)
 {
 	if (_showMsg)
 	{
-		_txtStatus = new Text(320, 16, 0, 92);
+		_txtStatus = new Text(320, 16, Screen::getDX(), 92 + Screen::getDY());
 		add(_txtStatus);
 
 		_txtStatus->setBig();


### PR DESCRIPTION
Centered "Loading game" and "Saving game" messages for quick save/load.

Removed blinking gray area in the "Hidden movement" state:
![screen033x50](https://f.cloud.github.com/assets/3616568/1076443/d623b830-14e2-11e3-862d-e1d0e0edd16a.png)
