### PR TITLE
More freedom for translators: Possibility to change the "Craftname-number" scheme.

### DIFF
--- a/bin/data/Language/en-GB.yml
+++ b/bin/data/Language/en-GB.yml
@@ -241,6 +241,7 @@ en-GB:
   STR_SELL_SACK: "Sell/Sack"
   STR_VALUE: "Value"
   STR_CRAFT_: "CRAFT> {ALT}{0}"
+  STR_CRAFTNAME: "{0}-{1}"
   STR_UFO_CRASH_RECOVERY: "UFO CRASH RECOVERY"
   STR_UFO_CRASH_RECOVERY_BRIEFING: "Exercise caution - There may be operatives in the UFO or around the crash site. Mission will be successful when all enemy units have been eliminated or neutralised. Recovery of UFO remains, artefacts and alien corpses can then be initiated. To abort the mission return XCom operatives to transport vehicle and click on the 'Abort Mission' icon."
   STR_UFO_GROUND_ASSAULT: "UFO GROUND ASSAULT"

--- a/bin/data/Language/en-US.yml
+++ b/bin/data/Language/en-US.yml
@@ -241,6 +241,7 @@ en-US:
   STR_SELL_SACK: "Sell/Sack"
   STR_VALUE: "Value"
   STR_CRAFT_: "CRAFT> {ALT}{0}"
+  STR_CRAFTNAME: "{0}-{1}"
   STR_UFO_CRASH_RECOVERY: "UFO CRASH RECOVERY"
   STR_UFO_CRASH_RECOVERY_BRIEFING: "Exercise caution - There may be operatives in the UFO or around the crash site.  Mission will be successful when all enemy units have been eliminated or neutralized.  Recovery of UFO remains, artifacts and alien corpses can then be initiated.  To abort the mission return XCom operatives to transport vehicle and click on the 'Abort Mission' icon."
   STR_UFO_GROUND_ASSAULT: "UFO GROUND ASSAULT"

--- a/src/Savegame/Craft.cpp
+++ b/src/Savegame/Craft.cpp
@@ -282,12 +282,7 @@ int Craft::getId() const
  */
 std::wstring Craft::getName(Language *lang) const
 {
-	if (_name.empty())
-	{
-		std::wostringstream name;
-		name << lang->getString(_rules->getType()) << "-" << _id;
-		return name.str();
-	}
+	if (_name.empty()) return lang->getString("STR_CRAFTNAME").arg(lang->getString(_rules->getType())).arg(_id);
 	return _name;
 }
 


### PR DESCRIPTION
With this, we can make for example: "number. Craftname" scheme, ex: "1. Interceptor"
Since more languages use "1. UFO" instead of "UFO-1", and this PR makes this thing complete.
So i think this is essential.
(i think we can include it in ver 1.0, not so much code is modified... -and i tested it, it works perfect)
