### PR TITLE
2-line fix for edgescrolling in Battlescape.

### DIFF
--- a/src/Battlescape/Camera.cpp
+++ b/src/Battlescape/Camera.cpp
@@ -161,6 +161,7 @@ void Camera::mouseOver(Action *action, State *)
 			{
 				_scrollMouseY = -scrollSpeed/2;
 			}
+			else _scrollMouseY = 0;
 		}
 		//right scroll
 		else if (posX > (_screenWidth - SCROLL_BORDER) * action->getXScale())
@@ -177,6 +178,7 @@ void Camera::mouseOver(Action *action, State *)
 			{
 				_scrollMouseY = -scrollSpeed/2;
 			}
+			else _scrollMouseY = 0;
 		}
 		else if (posX)
 		{


### PR DESCRIPTION
When scrolling diagonally and sliding the cursor to a straight
lateral scroll, the vertical component wasn't negated
