### PR TITLE
Grenade activation warning messages.

### DIFF
--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -665,6 +665,7 @@ void BattlescapeGame::handleNonTargetAction()
 		{
 			if (_currentAction.actor->spendTimeUnits(_currentAction.TU))
 			{
+				_parentState->warning("STR_GRENADE_IS_ACTIVATED");
 				_currentAction.weapon->setExplodeTurn(_save->getTurn() + _currentAction.value);
 			}
 			else

--- a/src/Battlescape/Inventory.cpp
+++ b/src/Battlescape/Inventory.cpp
@@ -701,7 +701,11 @@ void Inventory::mouseClick(Action *action, State *state)
 							if (0 == item->getExplodeTurn())
 							{
 								// Prime that grenade!
-								if (BT_PROXIMITYGRENADE == itemType) item->setExplodeTurn(1);
+								if (BT_PROXIMITYGRENADE == itemType)
+								{
+									_warning->showMessage(_game->getLanguage()->getString("STR_GRENADE_IS_ACTIVATED"));
+									item->setExplodeTurn(1);
+								}
 								else _game->pushState(new PrimeGrenadeState(_game, 0, true, item));
 							}
 							else item->setExplodeTurn(0);  // Unprime the grenade


### PR DESCRIPTION
- shows red warning when activating grenades in Tactical. But...
  only works for Proxies in the preBattle equip screen (someone
  with more understanding of thinkers & timers might do it for the
  other grenades, on preTactical screen)
- 2 line change ( intended to replicate behavior of original )
