### PR TITLE
fix LoS

### DIFF
--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -400,7 +400,8 @@ bool TileEngine::visible(BattleUnit *currentUnit, Tile *tile)
 		return false;
 	}
 
-	if (currentUnit->getFaction() == tile->getUnit()->getFaction()) return true; //friendlies are always seen
+	BattleUnit *targetUnit = tile->getUnit();
+	if (currentUnit->getFaction() == targetUnit->getFaction()) return true; // friendlies are always seen
 
 	Position originVoxel = getSightOriginVoxel(currentUnit);
 
@@ -437,6 +438,10 @@ bool TileEngine::visible(BattleUnit *currentUnit, Tile *tile)
 				unitSeen = false;
 				break;
 			}
+		}
+		if (t->getUnit() != targetUnit)
+		{
+			unitSeen = false;
 		}
 	}
 	return unitSeen;


### PR DESCRIPTION
- when a calculation is made to a potentially spotted enemy unit,
  but another unit is blocking that LoS, the trajectory stops at
  that unit and TileEngine::visible() returns true.
- this fix includes a last check to ensure that the unit that's
  attempting to be spotted is really the unit that the trajectory
  stops at. If not, return false.
