### PR TITLE
Now all armors may give TU, stamina and strength bonuses

### DIFF
--- a/src/Basescape/SoldierInfoState.cpp
+++ b/src/Basescape/SoldierInfoState.cpp
@@ -342,6 +342,7 @@ void SoldierInfoState::init()
 	_edtSoldier->setText(s->getName());
 	UnitStats *initial = s->getInitStats();
 	UnitStats *current = s->getCurrentStats();
+	Armor *armor=s->getArmor();
 
 	SurfaceSet *texture = _game->getResourcePack()->getSurfaceSet("BASEBITS.PCK");
 	texture->getFrame(s->getRankSprite())->setX(0);
@@ -349,17 +350,17 @@ void SoldierInfoState::init()
 	texture->getFrame(s->getRankSprite())->blit(_rank);
 
 	std::wstringstream ss;
-	ss << current->tu;
+	ss << current->tu + armor->getTUBonus(current->tu);
 	_numTimeUnits->setText(ss.str());
-	_barTimeUnits->setMax(current->tu);
-	_barTimeUnits->setValue(current->tu);
+	_barTimeUnits->setMax(current->tu + armor->getTUBonus(current->tu));
+	_barTimeUnits->setValue(current->tu + armor->getTUBonus(current->tu));
 	_barTimeUnits->setValue2(initial->tu);
 
 	std::wstringstream ss2;
-	ss2 << current->stamina;
+	ss2 << current->stamina + armor->getStaminaBonus(current->stamina);
 	_numStamina->setText(ss2.str());
-	_barStamina->setMax(current->stamina);
-	_barStamina->setValue(current->stamina);
+	_barStamina->setMax(current->stamina + armor->getStaminaBonus(current->stamina));
+	_barStamina->setValue(current->stamina + armor->getStaminaBonus(current->stamina));
 	_barStamina->setValue2(initial->stamina);
 
 	std::wstringstream ss3;
@@ -398,14 +399,14 @@ void SoldierInfoState::init()
 	_barThrowing->setValue2(initial->throwing);
 
 	std::wstringstream ss8;
-	ss8 << current->strength;
+	ss8 << current->strength + armor->getStrengthBonus(current->strength);
 	_numStrength->setText(ss8.str());
-	_barStrength->setMax(current->strength);
-	_barStrength->setValue(current->strength);
+	_barStrength->setMax(current->strength + armor->getStrengthBonus(current->strength));
+	_barStrength->setValue(current->strength + armor->getStrengthBonus(current->strength));
 	_barStrength->setValue2(initial->strength);
 
 	std::wstring wsArmor;
-	std::string armorType = s->getArmor()->getType();
+	std::string armorType = armor->getType();
 	if (armorType == "STR_NONE_UC")
 	{
 		wsArmor.reserve(15);

--- a/src/Battlescape/AlienBAIState.cpp
+++ b/src/Battlescape/AlienBAIState.cpp
@@ -1648,7 +1648,7 @@ void AlienBAIState::grenadeAction()
 			tu += _unit->getActionTUs(BA_PRIME, grenade);
 			tu += _unit->getActionTUs(BA_THROW, grenade);
 			// do we have enough TUs to prime and throw the grenade?
-			if (tu <= _unit->getStats()->tu)
+			if (tu <= _unit->getFullTU())
 			{
 				// are we within range?
 				if (_save->getTileEngine()->validateThrow(_attackAction))

--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -976,9 +976,9 @@ bool BattlescapeGame::checkReservedTU(BattleUnit *bu, int tu, bool justChecking)
 		}
 		switch (effectiveTuReserved)
 		{
-		case BA_SNAPSHOT: return tu + (bu->getStats()->tu / 3) < bu->getTimeUnits(); break; // 33%
-		case BA_AUTOSHOT: return tu + ((bu->getStats()->tu / 5)*2) < bu->getTimeUnits(); break; // 40%
-		case BA_AIMEDSHOT: return tu + (bu->getStats()->tu / 2) < bu->getTimeUnits(); break; // 50%
+		case BA_SNAPSHOT: return tu + (bu->getFullTU() / 3) < bu->getTimeUnits(); break; // 33%
+		case BA_AUTOSHOT: return tu + ((bu->getFullTU() / 5)*2) < bu->getTimeUnits(); break; // 40%
+		case BA_AIMEDSHOT: return tu + (bu->getFullTU() / 2) < bu->getTimeUnits(); break; // 50%
 		default: return tu < bu->getTimeUnits(); break;
 		}
 	}
@@ -1133,7 +1133,7 @@ bool BattlescapeGame::handlePanickingUnit(BattleUnit *unit)
 			}
 		}
 		// replace the TUs from shooting
-		unit->setTimeUnits(unit->getStats()->tu);
+		unit->setTimeUnits(unit->getFullTU());
 		ba.type = BA_NONE;
 		break;
 	default: break;

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -1140,10 +1140,10 @@ void BattlescapeState::updateSoldierInfo()
 		_rank->clear();
 	}
 	_numTimeUnits->setValue(battleUnit->getTimeUnits());
-	_barTimeUnits->setMax(battleUnit->getStats()->tu);
+	_barTimeUnits->setMax(battleUnit->getFullTU());
 	_barTimeUnits->setValue(battleUnit->getTimeUnits());
 	_numEnergy->setValue(battleUnit->getEnergy());
-	_barEnergy->setMax(battleUnit->getStats()->stamina);
+	_barEnergy->setMax(battleUnit->getFullStamina());
 	_barEnergy->setValue(battleUnit->getEnergy());
 	_numHealth->setValue(battleUnit->getHealth());
 	_barHealth->setMax(battleUnit->getStats()->health);

--- a/src/Battlescape/InventoryState.cpp
+++ b/src/Battlescape/InventoryState.cpp
@@ -305,9 +305,9 @@ void InventoryState::updateStats()
 	{
 		int Weight = unit->getCarriedWeight(_inv->getSelectedItem());
 		std::wstringstream ss;
-		ss << tr("STR_WEIGHT") << L'\x01' << Weight << " /" << unit->getStats()->strength;
+		ss << tr("STR_WEIGHT") << L'\x01' << Weight << " /" << unit->getFullStrength();
 		_txtWeight->setText(ss.str());
-		if (Weight > unit->getStats()->strength)
+		if (Weight > unit->getFullStrength())
 			_txtWeight->setSecondaryColor(Palette::blockOffset(2));
 		else _txtWeight->setSecondaryColor(Palette::blockOffset(1));
 	}

--- a/src/Battlescape/UnitInfoState.cpp
+++ b/src/Battlescape/UnitInfoState.cpp
@@ -390,7 +390,7 @@ void UnitInfoState::init()
 	std::wstringstream ss;
 	ss << _unit->getTimeUnits();
 	_numTimeUnits->setText(ss.str());
-	_barTimeUnits->setMax(_unit->getStats()->tu);
+	_barTimeUnits->setMax(_unit->getFullTU());
 	_barTimeUnits->setValue(_unit->getTimeUnits());
 
 	ss.str(L"");
@@ -406,7 +406,7 @@ void UnitInfoState::init()
 	ss.str(L"");
 	ss << _unit->getEnergy();
 	_numEnergy->setText(ss.str());
-	_barEnergy->setMax(_unit->getStats()->stamina);
+	_barEnergy->setMax(_unit->getFullStamina());
 	_barEnergy->setValue(_unit->getEnergy());
 
 	ss.str(L"");
@@ -455,8 +455,8 @@ void UnitInfoState::init()
 	ss.str(L"");
 	ss << _unit->getStats()->strength;
 	_numStrength->setText(ss.str());
-	_barStrength->setMax(_unit->getStats()->strength);
-	_barStrength->setValue(_unit->getStats()->strength);
+	_barStrength->setMax(_unit->getFullStrength());
+	_barStrength->setValue(_unit->getFullStrength());
 
 	if (_unit->getStats()->psiSkill > 0)
 	{

--- a/src/Ruleset/Armor.cpp
+++ b/src/Ruleset/Armor.cpp
@@ -30,7 +30,8 @@ namespace OpenXcom
  * @param movementType The movement type for this armor (walk, fly or slide).
  * @param size The size of the armor. Normally this is 1 (small) or 2 (big).
  */
-Armor::Armor(const std::string &type, std::string spriteSheet, int drawingRoutine, MovementType movementType, int size) : _type(type), _spriteSheet(spriteSheet), _spriteInv(""), _corpseItem(""), _storeItem(""), _frontArmor(0), _sideArmor(0), _rearArmor(0), _underArmor(0), _drawingRoutine(drawingRoutine), _movementType(movementType), _size(size)
+Armor::Armor(const std::string &type, std::string spriteSheet, int drawingRoutine, MovementType movementType, int size) : _type(type), _spriteSheet(spriteSheet), _spriteInv(""), _corpseItem(""), _storeItem(""), _frontArmor(0), _sideArmor(0), _rearArmor(0), _underArmor(0), _drawingRoutine(drawingRoutine), _movementType(movementType), _size(size),
+	_baseTUBonus(0), _percentTUBonus(0),_baseStaminaBonus(0), _percentStaminaBonus(0), _baseStrengthBonus(0), _percentStrengthBonus(0) 
 {
 	for (int i=0; i < DAMAGE_TYPES; i++)
 		_damageModifier[i] = 1.0;
@@ -72,6 +73,12 @@ void Armor::load(const YAML::Node &node)
 	_loftempsSet = node["loftempsSet"].as< std::vector<int> >(_loftempsSet);
 	if (node["loftemps"])
 		_loftempsSet.push_back(node["loftemps"].as<int>());
+	_baseTUBonus = node["baseTUBonus"].as<int>(_baseTUBonus); 
+	_percentTUBonus = node["percentTUBonus"].as<int>(_percentTUBonus);
+	_baseStaminaBonus = node["baseStaminaBonus"].as<int>(_baseStaminaBonus);
+	_percentStaminaBonus = node["percentStaminaBonus"].as<int>(_percentStaminaBonus);
+	_baseStrengthBonus = node["baseStrengthBonus"].as<int>(_baseStrengthBonus);
+	_percentStrengthBonus = node["percentStrengthBonus"].as<int>(_percentStrengthBonus);
 }
 
 /**
@@ -201,6 +208,36 @@ float Armor::getDamageModifier(ItemDamageType dt)
 std::vector<int> Armor::getLoftempsSet() const
 {
 	return _loftempsSet;
+}
+
+/**
+ * Gets the TU Bonus.
+ * @param tu The wearer's TU's.
+ * @return The TU bonus.
+ */
+int Armor::getTUBonus(int tu) const
+{
+	return _baseTUBonus + (_percentTUBonus * tu) / 100;
+}
+
+/**
+ * Gets the Stamina bonus.
+ * @param stamina The wearer's stamina's.
+ * @return The stamina bonus.
+ */
+int Armor::getStaminaBonus(int stamina) const
+{
+	return _baseStaminaBonus + (_percentStaminaBonus * stamina) / 100;
+}
+
+/**
+ * Gets the Strength bonus.
+ * @param strength The wearer's strength's.
+ * @return The strength bonus.
+ */
+int Armor::getStrengthBonus(int strength) const
+{
+	return _baseStrengthBonus + (_percentStrengthBonus * strength) / 100;
 }
 
 }

--- a/src/Ruleset/Armor.h
+++ b/src/Ruleset/Armor.h
@@ -41,6 +41,7 @@ private:
 	int _size;
 	float _damageModifier[DAMAGE_TYPES];
 	std::vector<int> _loftempsSet;
+	int _baseTUBonus, _percentTUBonus, _baseStaminaBonus, _percentStaminaBonus, _baseStrengthBonus, _percentStrengthBonus;
 public:
 	/// Creates a blank armor ruleset.
 	Armor(const std::string &type, std::string spriteSheet, int drawingRoutine, MovementType _movementType = MT_WALK, int size = 1);
@@ -76,8 +77,12 @@ public:
 	float getDamageModifier(ItemDamageType dt);
 	/// Gets loftempSet
 	std::vector<int> getLoftempsSet() const;
-};
-
+	/// Gets the TU bonus.
+	int getTUBonus(int tu) const;
+	/// Gets the Stamina bonus.
+	int getStaminaBonus(int stamina) const;
+	/// Gets the Strength bonus.
+	int getStrengthBonus(int strength) const; };
 }
 
 #endif

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -85,8 +85,8 @@ BattleUnit::BattleUnit(Soldier *soldier, UnitFaction faction) : _faction(faction
 
 	_value = 20 + soldier->getMissions() + rankbonus;
 
-	_tu = _stats.tu;
-	_energy = _stats.stamina;
+	_tu = getFullTU(); 
+	_energy = getFullStamina();
 	_health = _stats.health;
 	_morale = 100;
 	_stunlevel = 0;
@@ -1350,8 +1350,8 @@ void BattleUnit::prepareNewTurn()
 	_unitsSpottedThisTurn.clear();
 
 	// recover TUs
-	int TURecovery = getStats()->tu;
-	float encumbrance = (float)getStats()->strength / (float)getCarriedWeight();
+	int TURecovery = getFullTU();
+	float encumbrance = (float)getFullStrength() / (float)getCarriedWeight();
 	if (encumbrance < 1)
 	{
 	  TURecovery = int(encumbrance * TURecovery);
@@ -1363,12 +1363,12 @@ void BattleUnit::prepareNewTurn()
 	// recover energy
 	if (!isOut())
 	{
-		int ENRecovery = getStats()->tu / 3;
+		int ENRecovery = getFullTU() / 3;
 		// Each fatal wound to the body reduces the soldier's energy recovery by 10%.
 		ENRecovery -= (_energy * (_fatalWounds[BODYPART_TORSO] * 10))/100;
 		_energy += ENRecovery;
-		if (_energy > getStats()->stamina)
-			_energy = getStats()->stamina;
+		if (_energy > getFullStamina())
+			_energy = getFullStamina();
 	}
 
 	// suffer from fatal wounds
@@ -2518,4 +2518,19 @@ bool BattleUnit::hasInventory() const
 	return (_armor->getSize() == 1 && _rank != "STR_LIVE_TERRORIST");
 }
 
+/*
+ * get the unit + armor bonuses stats.
+*/
+int BattleUnit::getFullTU() const
+{
+	return _stats.tu + _armor->getTUBonus(_stats.tu);
+}
+int BattleUnit::getFullStamina() const
+{
+	return _stats.stamina + _armor->getStaminaBonus(_stats.stamina);
+}
+int BattleUnit::getFullStrength() const
+{
+	return _stats.strength + _armor->getStrengthBonus(_stats.strength);
+} 
 }

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -418,6 +418,10 @@ public:
 	bool isSelectable(UnitFaction faction, bool checkReselect, bool checkInventory) const;
 	/// Does this unit have an inventory?
 	bool hasInventory() const;
+	/// get full stats including armor bonuses
+	int getFullTU() const;
+	int getFullStamina() const;
+	int getFullStrength() const;
 };
 
 }


### PR DESCRIPTION
All armor rulesets may contain the following nodes
- baseTUBonus
- percentTUBonus
- baseStaminaBonus
- percentStaminaBonus
- baseStrengthBonus
- percentStrengthBonus

The formula for BonusX is baseXBonus+(percentXBonus*stats.X)/100. The bonus is then applied to stats.x.
The BonusX values are used to display unit informations (Basescape+Battlescape), at first/new turn values init, but NOT at calculating action costs, which depend only of raw stats.
