### PR TITLE
Fix: loading IDs of UFOs.

### DIFF
--- a/src/Savegame/Ufo.cpp
+++ b/src/Savegame/Ufo.cpp
@@ -105,7 +105,7 @@ private:
 void Ufo::load(const YAML::Node &node, const Ruleset &ruleset, SavedGame &game)
 {
 	MovingTarget::load(node);
-	_id = _crashId = _landId = node["id"].as<int>(_id);
+	_id = node["id"].as<int>(_id);
 	_crashId = node["crashId"].as<int>(_crashId);
 	_landId = node["landId"].as<int>(_landId);
 	_damage = node["damage"].as<int>(_damage);


### PR DESCRIPTION
If you save game with flying UFO,
 then load this game,
 then shoot down this UFO,
 then ID of crash site will be equivalent of the ID of UFO.
