### PR TITLE
Disable buttons while player's units are panicked or berserk

### DIFF
--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -896,7 +896,7 @@ void BattlescapeState::btnShowLayersClick(Action *)
  */
 void BattlescapeState::btnHelpClick(Action *)
 {
-	if (_map->getProjectile() == 0) // we're deliberately not using allowButtons() here, so we can save if something goes wrong during the alien turn, and submit it for dissection.
+	if (allowButtons(true))
 		_game->pushState(new BattlescapeOptionsState(_game));
 }
 
@@ -1843,11 +1843,18 @@ bool BattlescapeState::getMouseOverIcons() const
 }
 
 /**
- * Determines whether the player is allowed to press buttons?
+ * Determines whether the player is allowed to press buttons.
+ * Buttons are disabled in the middle of a shot, during the alien turn,
+ * and while a player's units are panicking.
+ * The save button is an exception as we want to still be able to save if something
+ * goes wrong during the alien turn, and submit the save file for dissection.
+ * @param allowSaving True, if the help button was clicked.
  */
-bool BattlescapeState::allowButtons() const
+bool BattlescapeState::allowButtons(bool allowSaving) const
 {
-	return (_save->getSide() == FACTION_PLAYER || _save->getDebugMode()) && _map->getProjectile() == 0;
+	return ((allowSaving || _save->getSide() == FACTION_PLAYER || _save->getDebugMode())
+		&& _battleGame->getPanicHandled()
+		&& (_map->getProjectile() == 0));
 }
 
 /**

--- a/src/Battlescape/BattlescapeState.h
+++ b/src/Battlescape/BattlescapeState.h
@@ -199,7 +199,7 @@ public:
 	/// Checks if the mouse is over the icons.
 	bool getMouseOverIcons() const;
 	/// Is the player allowed to press buttons?
-	bool allowButtons() const;
+	bool allowButtons(bool allowSaving = false) const;
 	/// Handler for clicking the reserve TUs to kneel button.
 	void btnReserveKneelClick(Action *action);
 	/// Handler for clicking the expend all TUs button.


### PR DESCRIPTION
so player for example cannot
- access inventory to drop dangerous weapons
- save which can result in a weird mid panic/berserk state that may
  cause the game to hang (see http://openxcom.org/forum/index.php/topic,1568.0.html)
