### PR TITLE
Fix build on Ubuntu since yaml-cpp 0.5 upgrade.

### DIFF
--- a/src/pch.cpp
+++ b/src/pch.cpp
@@ -1,1 +1,2 @@
+#include <yaml-cpp/yaml.h>
 #include "pch.h"


### PR DESCRIPTION
Thanks to sjamaan for help on #OpenXcom, and this Stack Overflow question for the solution: http://stackoverflow.com/questions/3128497/compiler-error-coming-out-of-yaml-cpp
