### PR TITLE
Add missing setup for tank only missions

### DIFF
--- a/src/Battlescape/InventoryState.cpp
+++ b/src/Battlescape/InventoryState.cpp
@@ -195,11 +195,7 @@ void InventoryState::init()
 		if (unit == selectNextUnit())
 		{
 			// starting a mission with just vehicles
-			_battleGame->resetUnitTiles();
-			for (std::vector<BattleUnit*>::iterator i = _battleGame->getUnits()->begin(); i != _battleGame->getUnits()->end(); ++i)
-				if ((*i)->getFaction() == _battleGame->getSide())
-					(*i)->prepareNewTurn();
-			_game->popState();
+			btnOkClick(0);
 			return;
 		}
 		else


### PR DESCRIPTION
For standard missions, clicking ok in the inventory screen calls some setup methods.  Tank only missions misses out the inventory stuff but we still need those setup calls.
