### PR TITLE
ifdef FLC rendering placement (should fix bug #294)

### DIFF
--- a/src/Engine/Flc.cpp
+++ b/src/Engine/Flc.cpp
@@ -508,10 +508,13 @@ void FlcMain(void (*frameCallBack)())
   SDL_Event event;
   
 //#ifndef __NO_FLC
-  SDL_Rect dstRect = {flc.dx, flc.dy, flc.screen_w, flc.screen_h};
   FlcInitFirstFrame();
-  //flc.offset = flc.dy*flc.mainscreen->pitch + flc.mainscreen->format->BytesPerPixel*flc.dx;
+#ifdef _WIN32
+  flc.offset = flc.dy * flc.mainscreen->pitch + flc.mainscreen->BytesPerPixel * flc.dx;
+#else
+  SDL_Rect dstRect = {(Sint16)flc.dx, (Sint16)flc.dy, (Uint16)flc.screen_w, (Uint16)flc.screen_h};
   flc.offset = 0;
+#endif
   while(!flc.quit) {
 	if (frameCallBack) (*frameCallBack)();
     flc.FrameCount++;
@@ -538,7 +541,14 @@ void FlcMain(void (*frameCallBack)())
       SDLWaitFrame();
       /* TODO: Track which rectangles have really changed */
       //SDL_UpdateRect(flc.mainscreen, 0, 0, 0, 0);
-      if (flc.mainscreen != flc.realscreen->getSurface()->getSurface()) SDL_BlitSurface(flc.mainscreen, 0, flc.realscreen->getSurface()->getSurface(), &dstRect);
+      if (flc.mainscreen != flc.realscreen->getSurface()->getSurface())
+        SDL_BlitSurface(flc.mainscreen, 0, flc.realscreen->getSurface()->getSurface(),
+#ifdef _WIN32
+                        0
+#else
+                        &dstRect
+#endif
+                       );
       flc.realscreen->flip();
     }
 


### PR DESCRIPTION
This uses old centering code for Windows, otherwise uses new centering code.
I use the same options under Linux as in bug report #294.
The centering code that works on one seems to have problems on the other.
Used for fixing:
  #ifdef _WIN32
    ...
  #else
    ...
  #endif

These issues may be system and/or SDL version dependent.
More bug reports may be needed to work this out.
