### PR TITLE
Fix units being saved from zombification by player saving game

### DIFF
--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -218,6 +218,8 @@ void BattleUnit::load(const YAML::Node &node)
 	_kills = node["kills"].as<int>(_kills);
 	_dontReselect = node["dontReselect"].as<bool>(_dontReselect);
 	_charging = 0;
+	_specab = (SpecialAbility)node["specab"].as<int>(_specab);
+	_spawnUnit = node["spawnUnit"].as<std::string>(_spawnUnit);
 }
 
 /**
@@ -270,6 +272,9 @@ YAML::Node BattleUnit::save() const
 		node["kills"] = _kills;
 	if (_faction == FACTION_PLAYER && _dontReselect)
 		node["dontReselect"] = _dontReselect;
+	node["specab"] = (int)_specab;
+	if (!_spawnUnit.empty())
+		node["spawnUnit"] = _spawnUnit;
 
 	return node;
 }


### PR DESCRIPTION
as currently the necessary information is not being recorded in the save
file.

A unit hit by a chryssalid and surviving is doomed to become a zombie at the end of the turn anyway, unless the player saves the game, reloads, then ends the turn.  This should fix that loophole.
