### PR TITLE
Fix Bug report #291  -  Ufopaedia doesn't show stun rod damage 

### DIFF
--- a/src/Ufopaedia/ArticleStateItem.cpp
+++ b/src/Ufopaedia/ArticleStateItem.cpp
@@ -226,6 +226,7 @@ namespace OpenXcom
 			case BT_AMMO:
 			case BT_GRENADE:
 			case BT_PROXIMITYGRENADE:
+			case BT_MELEE:
 				setDamageTypeText(_txtAmmoType[0], item);
 
 				ss.str(L"");ss.clear();
@@ -260,6 +261,9 @@ namespace OpenXcom
 				break;
 			case DT_STUN:
 				text_field->setText(tr("STR_STUN_UC").c_str());
+				break;
+			case DT_MELEE:
+				text_field->setText(tr("STR_ARMOR_PIERCING").c_str());
 				break;
 			default:
 				text_field->setText(tr("STR_UNKNOWN").c_str());


### PR DESCRIPTION
Added Melee action and melee damage assimilated as ARMOR PIERCING
