### PR TITLE
Gameplay: Quantity of alien missions depends on difficulty level.

### DIFF
--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -2104,7 +2104,7 @@ void GeoscapeState::determineAlienMissions(bool atGameStart)
 		strategy.removeMission(targetRegion, "STR_ALIEN_RESEARCH");
 	}
 
-	for (unsigned i = atGameStart? DIFF_EXPERIENCED : DIFF_BEGINNER; i <= _game->getSavedGame()->getDifficulty(); ++i)
+	for (int i = atGameStart? DIFF_EXPERIENCED : DIFF_BEGINNER; i <= _game->getSavedGame()->getDifficulty(); ++i)
 	{
 		//
 		// One randomly selected mission.


### PR DESCRIPTION
Now works next algorithm of missions generator (the wave of missions):
1. Each month generated one terror mission and one random mission.
2. If monthsPassed > 5, then generated 2 terror mission and 2 random mission.
Quantity of missions does not depend on difficulty level.

I believe, this is wrong. Quantity of missions should depend on the difficulty level. In vanilla Xcom, difficulty level affected on number of missions.

I suggest next algorithm of generator:
Each month, will generate one terror mission and several random missions.
Beginner: 1 terror + 1 random.
Experienced: 1 terror + 2 random.
Veteran: 1 terror + 3 random.
Genius: 1 terror + 4 random.
Superhuman: 1 terror + 5 random.

After 5 passed months, quantity of missions will be doubled.
Of course, real quantity will be less, because duplicated waves in each region will be removed.
