### PR TITLE
New attributes in the manufacture section of the ruleset: producedItem & produceQty

### DIFF
--- a/src/Ruleset/RuleManufacture.cpp
+++ b/src/Ruleset/RuleManufacture.cpp
@@ -24,7 +24,7 @@ namespace OpenXcom
  * Creates a new Manufacture.
  * @param name The unique manufacture name.
  */
-RuleManufacture::RuleManufacture(const std::string &name) : _name(name), _space(0), _time(0), _cost(0), _listOrder(0)
+RuleManufacture::RuleManufacture(const std::string &name) : _name(name), _producedItem(name), _space(0), _time(0), _cost(0), _listOrder(0), _produceQty(1)
 {
 }
 
@@ -35,12 +35,15 @@ RuleManufacture::RuleManufacture(const std::string &name) : _name(name), _space(
  */
 void RuleManufacture::load(const YAML::Node &node, int listOrder)
 {
-	_name = node["name"].as<std::string>(_name);
+	if (_name == _producedItem) _producedItem = _name = node["name"].as<std::string>(_name);
+	else _name = node["name"].as<std::string>(_name);
+	if (node["producedItem"]) _producedItem = node["producedItem"].as<std::string>(_producedItem);
 	_category = node["category"].as<std::string>(_category);
 	_requires = node["requires"].as< std::vector<std::string> >(_requires);
 	_space = node["space"].as<int>(_space);
 	_time = node["time"].as<int>(_time);
 	_cost = node["cost"].as<int>(_cost);
+	if (node["produceQty"]) _produceQty = node["produceQty"].as<int>(_produceQty);
 	_requiredItems = node["requiredItems"].as< std::map<std::string, int> >(_requiredItems);
 	_listOrder = node["listOrder"].as<int>(_listOrder);
 	if (!_listOrder)
@@ -56,6 +59,15 @@ void RuleManufacture::load(const YAML::Node &node, int listOrder)
 std::string RuleManufacture::getName () const
 {
 	return _name;
+}
+
+/**
+ * Get the name of the produced item (it is the same as getName in most cases, and by default)
+ * @return the name
+*/
+std::string RuleManufacture::getProducedItem() const
+{
+  return _producedItem;
 }
 
 /**
@@ -105,6 +117,14 @@ int RuleManufacture::getManufactureCost () const
 	return _cost;
 }
 
+/**
+ * Get the number of objects to manufacture instead of one (it is 1 in most cases, and by default)
+ * @return the number
+*/
+int RuleManufacture::getProduceQty() const
+{
+  return _produceQty;
+}
 /**
  * Gets the list of items required to manufacture one object.
  * @return The list of items required to manufacture one object.

--- a/src/Ruleset/RuleManufacture.h
+++ b/src/Ruleset/RuleManufacture.h
@@ -32,9 +32,9 @@ namespace OpenXcom
 class RuleManufacture
 {
 private:
-	std::string _name, _category;
+	std::string _name, _producedItem, _category;
 	std::vector<std::string> _requires;
-	int _space, _time, _cost;
+	int _space, _time, _cost, _produceQty;
 	std::map<std::string, int> _requiredItems;
 	int _listOrder;
 public:
@@ -44,6 +44,8 @@ public:
 	void load(const YAML::Node& node, int listOrder);
 	/// Gets the manufacture name.
 	std::string getName () const;
+	///Get the name of the produced item (it is the same as getName in most cases, and by default)
+	std::string getProducedItem() const;
 	/// Gets the manufacture category.
 	std::string getCategory () const;
 	/// Gets the manufacture's requirements.
@@ -54,6 +56,8 @@ public:
 	int getManufactureTime () const;
 	/// Gets the cost of manufacturing one object.
 	int getManufactureCost () const;
+	///Get the number of objects to manufacture instead of one (it is 1 in most cases, and by default)
+	int getProduceQty() const;
 	/// Gets the list of items required to manufacture one object.
 	const std::map<std::string, int> & getRequiredItems() const;
 	/// Gets the list weight for this manufacture item.

--- a/src/Savegame/Production.cpp
+++ b/src/Savegame/Production.cpp
@@ -92,14 +92,14 @@ productionProgress_e Production::step(Base * b, SavedGame * g, const Ruleset *r)
 		{
 			if (_rules->getCategory() == "STR_CRAFT")
 			{
-				Craft *craft = new Craft(r->getCraft(_rules->getName()), b, g->getId(_rules->getName()));
+				Craft *craft = new Craft(r->getCraft(_rules->getProducedItem()), b, g->getId(_rules->getProducedItem()));
 				craft->setStatus("STR_REFUELLING");
 				b->getCrafts()->push_back(craft);
 			}
 			else
 			{
 				// Check if it's ammo to reload a craft
-				if (r->getItem(_rules->getName())->getBattleType() == BT_NONE)
+				if (r->getItem(_rules->getProducedItem())->getBattleType() == BT_NONE)
 				{
 					for (std::vector<Craft*>::iterator c = b->getCrafts()->begin(); c != b->getCrafts()->end(); ++c)
 					{
@@ -107,7 +107,7 @@ productionProgress_e Production::step(Base * b, SavedGame * g, const Ruleset *r)
 							continue;
 						for (std::vector<CraftWeapon*>::iterator w = (*c)->getWeapons()->begin(); w != (*c)->getWeapons()->end(); ++w)
 						{
-							if ((*w) != 0 && (*w)->getRules()->getClipItem() == _rules->getName() && (*w)->getAmmo() < (*w)->getRules()->getAmmoMax())
+							if ((*w) != 0 && (*w)->getRules()->getClipItem() == _rules->getProducedItem() && (*w)->getAmmo() < (*w)->getRules()->getAmmoMax())
 							{
 								(*w)->setRearming(true);
 								(*c)->setStatus("STR_REARMING");
@@ -116,9 +116,9 @@ productionProgress_e Production::step(Base * b, SavedGame * g, const Ruleset *r)
 					}
 				}
 				if (allowAutoSellProduction && getAmountTotal() == std::numeric_limits<int>::max())
-					g->setFunds(g->getFunds() + r->getItem(_rules->getName())->getSellCost());
+					g->setFunds(g->getFunds() + (r->getItem(_rules->getProducedItem())->getSellCost() * _rules->getProduceQty()));
 				else
-					b->getItems()->addItem(_rules->getName(), 1);
+					b->getItems()->addItem(_rules->getProducedItem(), _rules->getProduceQty());
 			}
 			if (!canManufactureMoreItemsPerHour) break;
 			count++;


### PR DESCRIPTION
For the sake of moddability.

producedItem: The name of the produced item (it equals to name attrib if not specified, and by default)
produceQty: The (output) number of objects to manufacture instead of one (it equals to 1 if not specified, and by default)

With these two new attributes for example we can create manufacture rules to convert 1 piece Heavy Plasma Clip to 3 pieces of Elerium-115. (that clip is assembled of 3 pieces of elerium)
Sample ruleset file for this clips -> elerium conversion can be found here: http://openxcom.org/forum/index.php/topic,1623.msg15818.html#msg15818
