### PR TITLE
Draw Bases names in detailed zoom.

### DIFF
--- a/src/Geoscape/Globe.cpp
+++ b/src/Geoscape/Globe.cpp
@@ -1387,7 +1387,7 @@ void Globe::drawDetail()
 		delete label;
 	}
 
-	// Draw the city markers
+	// Draw the city and base markers
 	if (_zoom >= 3)
 	{
 		Text *label = new Text(80, 9, 0, 0);
@@ -1418,6 +1418,18 @@ void Globe::drawDetail()
 				label->setText(_game->getLanguage()->getString((*j)->getName()));
 				label->blit(_countries);
 			}
+		}
+		// Draw bases names
+		for (std::vector<Base*>::iterator j = _game->getSavedGame()->getBases()->begin(); j != _game->getSavedGame()->getBases()->end(); ++j)
+		{
+			if (pointBack((*j)->getLongitude(), (*j)->getLatitude()))
+				continue;
+			polarToCart((*j)->getLongitude(), (*j)->getLatitude(), &x, &y);
+			label->setX(x - 40);
+			label->setY(y + 2);
+			label->setColor(Palette::blockOffset(8)+5);
+			label->setText((*j)->getName());
+			label->blit(_countries);
 		}
 
 		delete label;


### PR DESCRIPTION
This commit makes show names of bases in Global view. It can be disabled via "Show funding countries" option.
