### PR TITLE
Don't warp crafts when they travel over the poles

### DIFF
--- a/src/Savegame/Target.cpp
+++ b/src/Savegame/Target.cpp
@@ -121,15 +121,15 @@ double Target::getLatitude() const
 void Target::setLatitude(double lat)
 {
 	_lat = lat;
-	// Keep between -PI/2 and PI/2
+	// If you travel past a pole, continue on the other side of the globe.
 	if (_lat < -M_PI/2)
 	{
-		_lat = M_PI - _lat;
+		_lat = -M_PI - _lat;
 		setLongitude(_lon + M_PI);
 	}
 	else if (_lat > M_PI/2)
 	{
-		_lat = -M_PI + _lat;
+		_lat = M_PI - _lat;
 		setLongitude(_lon - M_PI);
 	}
 }


### PR DESCRIPTION
I've tested both the north and south poles, and I'm not warping to the other pole (I've tossed in debug logs to make sure I passed over the pole).

Fixes [this](http://openxcom.org/bugs/openxcom/issues/331) issue.
