### PR TITLE
UI: Close screens by their hotkeys.

### DIFF
--- a/src/Basescape/BasescapeState.cpp
+++ b/src/Basescape/BasescapeState.cpp
@@ -178,6 +178,7 @@ BasescapeState::BasescapeState(Game *game, Base *base, Globe *globe) : State(gam
 	_btnGeoscape->setText(tr("STR_GEOSCAPE_UC"));
 	_btnGeoscape->onMouseClick((ActionHandler)&BasescapeState::btnGeoscapeClick);
 	_btnGeoscape->onKeyboardPress((ActionHandler)&BasescapeState::btnGeoscapeClick, (SDLKey)Options::getInt("keyCancel"));
+	_btnGeoscape->onKeyboardPress((ActionHandler)&BasescapeState::btnGeoscapeClick, (SDLKey)Options::getInt("keyGeoBases"));
 }
 
 /**

--- a/src/Battlescape/AbortMissionState.cpp
+++ b/src/Battlescape/AbortMissionState.cpp
@@ -120,6 +120,7 @@ AbortMissionState::AbortMissionState(Game *game, SavedBattleGame *battleGame, Ba
 	_btnCancel->setHighContrast(true);
 	_btnCancel->onMouseClick((ActionHandler)&AbortMissionState::btnCancelClick);
 	_btnCancel->onKeyboardPress((ActionHandler)&AbortMissionState::btnCancelClick, (SDLKey)Options::getInt("keyCancel"));
+	_btnCancel->onKeyboardPress((ActionHandler)&AbortMissionState::btnCancelClick, (SDLKey)Options::getInt("keyBattleAbort"));
 
 }
 

--- a/src/Battlescape/MiniMapState.cpp
+++ b/src/Battlescape/MiniMapState.cpp
@@ -72,6 +72,7 @@ MiniMapState::MiniMapState (Game * game, Camera * camera, SavedBattleGame * batt
 	btnLvlDwn->onMouseClick((ActionHandler)&MiniMapState::btnLevelDownClick);
 	btnOk->onMouseClick((ActionHandler)&MiniMapState::btnOkClick);
 	btnOk->onKeyboardPress((ActionHandler)&MiniMapState::btnOkClick, (SDLKey)Options::getInt("keyCancel"));
+	btnOk->onKeyboardPress((ActionHandler)&MiniMapState::btnOkClick, (SDLKey)Options::getInt("keyBattleMap"));
 	_txtLevel->setBig();
 	_txtLevel->setColor(Palette::blockOffset(4));
 	_txtLevel->setHighContrast(true);

--- a/src/Battlescape/UnitInfoState.cpp
+++ b/src/Battlescape/UnitInfoState.cpp
@@ -566,6 +566,10 @@ void UnitInfoState::handle(Action *action)
 		{
 			_game->popState();
 		}
+		else if (action->getDetails()->key.keysym.sym == Options::getInt("keyBattleStats"))
+		{
+			_game->popState();
+		}
 	}
 }
 

--- a/src/Geoscape/FundingState.cpp
+++ b/src/Geoscape/FundingState.cpp
@@ -73,6 +73,7 @@ FundingState::FundingState(Game *game) : State(game)
 	_btnOk->onMouseClick((ActionHandler)&FundingState::btnOkClick);
 	_btnOk->onKeyboardPress((ActionHandler)&FundingState::btnOkClick, (SDLKey)Options::getInt("keyOk"));
 	_btnOk->onKeyboardPress((ActionHandler)&FundingState::btnOkClick, (SDLKey)Options::getInt("keyCancel"));
+	_btnOk->onKeyboardPress((ActionHandler)&FundingState::btnOkClick, (SDLKey)Options::getInt("keyGeoFunding"));
 
 	_txtTitle->setColor(Palette::blockOffset(15)-1);
 	_txtTitle->setAlign(ALIGN_CENTER);

--- a/src/Geoscape/GraphsState.cpp
+++ b/src/Geoscape/GraphsState.cpp
@@ -283,6 +283,7 @@ GraphsState::GraphsState(Game *game) : State(game)
 	_btnFinance->onMouseClick((ActionHandler)&GraphsState::btnFinanceClick);
 	_btnGeoscape->onMouseClick((ActionHandler)&GraphsState::btnGeoscapeClick);
 	_btnGeoscape->onKeyboardPress((ActionHandler)&GraphsState::btnGeoscapeClick, (SDLKey)Options::getInt("keyCancel"));
+	_btnGeoscape->onKeyboardPress((ActionHandler)&GraphsState::btnGeoscapeClick, (SDLKey)Options::getInt("keyGeoGraphs"));
 
 	centerAllSurfaces();
 }

--- a/src/Geoscape/InterceptState.cpp
+++ b/src/Geoscape/InterceptState.cpp
@@ -82,6 +82,7 @@ InterceptState::InterceptState(Game *game, Globe *globe, Base *base, Target *tar
 	_btnCancel->onMouseClick((ActionHandler)&InterceptState::btnCancelClick);
 	_btnCancel->onKeyboardPress((ActionHandler)&InterceptState::btnCancelClick, (SDLKey)Options::getInt("keyOk"));
 	_btnCancel->onKeyboardPress((ActionHandler)&InterceptState::btnCancelClick, (SDLKey)Options::getInt("keyCancel"));
+	_btnCancel->onKeyboardPress((ActionHandler)&InterceptState::btnCancelClick, (SDLKey)Options::getInt("keyGeoIntercept"));
 
 	_txtTitle->setColor(Palette::blockOffset(15)-1);
 	_txtTitle->setAlign(ALIGN_CENTER);

--- a/src/Ufopaedia/UfopaediaSelectState.cpp
+++ b/src/Ufopaedia/UfopaediaSelectState.cpp
@@ -70,6 +70,7 @@ namespace OpenXcom
 		_btnOk->setText(tr("STR_OK"));
 		_btnOk->onMouseClick((ActionHandler)&UfopaediaSelectState::btnOkClick);
 		_btnOk->onKeyboardPress((ActionHandler)&UfopaediaSelectState::btnOkClick,(SDLKey)Options::getInt("keyCancel"));
+		_btnOk->onKeyboardPress((ActionHandler)&UfopaediaSelectState::btnOkClick,(SDLKey)Options::getInt("keyGeoUfopedia"));
 
 		_lstSelection->setColor(Palette::blockOffset(8)+5);
 		_lstSelection->setArrowColor(Palette::blockOffset(15)-1);

--- a/src/Ufopaedia/UfopaediaStartState.cpp
+++ b/src/Ufopaedia/UfopaediaStartState.cpp
@@ -95,6 +95,7 @@ namespace OpenXcom
 		_btnOk->setText(tr("STR_OK"));
 		_btnOk->onMouseClick((ActionHandler)&UfopaediaStartState::btnOkClick);
 		_btnOk->onKeyboardPress((ActionHandler)&UfopaediaStartState::btnOkClick, (SDLKey)Options::getInt("keyCancel"));
+		_btnOk->onKeyboardPress((ActionHandler)&UfopaediaStartState::btnOkClick, (SDLKey)Options::getInt("keyGeoUfopedia"));
 	}
 
 	UfopaediaStartState::~UfopaediaStartState()


### PR DESCRIPTION
Convenient way to close some screens by the same hotkey that is used to open them, so you don't have to reach for escape or other keys. Inventory hotkey is in another request. BasescapeState.cpp changes are probably due to newline conversions, I can't fix that.
