### PR TITLE
UI: Better radar lines

### DIFF
--- a/src/Geoscape/Globe.cpp
+++ b/src/Geoscape/Globe.cpp
@@ -1091,10 +1091,7 @@ void Globe::drawShadow()
 void Globe::XuLine(Surface* surface, Surface* src, double x1, double y1, double x2, double y2, Sint16)
 {
 	if (_clipper->LineClip(&x1,&y1,&x2,&y2) != 1) return; //empty line
-	x1+=0.5;
-	y1+=0.5;
-	x2+=0.5;
-	y2+=0.5;
+
 	double deltax = x2-x1, deltay = y2-y1;
 	bool inv;
 	Sint16 tcol;


### PR DESCRIPTION
I don't know why, but all radar's lines is shifted to bottom right corner.

Before:
![screen076x50](https://f.cloud.github.com/assets/3616568/1344470/28373bd2-3681-11e3-9af0-6677641871b4.png)
After:
![screen075x50](https://f.cloud.github.com/assets/3616568/1344474/336fcb72-3681-11e3-9e95-5a7cb365c1da.png)
