### PR TITLE
Fix filght path bug

### DIFF
--- a/src/Geoscape/Cord.h
+++ b/src/Geoscape/Cord.h
@@ -20,15 +20,38 @@
 #define	OPENXCOM_CORD_H
 
 #include <cmath>
+#include "../aresame.h"
 
 namespace OpenXcom
 {
-	
-	
+struct Cord;
+
+struct CordPolar
+{
+	double lon, lat;
+
+	inline CordPolar(double plon, double plat)
+	{
+		lon = plon;
+		lat = plat;
+	}
+	inline CordPolar(const CordPolar& pol)
+	{
+		lon = pol.lon;
+		lat = pol.lat;
+	}
+	inline CordPolar()
+	{
+		lon = 0;
+		lat = 0;
+	}
+	explicit inline CordPolar(const Cord&);
+};
+
 struct Cord
 {
 	double x, y, z;
-	
+
 	inline Cord(double px, double py, double pz)
 	{
 		x = px;
@@ -47,7 +70,16 @@ struct Cord
 		y = 0.0;
 		z = 0.0;
 	}
-	
+	explicit inline Cord(const CordPolar&);
+
+	inline Cord operator +()
+	{
+		return *this;
+	}
+	inline Cord operator -()
+	{
+		return Cord(-x, -y, -z);
+	}
 	inline Cord& operator *=(double d)
 	{
 		x *= d;
@@ -77,11 +109,30 @@ struct Cord
 		z -= c.z;
 		return *this;
 	}
+	inline bool operator ==(const Cord& c)
+	{
+		return AreSame(x, c.x) && AreSame(y, c.y) && AreSame(z, c.z);
+	}
+
 	inline double norm() const
 	{
-		return std::sqrt(x*x+ y*y + z*z);
+		return std::sqrt(x*x + y*y + z*z);
 	}
 };
+
+inline Cord::Cord(const CordPolar& pol)
+{
+	x = std::sin(pol.lon) * std::cos(pol.lat);
+	y = std::sin(pol.lat);
+	z = std::cos(pol.lon) * std::cos(pol.lat);
+}
+
+inline CordPolar::CordPolar(const Cord& c)
+{
+	double inv = 1/c.norm();
+	lat = asin(c.y * inv);
+	lon = atan2(c.x, c.z);
+}
 
 }//namespace OpenXcom
 #endif	/* OPENXCOM_CORD_H */


### PR DESCRIPTION
Path dont get lost near pole.
Line isnt draw anymore outside globe.

To determine path I used line in 3d between two points on globe sphere. Next I split it to smaller part depending on its length (longer path have more parts). Every part is then projected back to sphere surface and draw on globe (some time line could cross centre of sphere, `a == -b` prevent that).
