### PR TITLE
Fix: IDs generation.

### DIFF
--- a/src/Ruleset/Ruleset.cpp
+++ b/src/Ruleset/Ruleset.cpp
@@ -629,14 +629,6 @@ SavedGame *Ruleset::newSave() const
 		save->getRegions()->push_back(new Region(getRegion(*i)));
 	}
 
-	// Set up IDs
-	std::map<std::string, int> ids;
-	for (std::vector<std::string>::const_iterator i = _craftsIndex.begin(); i != _craftsIndex.end(); ++i)
-	{
-		ids[*i] = 1;
-	}
-	save->initIds(ids);
-
 	// Set up starting base
 	Base *base = new Base(this);
 	base->load(_startingBase, save, true);

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -247,7 +247,7 @@ void SavedGame::load(const std::string &filename, Ruleset *rule)
 	_globeLon = doc["globeLon"].as<double>(_globeLon);
 	_globeLat = doc["globeLat"].as<double>(_globeLat);
 	_globeZoom = doc["globeZoom"].as<int>(_globeZoom);
-	initIds(doc["ids"].as< std::map<std::string, int> >(_ids));
+	_ids = doc["ids"].as< std::map<std::string, int> >(_ids);
 
 	for (YAML::const_iterator i = doc["countries"].begin(); i != doc["countries"].end(); ++i)
 	{
@@ -600,33 +600,12 @@ int SavedGame::getId(const std::string &name)
 	std::map<std::string, int>::iterator i = _ids.find(name);
 	if (i != _ids.end())
 	{
-		i->second++;
-		return i->second;
+		return ++(i->second);
 	}
 	else
 	{
-		_ids[name] = 2;
+		_ids[name] = 1;
 		return 1;
-	}
-}
-
-/**
- * Initializes the list of object IDs.
- * @param ids ID number list.
- */
-void SavedGame::initIds(const std::map<std::string, int> &ids)
-{
-	_ids["STR_UFO"] = 1;
-	_ids["STR_LANDING_SITE"] = 1;
-	_ids["STR_CRASH_SITE"] = 1;
-	_ids["STR_WAYPOINT"] = 1;
-	_ids["STR_TERROR_SITE"] = 1;
-	_ids["STR_ALIEN_BASE"] = 1;
-	_ids["STR_SOLDIER"] = 1;
-	_ids["ALIEN_MISSIONS"] = 1;
-	for (std::map<std::string, int>::const_iterator i = ids.begin(); i != ids.end(); ++i)
-	{
-		_ids[i->first] = i->second;
 	}
 }
 

--- a/src/Savegame/SavedGame.h
+++ b/src/Savegame/SavedGame.h
@@ -130,8 +130,6 @@ public:
 	void setTime(GameTime time);
 	/// Gets the current ID for an object.
 	int getId(const std::string &name);
-	/// Initializes te IDs list.
-	void initIds(const std::map<std::string, int> &ids);
 	/// Gets the list of countries.
 	std::vector<Country*> *getCountries();
 	/// Gets the total country funding.


### PR DESCRIPTION
Now, ID generator generates IDs from 2. For example: if you start new game, 1st UFO will marked as 2nd (UFO-2).
This fix starts generating IDs from 1 for all objects of new game.
But old games keeps IDs of objects, which never existed (for example AVENGER-1). Therefore, for old games, some IDs will start from 2.
