### PR TITLE
Fix initialising battlescape

### DIFF
--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -1853,7 +1853,7 @@ bool BattlescapeState::getMouseOverIcons() const
 bool BattlescapeState::allowButtons(bool allowSaving) const
 {
 	return ((allowSaving || _save->getSide() == FACTION_PLAYER || _save->getDebugMode())
-		&& _battleGame->getPanicHandled()
+		&& (_battleGame->getPanicHandled() || firstInit )
 		&& (_map->getProjectile() == 0));
 }
 


### PR DESCRIPTION
disabling buttons while handling panic also broke the first turn of a mission.  Fix restores setup in BattlescapeState::init() being successfully called.
