### PR TITLE
Enable automatic saving of each turn in battlescape

### DIFF
--- a/src/Battlescape/NextTurnState.cpp
+++ b/src/Battlescape/NextTurnState.cpp
@@ -119,19 +119,12 @@ void NextTurnState::handle(Action *action)
 		}
 		else
 		{
-			if (Options::getInt("autosave") == 1)
+			if (Options::getInt("autosave") == 1 && _battleGame->getSide() == FACTION_PLAYER)
 			{
-				std::wstringstream ss;
-				ss << "Battlescape autosave "
-					<< tr("STR_TURN").arg(_battleGame->getTurn())
-					<< " "
-					<< tr("STR_SIDE").arg(tr(_battleGame->getSide() == FACTION_PLAYER ? "STR_XCOM" : "STR_ALIENS"));
-
-				// remove the > characters introduced by STR_TURN and STR_SIDE not a good idea to have these in file names.
-				std::wstring filename = ss.str();
-				Language::replace(filename  , L">", L"");
-
-				_game->pushState(new SaveState(_game, OPT_BATTLESCAPE, filename));
+				if (_battleGame->getTurn() == 1)
+					_game->pushState(new SaveState(_game, OPT_BATTLESCAPE, false, L"Battlescape autosave first turn"));
+				else
+					_game->pushState(new SaveState(_game, OPT_BATTLESCAPE, false, L"Battlescape autosave latest turn"));
 			}
 			_state->btnCenterClick(0);
 		}

--- a/src/Menu/SaveState.cpp
+++ b/src/Menu/SaveState.cpp
@@ -61,19 +61,9 @@ SaveState::SaveState(Game *game, OptionsOrigin origin) : SavedGameState(game, or
  * @param game Pointer to the core game.
  * @param origin Game section that originated this state.
  * @param showMsg True if need to show messages like "Loading game" or "Saving game".
- */
-SaveState::SaveState(Game *game, OptionsOrigin origin, bool showMsg) : SavedGameState(game, origin, showMsg)
-{
-	quickSave(L"autosave");
-}
-
-/**
- * Creates the Auto Save Game state.
- * @param game Pointer to the core game.
- * @param origin Game section that originated this state.
  * @param filename Name of the save file.
  */
-SaveState::SaveState(Game *game, OptionsOrigin origin, const std::wstring &filename) : SavedGameState(game, origin, false)
+SaveState::SaveState(Game *game, OptionsOrigin origin, bool showMsg, const std::wstring &filename) : SavedGameState(game, origin, showMsg)
 {
 	quickSave(filename);
 }

--- a/src/Menu/SaveState.h
+++ b/src/Menu/SaveState.h
@@ -41,9 +41,7 @@ public:
 	/// Creates the Save Game state.
 	SaveState(Game *game, OptionsOrigin origin);
 	/// Creates the Quick Save Game state.
-	SaveState(Game *game, OptionsOrigin origin, bool showMsg);
-	/// Creates the Auto Save state used in the battlescape.
-	SaveState(Game *game, OptionsOrigin origin, const std::wstring &filename);
+	SaveState(Game *game, OptionsOrigin origin, bool showMsg, const std::wstring &filename = L"autosave");
 	/// Cleans up the Save Game state.
 	~SaveState();
 	/// Updates the savegame list.


### PR DESCRIPTION
It's a bit annoying have something interesting happen, be it a crash or an anomaly,  in the battlescape and not have a save just before it happened or know how to recreate it.  I propose that we allow the option to save the game before each player and alien turn so that we are more likely to capture these events.

To avoid the introduction of yet another option I further propose that we use the existing autosave option.
