### PR TITLE
fix for bug 490: ensure intro movie is centered on linux

### DIFF
--- a/src/Engine/Flc.cpp
+++ b/src/Engine/Flc.cpp
@@ -507,22 +507,15 @@ void FlcMain(void (*frameCallBack)())
 { flc.quit=false;
   SDL_Event event;
   
-//#ifndef __NO_FLC
   FlcInitFirstFrame();
-#ifdef _WIN32
   flc.offset = flc.dy * flc.mainscreen->pitch + flc.mainscreen->format->BytesPerPixel * flc.dx;
-#else
-  SDL_Rect dstRect = {(Sint16)flc.dx, (Sint16)flc.dy, (Uint16)flc.screen_w, (Uint16)flc.screen_h};
-  flc.offset = 0;
-#endif
   while(!flc.quit) {
 	if (frameCallBack) (*frameCallBack)();
     flc.FrameCount++;
     if(FlcCheckFrame()) {
       if (flc.FrameCount<=flc.HeaderFrames) {
-        //printf("Frame failure -- corrupt file?\n");
         Log(LOG_ERROR) << "Frame failure -- corrupt file?";
-				return;
+	return;
       } else {
         if(flc.loop)
           FlcInitFirstFrame();
@@ -542,13 +535,7 @@ void FlcMain(void (*frameCallBack)())
       /* TODO: Track which rectangles have really changed */
       //SDL_UpdateRect(flc.mainscreen, 0, 0, 0, 0);
       if (flc.mainscreen != flc.realscreen->getSurface()->getSurface())
-        SDL_BlitSurface(flc.mainscreen, 0, flc.realscreen->getSurface()->getSurface(),
-#ifdef _WIN32
-                        0
-#else
-                        &dstRect
-#endif
-                       );
+        SDL_BlitSurface(flc.mainscreen, 0, flc.realscreen->getSurface()->getSurface(), 0);
       flc.realscreen->flip();
     }
 


### PR DESCRIPTION
revert atlimit8's commit from feef4e844a1d4cc0ba6d38049ada58ac539bf4a9
I attempted to reach him/her about the reasoning for this commit but did
not get a reply.

tested on Gentoo Linux with sdl-1.2.15, sdl-gfx-2.0.24 with:
  displayWidth:    1920
  displayHeight:   1200
  baseXResolution: 640
  baseYResolution: 400

see:
https://github.com/SupSuper/OpenXcom/commit/feef4e844a1d4cc0ba6d38049ada58ac539bf4a9
https://github.com/SupSuper/OpenXcom/pull/678
https://github.com/SupSuper/OpenXcom/pull/675
http://openxcom.org/bugs/openxcom/issues/294
http://openxcom.org/bugs/openxcom/issues/490
