### PR TITLE
Fix: Give more space to STR_REMAINING_PSI_LAB_CAPACITY!

### DIFF
--- a/src/Geoscape/AllocatePsiTrainingState.cpp
+++ b/src/Geoscape/AllocatePsiTrainingState.cpp
@@ -49,7 +49,7 @@ AllocatePsiTrainingState::AllocatePsiTrainingState(Game *game, Base *base) : Sta
 	// Create objects
 	_window = new Window(this, 320, 200, 0, 0);
 	_txtTitle = new Text(300, 17, 10, 8);
-	_txtRemaining = new Text(134, 10, 10, 24);
+	_txtRemaining = new Text(300, 10, 10, 24);
 	_txtName = new Text(64, 10, 10, 40);
 	_txtPsiStrength = new Text(80, 20, 124, 32);
 	_txtPsiSkill = new Text(80, 20, 188, 32);


### PR DESCRIPTION
(since it is alone in that line)
