### PR TITLE
UI improvement: Color of strings "Saving game" and "Loading game" in battlescape.

### DIFF
--- a/src/Menu/SavedGameState.cpp
+++ b/src/Menu/SavedGameState.cpp
@@ -126,7 +126,13 @@ SavedGameState::SavedGameState(Game *game, OptionsOrigin origin, bool showMsg) :
 
 		_txtStatus->setBig();
 		_txtStatus->setAlign(ALIGN_CENTER);
-		_txtStatus->setColor(Palette::blockOffset(8)+5);
+		if (origin == OPT_BATTLESCAPE)
+		{
+			_txtStatus->setColor(Palette::blockOffset(5));
+			_txtStatus->setHighContrast(true);
+		}
+		else
+			_txtStatus->setColor(Palette::blockOffset(8)+5);
 	}
 }
 


### PR DESCRIPTION
Changed color when uses quick save/load in battlescape. Looks native-like.

Before:
![clipboard05](https://f.cloud.github.com/assets/3616568/1277150/7d7ad150-2eaf-11e3-9ec1-1964cd69499c.png)

After:
![clipboard06](https://f.cloud.github.com/assets/3616568/1277151/894a619e-2eaf-11e3-9f56-c42184292647.png)
