### PR TITLE
New Feature/Option: Allow Psi-Strength Improvement

### DIFF
--- a/bin/data/Language/en-GB.yml
+++ b/bin/data/Language/en-GB.yml
@@ -1189,6 +1189,8 @@ en-GB:
   STR_GO_TO_BASE: "Go to Base"
   STR_DISABLEAUTOEQUIP: "Disable auto-equip"
   STR_DISABLEAUTOEQUIP_DESC: "Disable auto-equipping of new soldiers before battle."
+  STR_ALLOWPSISTRENGTHIMPROVEMENT: "Allow Psi-Strength Improvement"
+  STR_ALLOWPSISTRENGTHIMPROVEMENT_DESC: "Psionic strength of the soldiers can be improved by experience and training."
   STR_TFTDDAMAGE: "TFTD Damage Formula"
   STR_TFTDDAMAGE_DESC: "Weapons will do between 50% and 150% of their rated damage as opposed to UFO: Enemy Unknown's 0% to 200%"
   STR_BATTLESMOOTHCAMERA: "Smooth Bullet Camera"

--- a/bin/data/Language/en-US.yml
+++ b/bin/data/Language/en-US.yml
@@ -1189,6 +1189,8 @@ en-US:
   STR_GO_TO_BASE: "Go to Base"
   STR_DISABLEAUTOEQUIP: "Disable auto-equip"
   STR_DISABLEAUTOEQUIP_DESC: "Disable auto-equipping of new soldiers before battle."
+  STR_ALLOWPSISTRENGTHIMPROVEMENT: "Allow Psi-Strength Improvement"
+  STR_ALLOWPSISTRENGTHIMPROVEMENT_DESC: "Psionic strength of the soldiers can be improved by experience and training."
   STR_TFTDDAMAGE: "TFTD Damage Formula"
   STR_TFTDDAMAGE_DESC: "Weapons will do between 50% and 150% of their rated damage as opposed to X-COM: UFO Defense's 0% to 200%"
   STR_BATTLESMOOTHCAMERA: "Smooth Bullet Camera"

--- a/bin/data/Ruleset/Xcom1Ruleset.rul
+++ b/bin/data/Ruleset/Xcom1Ruleset.rul
@@ -4390,7 +4390,7 @@ soldiers:
       firing: 120
       throwing: 120
       strength: 70
-      psiStrength: 0
+      psiStrength: 100
       psiSkill: 100
       melee: 120
     armor: STR_NONE_UC

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -2434,11 +2434,12 @@ bool TileEngine::psiAttack(BattleAction *action)
 		defenseStrength += 20;
 	}
 
-	action->actor->addPsiExp();
+	action->actor->addPsiSkillExp();
+	if (Options::allowPsiStrengthImprovement) victim->addPsiStrengthExp();
 	if (attackStrength > defenseStrength)
 	{
-		action->actor->addPsiExp();
-		action->actor->addPsiExp();
+		action->actor->addPsiSkillExp();
+		action->actor->addPsiSkillExp();
 		if (action->type == BA_PANIC)
 		{
 			int moraleLoss = (110-_save->getTile(action->target)->getUnit()->getStats()->bravery);
@@ -2469,7 +2470,15 @@ bool TileEngine::psiAttack(BattleAction *action)
 		}
 		return true;
 	}
-	return false;
+	else
+	{
+		if (Options::allowPsiStrengthImprovement)
+		{
+			victim->addPsiStrengthExp();
+			victim->addPsiStrengthExp();
+		}
+		return false;
+	}
 }
 
 /**

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -182,6 +182,7 @@ void create()
 	_info.push_back(OptionInfo("battleConfirmFireMode", &battleConfirmFireMode, false, "STR_BATTLECONFIRMFIREMODE", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("weaponSelfDestruction", &weaponSelfDestruction, false, "STR_WEAPONSELFDESTRUCTION", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("allowPsionicCapture", &allowPsionicCapture, false, "STR_ALLOWPSIONICCAPTURE", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("allowPsiStrengthImprovement", &allowPsiStrengthImprovement, false, "STR_ALLOWPSISTRENGTHIMPROVEMENT", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("strafe", &strafe, false, "STR_STRAFE", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("forceFire", &forceFire, true, "STR_FORCE_FIRE", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("skipNextTurnScreen", &skipNextTurnScreen, false, "STR_SKIPNEXTTURNSCREEN", "STR_BATTLESCAPE"));

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -20,7 +20,7 @@ OPT SDLKey keyOk, keyCancel, keyScreenshot, keyFps, keyQuickLoad, keyQuickSave;
 OPT int geoClockSpeed, dogfightSpeed, geoScrollSpeed, geoDragScrollButton, geoscapeScale;
 OPT bool includePrimeStateInSavedLayout, anytimePsiTraining, weaponSelfDestruction, spendResearchedItems, craftLaunchAlways, globeSeasons, globeDetail, globeRadarLines, globeFlightPaths, globeAllRadarsOnBaseBuild,
 	storageLimitsEnforced, canSellLiveAliens, canTransferCraftsWhileAirborne, canManufactureMoreItemsPerHour, customInitialBase, aggressiveRetaliation, geoDragScrollInvert,
-	allowBuildingQueue, showFundsOnGeoscape, psiStrengthEval, fieldPromotions;
+	allowBuildingQueue, showFundsOnGeoscape, psiStrengthEval, allowPsiStrengthImprovement, fieldPromotions;
 OPT SDLKey keyGeoLeft, keyGeoRight, keyGeoUp, keyGeoDown, keyGeoZoomIn, keyGeoZoomOut, keyGeoSpeed1, keyGeoSpeed2, keyGeoSpeed3, keyGeoSpeed4, keyGeoSpeed5, keyGeoSpeed6,
 	keyGeoIntercept, keyGeoBases, keyGeoGraphs, keyGeoUfopedia, keyGeoOptions, keyGeoFunding, keyGeoToggleDetail, keyGeoToggleRadar,
 	keyBaseSelect1, keyBaseSelect2, keyBaseSelect3, keyBaseSelect4, keyBaseSelect5, keyBaseSelect6, keyBaseSelect7, keyBaseSelect8;

--- a/src/Geoscape/AllocatePsiTrainingState.cpp
+++ b/src/Geoscape/AllocatePsiTrainingState.cpp
@@ -119,6 +119,7 @@ AllocatePsiTrainingState::AllocatePsiTrainingState(Game *game, Base *base) : Sta
 		if ((*s)->getCurrentStats()->psiSkill > 0 || (Options::psiStrengthEval && _game->getSavedGame()->isResearched(_game->getRuleset()->getPsiRequirements())))
 		{
 			ssStr << L"   " << (*s)->getCurrentStats()->psiStrength;
+			if (Options::allowPsiStrengthImprovement) ssStr << "/+" << (*s)->getPsiStrImprovement();
 		}
 		else
 		{

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -51,7 +51,7 @@ BattleUnit::BattleUnit(Soldier *soldier, UnitFaction faction) : _faction(faction
 																_lastPos(Position()), _direction(0), _toDirection(0), _directionTurret(0), _toDirectionTurret(0),
 																_verticalDirection(0), _status(STATUS_STANDING), _walkPhase(0), _fallPhase(0), _kneeled(false), _floating(false),
 																_dontReselect(false), _fire(0), _currentAIState(0), _visible(false), _cacheInvalid(true),
-																_expBravery(0), _expReactions(0), _expFiring(0), _expThrowing(0), _expPsiSkill(0), _expMelee(0),
+																_expBravery(0), _expReactions(0), _expFiring(0), _expThrowing(0), _expPsiSkill(0), _expPsiStrength(0), _expMelee(0),
 																_motionPoints(0), _kills(0), _hitByFire(false), _moraleRestored(0), _coverReserve(0), _charging(0),
 																_turnsSinceSpotted(255), _geoscapeSoldier(soldier), _unitRules(0), _rankInt(-1), _turretType(-1), _hidingForTurn(false)
 {
@@ -121,7 +121,7 @@ BattleUnit::BattleUnit(Unit *unit, UnitFaction faction, int id, Armor *armor, in
 																						_toDirectionTurret(0),  _verticalDirection(0), _status(STATUS_STANDING), _walkPhase(0),
 																						_fallPhase(0), _kneeled(false), _floating(false), _dontReselect(false), _fire(0), _currentAIState(0),
 																						_visible(false), _cacheInvalid(true), _expBravery(0), _expReactions(0), _expFiring(0),
-																						_expThrowing(0), _expPsiSkill(0), _expMelee(0), _motionPoints(0), _kills(0), _hitByFire(false),
+																						_expThrowing(0), _expPsiSkill(0), _expPsiStrength(0), _expMelee(0), _motionPoints(0), _kills(0), _hitByFire(false),
 																						_moraleRestored(0), _coverReserve(0), _charging(0), _turnsSinceSpotted(255),
 																						_armor(armor), _geoscapeSoldier(0),  _unitRules(unit), _rankInt(-1),
 																						_turretType(-1), _hidingForTurn(false)
@@ -211,6 +211,7 @@ void BattleUnit::load(const YAML::Node &node)
 	_expFiring = node["expFiring"].as<int>(_expFiring);
 	_expThrowing = node["expThrowing"].as<int>(_expThrowing);
 	_expPsiSkill = node["expPsiSkill"].as<int>(_expPsiSkill);
+	_expPsiStrength = node["expPsiStrength"].as<int>(_expPsiStrength);
 	_expMelee = node["expMelee"].as<int>(_expMelee);
 	_turretType = node["turretType"].as<int>(_turretType);
 	_visible = node["visible"].as<bool>(_visible);
@@ -261,6 +262,7 @@ YAML::Node BattleUnit::save() const
 	node["expFiring"] = _expFiring;
 	node["expThrowing"] = _expThrowing;
 	node["expPsiSkill"] = _expPsiSkill;
+	node["expPsiStrength"] = _expPsiStrength;
 	node["expMelee"] = _expMelee;
 	node["turretType"] = _turretType;
 	node["visible"] = _visible;
@@ -1864,7 +1866,7 @@ void BattleUnit::addFiringExp()
 }
 
 /**
- * Adds one to the firing exp counter.
+ * Adds one to the throwing exp counter.
  */
 void BattleUnit::addThrowingExp()
 {
@@ -1872,15 +1874,23 @@ void BattleUnit::addThrowingExp()
 }
 
 /**
- * Adds one to the firing exp counter.
+ * Adds one to the psi skill exp counter.
  */
-void BattleUnit::addPsiExp()
+void BattleUnit::addPsiSkillExp()
 {
 	_expPsiSkill++;
 }
 
 /**
- * Adds one to the firing exp counter.
+ * Adds one to the psi strength exp counter.
+ */
+void BattleUnit::addPsiStrengthExp()
+{
+	_expPsiStrength++;
+}
+
+/**
+ * Adds one to the melee exp counter.
  */
 void BattleUnit::addMeleeExp()
 {
@@ -1939,8 +1949,12 @@ bool BattleUnit::postMissionProcedures(SavedGame *geoscape)
 	{
 		stats->psiSkill += improveStat(_expPsiSkill);
 	}
+	if (_expPsiStrength && stats->psiStrength < caps.psiStrength)
+	{
+		stats->psiStrength += improveStat(_expPsiStrength);
+	}
 
-	if (_expBravery || _expReactions || _expFiring || _expPsiSkill || _expMelee)
+	if (_expBravery || _expReactions || _expFiring || _expPsiSkill || _expPsiStrength || _expMelee)
 	{
 		if (s->getRank() == RANK_ROOKIE)
 			s->promoteRank();

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -82,7 +82,7 @@ private:
 	bool _visible;
 	Surface *_cache[5];
 	bool _cacheInvalid;
-	int _expBravery, _expReactions, _expFiring, _expThrowing, _expPsiSkill, _expMelee;
+	int _expBravery, _expReactions, _expFiring, _expThrowing, _expPsiSkill, _expPsiStrength, _expMelee;
 	int improveStat(int exp);
 	int _motionPoints;
 	int _kills;
@@ -293,8 +293,10 @@ public:
 	void addFiringExp();
 	/// Adds one to the throwing exp counter.
 	void addThrowingExp();
-	/// Adds one to the psi exp counter.
-	void addPsiExp();
+	/// Adds one to the psi skill exp counter.
+	void addPsiSkillExp();
+	/// Adds one to the psi strength exp counter.
+	void addPsiStrengthExp();
 	/// Adds one to the melee exp counter.
 	void addMeleeExp();
 	/// Updates the stats of a Geoscape soldier.

--- a/src/Savegame/Soldier.h
+++ b/src/Savegame/Soldier.h
@@ -50,7 +50,7 @@ class Soldier
 {
 private:
 	std::wstring _name;
-	int _id, _improvement;
+	int _id, _improvement, _psiStrImprovement;
 	RuleSoldier *_rules;
 	UnitStats _initialStats, _currentStats;
 	SoldierRank _rank;
@@ -132,8 +132,10 @@ public:
 	bool isInPsiTraining();
 	/// set the psi training status
 	void setPsiTraining();
-	/// returns this soldier's psionic improvement score for this month.
+	/// returns this soldier's psionic skill improvement score for this month.
 	int getImprovement();
+	/// returns this soldier's psionic strength improvement score for this month.
+	int getPsiStrImprovement();
 	/// Gets the soldier death info.
 	SoldierDeath *getDeath() const;
 	/// Kills the soldier.


### PR DESCRIPTION
Default: OFF
Psionic strength of the soldiers can be improved by experience and training.
