### PR TITLE
Require the correct Yaml version for CMake as well.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if ( IS_DIRECTORY ${DEPS_DIR} )
    set ( YAMLCPP_LIBRARY yaml-cpp )
 else ( )
   find_package ( SDL2 COMPONENTS mixer gfx image)
-  find_package ( Yaml_cpp )
+  find_package ( Yaml_cpp 0.5.0)
   find_package ( OpenGL )
 
   if ( NOT OPENGL_FOUND )


### PR DESCRIPTION
The autotools configure script will complain if it can only find a 0.3.0 API version of yaml-cpp when the new 0.5.0 one is required. The CMake project however is happy, but the project then fails to compile.
