### PR TITLE
Fixes walk aborting prematurely

### DIFF
--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -315,9 +315,9 @@ bool TileEngine::calculateFOV(BattleUnit *unit)
 									if (tst>127) --tsize; //last tile is blocked thus must be cropped
 									for (unsigned int i = 0; i < tsize; i++)
 									{
-										Position posi = _trajectory.at(i); 
+										Position posi = _trajectory.at(i);
 										//mark every tile of line as visible (as in original)
-										//this is needed because of bresenham narrow stroke. 
+										//this is needed because of bresenham narrow stroke.
 										_save->getTile(posi)->setVisible(+1);
 										_save->getTile(posi)->setDiscovered(true, 2);
 										// walls to the east or south of a visible tile, we see that too
@@ -1586,7 +1586,7 @@ int TileEngine::horizontalBlockage(Tile *startTile, Tile *endTile, ItemDamageTyp
 	}
 	else
 	{
-        if ( block <= 127 ) 
+        if ( block <= 127 )
         {
             direction += 4;
             if (direction > 7)
@@ -1740,12 +1740,13 @@ int TileEngine::unitOpensDoor(BattleUnit *unit, bool rClick, int dir)
 	{
 		dir = unit->getDirection();
 	}
+	Tile *tile;
 	for (int x = 0; x < size && door == -1; x++)
 	{
 		for (int y = 0; y < size && door == -1; y++)
 		{
 			std::vector<std::pair<Position, int> > checkPositions;
-			Tile *tile = _save->getTile(unit->getPosition() + Position(x,y,z));
+			tile = _save->getTile(unit->getPosition() + Position(x,y,z));
 			if (!tile) continue;
 
 			switch (dir)
@@ -1833,6 +1834,7 @@ int TileEngine::unitOpensDoor(BattleUnit *unit, bool rClick, int dir)
 		{
 			if (unit->spendTimeUnits(TUCost))
 			{
+				tile->animate();	// ensures frame advances for ufo doors to update TU cost
 				calculateFOV(unit->getPosition());
 				// look from the other side (may be need check reaction fire?)
 				std::vector<BattleUnit*> *vunits = unit->getVisibleUnits();
@@ -2108,7 +2110,7 @@ int TileEngine::calculateParabola(const Position& origin, const Position& target
 	int z = origin.z;
 	int i = 8;
 	Position lastPosition = Position(x,y,z);
-	while (z > 0) 
+	while (z > 0)
 	{
 		x = (int)((double)origin.x + (double)i * cos(te) * sin(fi));
 		y = (int)((double)origin.y + (double)i * sin(te) * sin(fi));
@@ -2685,7 +2687,7 @@ int TileEngine::getDirectionTo(const Position &origin, const Position &target) c
 
 Position TileEngine::getOriginVoxel(BattleAction &action, Tile *tile)
 {
-	
+
 	const int dirYshift[24] = {1, 3, 9, 15, 15, 13, 7, 1,  1, 1, 7, 13, 15, 15, 9, 3,  1, 2, 8, 14, 15, 14, 8, 2};
 	const int dirXshift[24] = {9, 15, 15, 13, 8, 1, 1, 3,  7, 13, 15, 15, 9, 3, 1, 1,  8, 14, 15, 14, 8, 2, 1, 2};
 	if (!tile)
@@ -2704,7 +2706,7 @@ Position TileEngine::getOriginVoxel(BattleAction &action, Tile *tile)
 		originVoxel.z += -tile->getTerrainLevel();
 
 		originVoxel.z += action.actor->getHeight() + action.actor->getFloatHeight();
-		
+
 		if (action.type == BA_THROW)
 		{
 			originVoxel.z -= 3;

--- a/src/Savegame/Tile.cpp
+++ b/src/Savegame/Tile.cpp
@@ -33,7 +33,7 @@ namespace OpenXcom
 {
 
 /// How many bytes various fields use in a serialized tile. See header.
-Tile::SerializationKey Tile::serializationKey = 
+Tile::SerializationKey Tile::serializationKey =
 {4, // index
  2, // _mapDataSetID, four of these
  2, // _mapDataID, four of these
@@ -222,16 +222,16 @@ bool Tile::isVoid() const
 }
 
 /**
- * Get the TU cost to walk over a certain part of the tile.
- * @param part
- * @param movementType
- * @return TU cost
+ * Gets the TU cost to walk over a certain part of the tile.
+ * @param part The part number.
+ * @param movementType The movement type.
+ * @return TU cost.
  */
 int Tile::getTUCost(int part, MovementType movementType) const
 {
 	if (_objects[part])
 	{
-		if (_objects[part]->isUFODoor() && _currentFrame[part] == 7)
+		if (_objects[part]->isUFODoor() && _currentFrame[part] > 1)
 			return 0;
 		if (_objects[part]->getBigWall() >= 4)
 			return 0;


### PR DESCRIPTION
when we still have enough TUs but destination is tile after closed ufo
door.

Ashura checks she has enough tu get through a door
![screen000](https://f.cloud.github.com/assets/1824834/1844482/70db63f0-752d-11e3-9225-cfab365f7396.png)

... she confidently proceeds
![screen001](https://f.cloud.github.com/assets/1824834/1844486/847ff51a-752d-11e3-80c9-5f30dae6b12a.png)

... "What the!?", says our confused hero.
![screen002](https://f.cloud.github.com/assets/1824834/1844487/a1b2f6b4-752d-11e3-99ec-1ebb5eba7285.png)

The solution I propose fixes this by charging the tu cost for door opening up to the first frame of animation, thereafter the door is effectively open so it's no charge.  This does fix the problem, but mysteriously only part of the time.  For consistency I had to ensure the animation advanced so that the fix worked all of the time.
