### PR TITLE
Set floating flag correctly when placing unit

### DIFF
--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -1595,7 +1595,7 @@ void BattleUnit::setTile(Tile *tile, Tile *tileBelow)
 		_status = STATUS_WALKING;
 		_floating = false;
 	}
-	else if (_status == STATUS_STANDING)
+	else if (_status == STATUS_STANDING && _armor->getMovementType() == MT_FLY)
 	{
 		_floating = _tile->hasNoFloor(tileBelow);
 	}

--- a/src/Savegame/SavedBattleGame.cpp
+++ b/src/Savegame/SavedBattleGame.cpp
@@ -1392,7 +1392,6 @@ bool SavedBattleGame::setUnitPosition(BattleUnit *bu, const Position &position, 
 			if (x==0 && y==0)
 			{
 				bu->setPosition(position);
-				bu->setTile(getTile(position), getTile(position - Position(0,0,1)));
 			}
 			getTile(position + Position(x,y,0))->setUnit(bu, getTile(position + Position(x,y,-1)));
 		}


### PR DESCRIPTION
When moving to the next stage in Cydonia, flying units were still floating in the deployment zone:
![screen023](https://f.cloud.github.com/assets/1824834/1609390/39c3c53a-5541-11e3-986a-4af4a91c49dd.png)

Update stops the floating:
![screen022](https://f.cloud.github.com/assets/1824834/1609392/543f1fa4-5541-11e3-91b8-5e849ed80f54.png)
