### PR TITLE
More floating

### DIFF
--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -315,9 +315,9 @@ bool TileEngine::calculateFOV(BattleUnit *unit)
 									if (tst>127) --tsize; //last tile is blocked thus must be cropped
 									for (unsigned int i = 0; i < tsize; i++)
 									{
-										Position posi = _trajectory.at(i); 
+										Position posi = _trajectory.at(i);
 										//mark every tile of line as visible (as in original)
-										//this is needed because of bresenham narrow stroke. 
+										//this is needed because of bresenham narrow stroke.
 										_save->getTile(posi)->setVisible(+1);
 										_save->getTile(posi)->setDiscovered(true, 2);
 										// walls to the east or south of a visible tile, we see that too
@@ -1564,7 +1564,7 @@ int TileEngine::horizontalBlockage(Tile *startTile, Tile *endTile, ItemDamageTyp
 	}
 	else
 	{
-        if ( block <= 127 ) 
+        if ( block <= 127 )
         {
             direction += 4;
             if (direction > 7)
@@ -2086,7 +2086,7 @@ int TileEngine::calculateParabola(const Position& origin, const Position& target
 	int z = origin.z;
 	int i = 8;
 	Position lastPosition = Position(x,y,z);
-	while (z > 0) 
+	while (z > 0)
 	{
 		x = (int)((double)origin.x + (double)i * cos(te) * sin(fi));
 		y = (int)((double)origin.y + (double)i * sin(te) * sin(fi));
@@ -2361,29 +2361,31 @@ bool TileEngine::psiAttack(BattleAction *action)
  */
 Tile *TileEngine::applyGravity(Tile *t)
 {
-	if (t->getInventory()->empty() && !t->getUnit()) return t; // skip this if there are no items
 	if (!t)
 	{
 		return 0;
 	}
 
-	Position p = t->getPosition();
+	if (t->getInventory()->empty() && !t->getUnit()) return t; // skip this if there are no items
+
 	Tile *rt = t;
 	Tile *rtb;
-	BattleUnit *occupant = t->getUnit();
 
-	if (occupant && (occupant->getArmor()->getMovementType() != MT_FLY || occupant->isOut()))
+	// Where should units end up?
+	BattleUnit *occupant = t->getUnit();
+	if (occupant)
 	{
+		int size = occupant->getArmor()->getSize();
 		Position unitpos = occupant->getPosition();
 		while (unitpos.z >= 0)
 		{
 			bool canFall = true;
-			for (int y = 0; y < occupant->getArmor()->getSize() && canFall; ++y)
+			for (int y = 0; y < size && canFall; ++y)
 			{
-				for (int x = 0; x < occupant->getArmor()->getSize() && canFall; ++x)
+				for (int x = 0; x < size && canFall; ++x)
 				{
-					rt = _save->getTile(Position(unitpos.x+x, unitpos.y+y, unitpos.z));
-					rtb = _save->getTile(Position(unitpos.x+x, unitpos.y+y, unitpos.z-1)); //below
+					rt = _save->getTile(Position(unitpos.x + x, unitpos.y + y, unitpos.z));
+					rtb = _save->getTile(Position(unitpos.x + x, unitpos.y + y, unitpos.z - 1)); //below
 					if (!rt->hasNoFloor(rtb))
 					{
 						canFall = false;
@@ -2394,30 +2396,42 @@ Tile *TileEngine::applyGravity(Tile *t)
 				break;
 			unitpos.z--;
 		}
+
 		if (unitpos != occupant->getPosition())
 		{
-			if (occupant->getHealth() != 0 && occupant->getStunlevel() < occupant->getHealth())
+			if (occupant->getArmor()->getMovementType() != MT_FLY || occupant->isOut())
 			{
-				occupant->startWalking(Pathfinding::DIR_DOWN, occupant->getPosition() + Position(0,0,-1),
-					_save->getTile(occupant->getPosition() + Position(0,0,-1)), true);
-				_save->addFallingUnit(occupant);
+				if (occupant->getHealth() != 0 && occupant->getStunlevel() < occupant->getHealth())
+				{
+					occupant->startWalking(Pathfinding::DIR_DOWN, occupant->getPosition() + Position(0, 0, -1),
+						_save->getTile(occupant->getPosition() + Position(0, 0, -1)), true);
+					_save->addFallingUnit(occupant);
+				}
+				else
+				{
+					Position origin = occupant->getPosition();
+					for (int y = size - 1; y >= 0; --y)
+					{
+						for (int x = size - 1; x >= 0; --x)
+						{
+							_save->getTile(origin + Position(x, y, 0))->setUnit(0);
+						}
+					}
+					occupant->setPosition(unitpos);
+				}
 			}
 			else
 			{
-				Position origin = occupant->getPosition();
-				for (int y = occupant->getArmor()->getSize()-1; y >= 0; --y)
-				{
-					for (int x = occupant->getArmor()->getSize()-1; x >= 0; --x)
-					{
-						_save->getTile(origin + Position(x, y, 0))->setUnit(0);
-					}
-				}
-				occupant->setPosition(unitpos);
+				// flying unit - update floating/kneeling
+				t->setUnit(occupant);
 			}
 		}
 	}
+
+	// Where should items end up?
 	rt = t;
 	bool canFall = true;
+	Position p = t->getPosition();
 	while (p.z >= 0 && canFall)
 	{
 		rt = _save->getTile(p);
@@ -2426,22 +2440,19 @@ Tile *TileEngine::applyGravity(Tile *t)
 			canFall = false;
 		p.z--;
 	}
-
-	for (std::vector<BattleItem*>::iterator it = t->getInventory()->begin(); it != t->getInventory()->end(); ++it)
-	{
-		if ((*it)->getUnit() && t->getPosition() == (*it)->getUnit()->getPosition())
-		{
-			(*it)->getUnit()->setPosition(rt->getPosition());
-		}
-		if (t != rt)
-		{
-			rt->addItem(*it, (*it)->getSlot());
-		}
-	}
-
 	if (t != rt)
 	{
-		// clear tile
+		// Move items to new tile.
+		for (std::vector<BattleItem*>::iterator it = t->getInventory()->begin(); it != t->getInventory()->end(); ++it)
+		{
+			// Corpses.
+			if ((*it)->getUnit() && t->getPosition() == (*it)->getUnit()->getPosition())
+			{
+				(*it)->getUnit()->setPosition(rt->getPosition());
+			}
+			rt->addItem(*it, (*it)->getSlot());
+		}
+		// Clear tile.
 		t->getInventory()->clear();
 	}
 
@@ -2654,7 +2665,7 @@ int TileEngine::getDirectionTo(const Position &origin, const Position &target) c
 
 Position TileEngine::getOriginVoxel(BattleAction &action, Tile *tile)
 {
-	
+
 	const int dirYshift[24] = {1, 3, 9, 15, 15, 13, 7, 1,  1, 1, 7, 13, 15, 15, 9, 3,  1, 2, 8, 14, 15, 14, 8, 2};
 	const int dirXshift[24] = {9, 15, 15, 13, 8, 1, 1, 3,  7, 13, 15, 15, 9, 3, 1, 1,  8, 14, 15, 14, 8, 2, 1, 2};
 	if (!tile)
@@ -2673,7 +2684,7 @@ Position TileEngine::getOriginVoxel(BattleAction &action, Tile *tile)
 		originVoxel.z += -tile->getTerrainLevel();
 
 		originVoxel.z += action.actor->getHeight() + action.actor->getFloatHeight();
-		
+
 		if (action.type == BA_THROW)
 		{
 			originVoxel.z -= 3;

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -1599,9 +1599,11 @@ void BattleUnit::setTile(Tile *tile, Tile *tileBelow)
 		_status = STATUS_WALKING;
 		_floating = false;
 	}
-	else if (_status == STATUS_UNCONSCIOUS)
+	else
 	{
 		_floating = _armor->getMovementType() == MT_FLY && _tile->hasNoFloor(tileBelow);
+		if (_floating)
+			kneel(false);
 	}
 }
 

--- a/src/Savegame/SavedBattleGame.cpp
+++ b/src/Savegame/SavedBattleGame.cpp
@@ -201,7 +201,7 @@ void SavedBattleGame::load(const YAML::Node &node, Ruleset *rule, SavedGame* sav
 		{
 			if ((unit->getId() == selectedUnit) || (_selectedUnit == 0 && !unit->isOut()))
 				_selectedUnit = unit;
-			
+
 			// silly hack to fix mind controlled aliens
 			// TODO: save stats instead? maybe some kind of weapon will affect them at some point.
 			if (unit->getOriginalFaction() == FACTION_HOSTILE)
@@ -231,8 +231,6 @@ void SavedBattleGame::load(const YAML::Node &node, Ruleset *rule, SavedGame* sav
 			}
 		}
 	}
-	// matches up tiles and units
-	resetUnitTiles();
 
 	for (YAML::const_iterator i = node["items"].begin(); i != node["items"].end(); ++i)
 	{
@@ -323,6 +321,9 @@ void SavedBattleGame::loadMapResources(Game *game)
 			}
 		}
 	}
+
+	// matches up tiles and units
+	resetUnitTiles();
 
 	initUtilities(res);
 	getTileEngine()->calculateSunShading();
@@ -916,7 +917,6 @@ void SavedBattleGame::resetUnitTiles()
 					t->setUnit((*i), getTile(t->getPosition() + Position(0,0,-1)));
 				}
 			}
-
 		}
 		if ((*i)->getFaction() == FACTION_PLAYER)
 		{


### PR DESCRIPTION
Found another case.  Kneel a flying unit on a destructible roof and shoot out the floor tile.  Unit carries on kneeling and _floating is not set to true.

![screen002](https://f.cloud.github.com/assets/1824834/1751011/0b6fa354-65c5-11e3-961b-52782572743e.png)

Tested against other cases in bug413 and nothing broke to my knowledge.
