### PR TITLE
get things compiling again with gcc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,15 +60,15 @@ _ReSharper.*/
 *.idc
 *.tmp
 #OpenXcom stuff
-bin/data/GEODATA/
-bin/data/GEOGRAPH/
-bin/data/MAPS/
-bin/data/ROUTES/
-bin/data/SOUND/
-bin/data/TERRAIN/
-bin/data/UFOGRAPH/
-bin/data/UFOINTRO/
-bin/data/UNITS/
+bin/data/GEODATA
+bin/data/GEOGRAPH
+bin/data/MAPS
+bin/data/ROUTES
+bin/data/SOUND
+bin/data/TERRAIN
+bin/data/UFOGRAPH
+bin/data/UFOINTRO
+bin/data/UNITS
 deps/
 docs/html/
 build/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -559,34 +559,42 @@ set ( ufopedia_src
 )
 
 set ( data_install_dir bin )
-if ( CMAKE_COMPILER_IS_GNUCXX AND "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" )
-  add_definitions ( -D_DEBUG )
-endif ()
-if ( CMAKE_COMPILER_IS_GNUCXX AND ( "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" OR ENABLE_WARNING) )
+
+if ( CMAKE_COMPILER_IS_GNUCXX )
+  # fails to compile in previous standards due to missing functions (like to_wstring)
+  add_definitions ( -std=gnu++11 )
+
+  if ( "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" )
+    add_definitions ( -D_DEBUG )
+  endif ()
+
+  if ( "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" OR ENABLE_WARNING )
     # Enable more GCC warnings if requested or we are doing a Debug build.
     add_definitions ( -Wall
-      -Wsign-compare
-      -Winit-self
-      -Wmissing-include-dirs
-      -Wunknown-pragmas
-      -Wmissing-format-attribute
-      -Wredundant-decls
-      -Winline
-      -Wformat-security
-      -Wtype-limits
-      -Wclobbered
-      -Wempty-body
-      -Wlogical-op
-      -Wuninitialized
-      -Wshadow
-# These two warning options actually generate way too many warnings. Should be enabled later.
-#      -Wignored-qualifiers
-#      -Weffc++
-      )
+        -Wsign-compare
+        -Winit-self
+        -Wmissing-include-dirs
+        -Wunknown-pragmas
+        -Wmissing-format-attribute
+        -Wredundant-decls
+        -Winline
+        -Wformat-security
+        -Wtype-limits
+        -Wclobbered
+        -Wempty-body
+        -Wlogical-op
+        -Wuninitialized
+        -Wshadow
+  # These two warning options actually generate way too many warnings. Should be enabled later.
+  #      -Wignored-qualifiers
+  #      -Weffc++
+        )
+
     if ( FATAL_WARNING )
       add_definitions ( -Werror )
     endif ( FATAL_WARNING )
-endif()
+  endif()
+endif ()
 
 if ( MSVC )
   if ( ENABLE_WARNING )
@@ -693,17 +701,17 @@ if ( APPLE AND CREATE_BUNDLE )
     get_filename_component ( framework_name ${framework} NAME )
     if ( EXISTS "${framework}" )
       if ( "${CMAKE_GENERATOR}" STREQUAL "Xcode" )
-	add_custom_command ( TARGET openxcom
-	  POST_BUILD
-	  COMMAND ${CMAKE_COMMAND} -E make_directory ${EXECUTABLE_OUTPUT_PATH}/Debug/openxcom.app/Contents/Frameworks/${framework_name}
-	  COMMAND ${CMAKE_COMMAND} -E copy_directory ${framework} ${EXECUTABLE_OUTPUT_PATH}/Debug/openxcom.app/Contents/Frameworks/${framework_name}
-	  COMMAND ${CMAKE_COMMAND} -E make_directory ${EXECUTABLE_OUTPUT_PATH}/Release/openxcom.app/Contents/Frameworks/${framework_name}
-	  COMMAND ${CMAKE_COMMAND} -E copy_directory ${framework} ${EXECUTABLE_OUTPUT_PATH}/Release/openxcom.app/Contents/Frameworks/${framework_name} )
+        add_custom_command ( TARGET openxcom
+          POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E make_directory ${EXECUTABLE_OUTPUT_PATH}/Debug/openxcom.app/Contents/Frameworks/${framework_name}
+          COMMAND ${CMAKE_COMMAND} -E copy_directory ${framework} ${EXECUTABLE_OUTPUT_PATH}/Debug/openxcom.app/Contents/Frameworks/${framework_name}
+          COMMAND ${CMAKE_COMMAND} -E make_directory ${EXECUTABLE_OUTPUT_PATH}/Release/openxcom.app/Contents/Frameworks/${framework_name}
+          COMMAND ${CMAKE_COMMAND} -E copy_directory ${framework} ${EXECUTABLE_OUTPUT_PATH}/Release/openxcom.app/Contents/Frameworks/${framework_name} )
       else ()
-	add_custom_command ( TARGET openxcom
-	  POST_BUILD
-	  COMMAND ${CMAKE_COMMAND} -E make_directory ${EXECUTABLE_OUTPUT_PATH}/openxcom.app/Contents/Frameworks/${framework_name}
-	  COMMAND ${CMAKE_COMMAND} -E copy_directory ${framework} ${EXECUTABLE_OUTPUT_PATH}/openxcom.app/Contents/Frameworks/${framework_name} )
+        add_custom_command ( TARGET openxcom
+          POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E make_directory ${EXECUTABLE_OUTPUT_PATH}/openxcom.app/Contents/Frameworks/${framework_name}
+          COMMAND ${CMAKE_COMMAND} -E copy_directory ${framework} ${EXECUTABLE_OUTPUT_PATH}/openxcom.app/Contents/Frameworks/${framework_name} )
       endif ()
     endif ()
   endforeach ()

--- a/src/Ruleset/MapData.cpp
+++ b/src/Ruleset/MapData.cpp
@@ -21,6 +21,13 @@
 namespace OpenXcom
 {
 
+// These are here instead of in MapData.h to avoid undefined reference errors
+// while linking with gcc
+const int MapData::O_FLOOR     = 0;
+const int MapData::O_WESTWALL  = 1;
+const int MapData::O_NORTHWALL = 2;
+const int MapData::O_OBJECT    = 3;
+
 /**
  * Creates a new Map Data Object.
  * @param dataset The dataset this object belongs to.

--- a/src/Ruleset/MapData.h
+++ b/src/Ruleset/MapData.h
@@ -61,10 +61,10 @@ private:
 	int _loftID[12];
 	unsigned short _miniMapIndex;
 public:
-	static const int O_FLOOR = 0;
-	static const int O_WESTWALL = 1;
-	static const int O_NORTHWALL = 2;
-	static const int O_OBJECT = 3;
+	static const int O_FLOOR;
+	static const int O_WESTWALL;
+	static const int O_NORTHWALL;
+	static const int O_OBJECT;
 	MapData(MapDataSet *dataset);
 	~MapData();
 	/// Gets the dataset this object belongs to.


### PR DESCRIPTION
fixes compilation and linkage issues with gcc
- due to use of c++11-only features (in this case, to_wstring), compilation requires -std=gnu++11
- some static const ints were optimized out of a header file and were causing linkage issues; moved them to corresponding .cpp file
- modified .gitignore slightly to allow for symlinks to original xcom data instead of real directories (real directories still work, of course)
