### PR TITLE
Do not autoequip two-wide ammo if not enough belt space

### DIFF
--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -600,7 +600,7 @@ void BattlescapeGenerator::deployAliens(AlienRace *race, AlienDeployment *deploy
 		std::string alienName = race->getMember((*d).alienRank);
 
 		int quantity;
-		
+
 		if (_game->getSavedGame()->getDifficulty() < DIFF_VETERAN)
 			quantity = (*d).lowQty + RNG::generate(0, (*d).dQty); // beginner/experienced
 		else if (_game->getSavedGame()->getDifficulty() < DIFF_SUPERHUMAN)
@@ -825,16 +825,16 @@ BattleItem* BattlescapeGenerator::addItem(BattleItem *item, bool secondPass)
 					{
 						for (std::vector<std::string>::iterator it = (*bu)->getMainHandWeapon()->getRules()->getCompatibleAmmo()->begin(); it != (*bu)->getMainHandWeapon()->getRules()->getCompatibleAmmo()->end() && !placed; ++it)
 						{
-							if (*it == item->getRules()->getType())
+							if (*it == item->getRules()->getType()
+								&& !(*bu)->getItem("STR_BELT", 1)
+								&& item->getRules()->getInventoryHeight() == 1
+								&& (item->getRules()->getInventoryWidth() == 1 || !(*bu)->getItem("STR_BELT", 2)))
 							{
-								if (!(*bu)->getItem("STR_BELT", 1) && item->getRules()->getInventoryHeight() == 1)
-								{
-									item->moveToOwner((*bu));
-									item->setSlot(_game->getRuleset()->getInventory("STR_BELT"));
-									item->setSlotX(1);
-									placed = true;
-									break;
-								}
+								item->moveToOwner((*bu));
+								item->setSlot(_game->getRuleset()->getInventory("STR_BELT"));
+								item->setSlotX(1);
+								placed = true;
+								break;
 							}
 						}
 					}


### PR DESCRIPTION
Trying to avoid something like this:
![screen021](https://f.cloud.github.com/assets/1824834/1567411/b247e9b2-509d-11e3-8006-8899571ce4c3.png)

There was already a clip on the right of the belt and the auto equip put another one overlapping it.
