### PR TITLE
Update soldier info after handling panicking

### DIFF
--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -134,6 +134,7 @@ void BattlescapeGame::think()
 			if (!_playerPanicHandled)
 			{
 				_playerPanicHandled = handlePanickingPlayer();
+				_save->getBattleState()->updateSoldierInfo();
 			}
 		}
 		if (_save->getUnitsFalling())


### PR DESCRIPTION
seeing as disabling buttons while handling panic broke showing soldier
info at the start of a player's turn.

Dang, replaced a bug with a new one.
