### PR TITLE
Closes the inventory screen on RMB

### DIFF
--- a/src/Battlescape/Inventory.cpp
+++ b/src/Battlescape/Inventory.cpp
@@ -709,6 +709,10 @@ void Inventory::mouseClick(Action *action, State *state)
 					}
 				}
 			}
+			else
+			{
+				_game->popState(); // Closes the inventory window on right-click (if not in preBattle equip screen!)
+			}
 		}
 		else
 		{


### PR DESCRIPTION
- only if _not_ in preBattle screen! otherwise things get weird...
