### PR TITLE
Fix window caption disappereance in Linux

### DIFF
--- a/src/Engine/Screen.cpp
+++ b/src/Engine/Screen.cpp
@@ -327,10 +327,14 @@ void Screen::resetDisplay(bool resetVideo)
 		// Workaround for segfault when switching to opengl
 		if (!(oldFlags & SDL_OPENGL) && (_flags & SDL_OPENGL))
 		{
+			Uint8 cursor = 0;
+			char *_oldtitle = 0;
+			SDL_WM_GetCaption(&_oldtitle, NULL);
+			std::string title(_oldtitle);
 			SDL_QuitSubSystem(SDL_INIT_VIDEO);
 			SDL_InitSubSystem(SDL_INIT_VIDEO);
 			SDL_ShowCursor(SDL_ENABLE);
-			Uint8 cursor = 0;
+			SDL_WM_SetCaption(title.c_str(), 0);
 			SDL_SetCursor(SDL_CreateCursor(&cursor, &cursor, 1,1,0,0));
 		}
 #endif


### PR DESCRIPTION
After commit 05bb5efca7 on Linux caption of main window reinitializing
to empty caption after switching from/to OpenGL.
This commit fixes that.
