### PR TITLE
Fix kneel reserve button being used while moving MC'd alien

### DIFF
--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -972,14 +972,14 @@ bool BattlescapeGame::checkReservedTU(BattleUnit *bu, int tu, bool justChecking)
 	{
 		effectiveTuReserved = BA_AIMEDSHOT;
 	}
-	const int tuKneel = _kneelReserved ? 4 : 0;
-	if ((effectiveTuReserved != BA_NONE || _kneelReserved) &&
+	const int tuKneel = getKneelReserved() ? 4 : 0;
+	if ((effectiveTuReserved != BA_NONE || getKneelReserved()) &&
 		tu + tuKneel + bu->getActionTUs(effectiveTuReserved, slowestWeapon) > bu->getTimeUnits() &&
 		(tuKneel + bu->getActionTUs(effectiveTuReserved, slowestWeapon) <= bu->getTimeUnits() || justChecking))
 	{
 		if (!justChecking)
 		{
-			if (_kneelReserved)
+			if (getKneelReserved())
 			{
 				switch (effectiveTuReserved)
 				{
@@ -1292,7 +1292,7 @@ void BattlescapeGame::primaryAction(const Position &pos)
 		{
 			_currentAction.target = pos;
 			getMap()->setCursorType(CT_NONE);
-			
+
 			if (Options::battleConfirmFireMode)
 			{
 				_currentAction.waypoints.clear();
@@ -1989,8 +1989,8 @@ void BattlescapeGame::tallyUnits(int &liveAliens, int &liveSoldiers, bool conver
  */
 void BattlescapeGame::setKneelReserved(bool reserved)
 {
-	_kneelReserved = reserved;
-	_save->setKneelReserved(reserved);
+	_kneelReserved = (_save->getSelectedUnit() && _save->getSelectedUnit()->getGeoscapeSoldier()) ? reserved : false;
+	_save->setKneelReserved(_kneelReserved);
 }
 
 /**


### PR DESCRIPTION
You will need one heroic XCom soldier and a mindcontrolled alien.
Issue 1: 
Click on the soldier and toggle the kneel reserve button to on.  Click on the alien.  Click the kneel reserve button a few times.  Observe it is always in the unreserved position.  So far so good.  Switch back to the soldier.  Now attempt to reserve kneeling.  Observe you need to click the kneel reserve button twice for it to register.

Issue 2:
You will need path preview on for this.
Click on the soldier and toggle the kneel reserve button to on.  Click on the alien.  Preview a sufficiently distant path.  Note how far the alien can travel before our preview turns yellow.
![screen066](https://cloud.githubusercontent.com/assets/1824834/2896608/b2312ba8-d56f-11e3-8ac1-9d00aab69721.png)

 Click on the soldier.  Unreserve kneeling.  Click on alien and preview the same path.  The preview turns yellow one tile later. 
![screen067](https://cloud.githubusercontent.com/assets/1824834/2896612/b9b4aed6-d56f-11e3-9fd4-8f4d4b80e1bb.png)

 Aliens cannot kneel so the preview should be ignoring this.  You can even trigger a " TUs reserved for kneeling and firing" warning.
![screen069](https://cloud.githubusercontent.com/assets/1824834/2896619/dde14a4e-d56f-11e3-8994-72cda723b09d.png)

Fix restores responsiveness to kneel reserve button;  makes alien preview paths ignore the kneel setting; and removes the kneeling element of triggered reserved TU warnings.
