### PR TITLE
Bug Fix: Globe keeps rotating indefinitely.

### DIFF
--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -1743,6 +1743,7 @@ void GeoscapeState::globeClick(Action *action)
  */
 void GeoscapeState::btnInterceptClick(Action *)
 {
+	_globe->rotateStop();
 	_game->pushState(new InterceptState(_game, _globe));
 }
 
@@ -1752,6 +1753,7 @@ void GeoscapeState::btnInterceptClick(Action *)
  */
 void GeoscapeState::btnBasesClick(Action *)
 {
+	_globe->rotateStop();
 	timerReset();
 	if (!_game->getSavedGame()->getBases()->empty())
 	{
@@ -1769,6 +1771,7 @@ void GeoscapeState::btnBasesClick(Action *)
  */
 void GeoscapeState::btnGraphsClick(Action *)
 {
+	_globe->rotateStop();
 	_game->pushState(new GraphsState(_game));
 }
 
@@ -1778,6 +1781,7 @@ void GeoscapeState::btnGraphsClick(Action *)
  */
 void GeoscapeState::btnUfopaediaClick(Action *)
 {
+	_globe->rotateStop();
 	Ufopaedia::open(_game);
 }
 
@@ -1787,6 +1791,7 @@ void GeoscapeState::btnUfopaediaClick(Action *)
  */
 void GeoscapeState::btnOptionsClick(Action *)
 {
+	_globe->rotateStop();
 	_game->pushState(new PauseState(_game, OPT_GEOSCAPE));
 }
 
@@ -1796,6 +1801,7 @@ void GeoscapeState::btnOptionsClick(Action *)
  */
 void GeoscapeState::btnFundingClick(Action *)
 {
+	_globe->rotateStop();
 	_game->pushState(new FundingState(_game));
 }
 


### PR DESCRIPTION
Globe keeps rotating indefinitely if geoscape screen (like Intercept) was opened while rotating globe by hotkey.
