### PR TITLE
Fixed compilation error on GCC

### DIFF
--- a/src/Battlescape/Map.cpp
+++ b/src/Battlescape/Map.cpp
@@ -36,6 +36,7 @@
 #include "../Engine/Palette.h"
 #include "../Engine/RNG.h"
 #include "../Engine/Game.h"
+#include "../Engine/Screen.h"
 #include "../Savegame/SavedBattleGame.h"
 #include "../Savegame/Tile.h"
 #include "../Savegame/BattleUnit.h"


### PR DESCRIPTION
Fixed "Battlescape/Map.cpp:89:59: error: incomplete type 'OpenXcom::Screen' used in nested name specifier'"
