### PR TITLE
Direct medics to the wounded body part

### DIFF
--- a/src/Battlescape/MedikitState.cpp
+++ b/src/Battlescape/MedikitState.cpp
@@ -219,6 +219,7 @@ void MedikitState::onHealClick(Action *)
 	{
 		_targetUnit->heal(_medikitView->getSelectedPart(), rule->getWoundRecovery(), rule->getHealthRecovery());
 		_item->setHealQuantity(--heal);
+		_medikitView->updateSelectedPart();
 		_medikitView->invalidate();
 		update();
 

--- a/src/Battlescape/MedikitView.cpp
+++ b/src/Battlescape/MedikitView.cpp
@@ -55,6 +55,7 @@ const std::string PARTS_STRING[6] =
  */
 MedikitView::MedikitView (int w, int h, int x, int y, Game * game, BattleUnit *unit, Text *partTxt, Text *woundTxt) : InteractiveSurface(w, h, x, y), _game(game), _selectedPart(0), _unit(unit), _partTxt(partTxt), _woundTxt(woundTxt)
 {
+	updateSelectedPart();
 	_redraw = true;
 }
 
@@ -118,5 +119,22 @@ void MedikitView::mouseClick (Action *action, State *)
 int MedikitView::getSelectedPart() const
 {
 	return _selectedPart;
+}
+
+/**
+ * Updates the selected body part.
+ * If there is a wounded body part, selects that.
+ * Otherwise does not change the selected part.
+ */
+void MedikitView::updateSelectedPart()
+{
+	for (int i = 0; i < 6; ++i)
+	{
+		if (_unit->getFatalWound(i))
+		{
+			_selectedPart = i;
+			break;
+		}
+	}
 }
 }

--- a/src/Battlescape/MedikitView.h
+++ b/src/Battlescape/MedikitView.h
@@ -45,6 +45,8 @@ public:
 	void draw();
 	/// Gets the selected body part.
 	int getSelectedPart() const;
+	/// Updates the seleted body part.
+	void updateSelectedPart();
 };
 }
 


### PR DESCRIPTION
The heal action recovers fatal wounds so is only useful when fatal wounds are selected.  Unfortunately the game does not track which part the player is looking at when heal is clicked.  I know this because I have tried this many times.  It's possibly because I see the body part coloured in red and think "that's the body part I'm about to heal", click heal, then more correctly think "nope I'm healing the head yet again, that's why it says head right there, I should have clicked that leg".

Instead of tracking player's eye movements, I propose the medikit view, instead of always opening with the head selected,  preselects any fatal wound.  This saves the player one mouse click and spares any embarrassment due to a useless heal action.  Additionally, on clicking heal, any fatal wound is selected next, again saving the player from having to click on the next fatal wound.
