### PR TITLE
Auto equip flares on night missions

### DIFF
--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -730,6 +730,10 @@ BattleItem* BattlescapeGenerator::placeItemByLayout(BattleItem *item)
 	RuleInventory *ground = _game->getRuleset()->getInventory("STR_GROUND");
 	if (item->getSlot() == ground)
 	{
+		// skip flares if not dark enough
+		if (BT_FLARE == item->getRules()->getBattleType() && _worldShade < NIGHT_SHADE_LEVEL)
+			return item;
+
 		bool loaded;
 		RuleInventory *righthand = _game->getRuleset()->getInventory("STR_RIGHT_HAND");
 
@@ -764,7 +768,7 @@ BattleItem* BattlescapeGenerator::placeItemByLayout(BattleItem *item)
 						}
 					}
 				}
-				// only place the weapon onto the soldier when its loaded with its layout-ammo (if any)
+				// only place the weapon onto the soldier when it's loaded with its layout-ammo (if any)
 				if (loaded)
 				{
 					item->moveToOwner((*i));
@@ -894,6 +898,26 @@ BattleItem* BattlescapeGenerator::addItem(BattleItem *item, bool secondPass)
 					item->setSlotX(3);
 					item->setSlotY(0);
 					break;
+				}
+			}
+			break;
+		case BT_FLARE:
+			// equip these on night-missions
+			if (_worldShade >= NIGHT_SHADE_LEVEL)
+			{
+				for (std::vector<BattleUnit*>::iterator i = _save->getUnits()->begin(); i != _save->getUnits()->end(); ++i)
+				{
+					// skip the vehicles
+					if ((*i)->getArmor()->getSize() > 1 || 0 == (*i)->getGeoscapeSoldier()) continue;
+
+					if (!(*i)->getItem("STR_LEFT_SHOULDER", 1,0))
+					{
+						item->moveToOwner((*i));
+						item->setSlot(_game->getRuleset()->getInventory("STR_LEFT_SHOULDER"));
+						item->setSlotX(1);
+						item->setSlotY(0);
+						break;
+					}
 				}
 			}
 			break;

--- a/src/Battlescape/BattlescapeGenerator.h
+++ b/src/Battlescape/BattlescapeGenerator.h
@@ -62,6 +62,7 @@ private:
 	Tile *_craftInventoryTile;
 	std::string _alienRace;
 	int _alienItemLevel;
+	static const int NIGHT_SHADE_LEVEL = 12;
 
 	/// Generates a new battlescape map.
 	void generateMap();


### PR DESCRIPTION
Uses a spare shoulder slot.  Flares are equipped if it is sufficiently
dark, i.e. when visibility would drop to 9 tiles for XCom units, and not
equipped otherwise

Eliminates some of the micromanagement of flares.
