### PR TITLE
Explicit casts added

### DIFF
--- a/src/Engine/Adlib/fmopl.cpp
+++ b/src/Engine/Adlib/fmopl.cpp
@@ -126,45 +126,45 @@ static const int slot_array[32]=
 static const UINT32 KSL_TABLE[8*16]=
 {
 	/* OCT 0 */
-	 0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
-	 0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
-	 0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
-	 0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV),
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV),
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV),
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV),
 	/* OCT 1 */
-	 0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
-	 0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
-	 0.000/DV, 0.750/DV, 1.125/DV, 1.500/DV,
-	 1.875/DV, 2.250/DV, 2.625/DV, 3.000/DV,
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV),
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV),
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.750/DV), static_cast<UINT32>(1.125/DV), static_cast<UINT32>(1.500/DV),
+	 static_cast<UINT32>(1.875/DV), static_cast<UINT32>(2.250/DV), static_cast<UINT32>(2.625/DV), static_cast<UINT32>(3.000/DV),
 	/* OCT 2 */
-	 0.000/DV, 0.000/DV, 0.000/DV, 0.000/DV,
-	 0.000/DV, 1.125/DV, 1.875/DV, 2.625/DV,
-	 3.000/DV, 3.750/DV, 4.125/DV, 4.500/DV,
-	 4.875/DV, 5.250/DV, 5.625/DV, 6.000/DV,
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV),
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(1.125/DV), static_cast<UINT32>(1.875/DV), static_cast<UINT32>(2.625/DV),
+	 static_cast<UINT32>(3.000/DV), static_cast<UINT32>(3.750/DV), static_cast<UINT32>(4.125/DV), static_cast<UINT32>(4.500/DV),
+	 static_cast<UINT32>(4.875/DV), static_cast<UINT32>(5.250/DV), static_cast<UINT32>(5.625/DV), static_cast<UINT32>(6.000/DV),
 	/* OCT 3 */
-	 0.000/DV, 0.000/DV, 0.000/DV, 1.875/DV,
-	 3.000/DV, 4.125/DV, 4.875/DV, 5.625/DV,
-	 6.000/DV, 6.750/DV, 7.125/DV, 7.500/DV,
-	 7.875/DV, 8.250/DV, 8.625/DV, 9.000/DV,
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(1.875/DV),
+	 static_cast<UINT32>(3.000/DV), static_cast<UINT32>(4.125/DV), static_cast<UINT32>(4.875/DV), static_cast<UINT32>(5.625/DV),
+	 static_cast<UINT32>(6.000/DV), static_cast<UINT32>(6.750/DV), static_cast<UINT32>(7.125/DV), static_cast<UINT32>(7.500/DV),
+	 static_cast<UINT32>(7.875/DV), static_cast<UINT32>(8.250/DV), static_cast<UINT32>(8.625/DV), static_cast<UINT32>(9.000/DV),
 	/* OCT 4 */
-	 0.000/DV, 0.000/DV, 3.000/DV, 4.875/DV,
-	 6.000/DV, 7.125/DV, 7.875/DV, 8.625/DV,
-	 9.000/DV, 9.750/DV,10.125/DV,10.500/DV,
-	10.875/DV,11.250/DV,11.625/DV,12.000/DV,
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(0.000/DV), static_cast<UINT32>(3.000/DV), static_cast<UINT32>(4.875/DV),
+	 static_cast<UINT32>(6.000/DV), static_cast<UINT32>(7.125/DV), static_cast<UINT32>(7.875/DV), static_cast<UINT32>(8.625/DV),
+	 static_cast<UINT32>(9.000/DV), static_cast<UINT32>(9.750/DV),static_cast<UINT32>(10.125/DV),static_cast<UINT32>(10.500/DV),
+	static_cast<UINT32>(10.875/DV),static_cast<UINT32>(11.250/DV),static_cast<UINT32>(11.625/DV),static_cast<UINT32>(12.000/DV),
 	/* OCT 5 */
-	 0.000/DV, 3.000/DV, 6.000/DV, 7.875/DV,
-	 9.000/DV,10.125/DV,10.875/DV,11.625/DV,
-	12.000/DV,12.750/DV,13.125/DV,13.500/DV,
-	13.875/DV,14.250/DV,14.625/DV,15.000/DV,
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(3.000/DV), static_cast<UINT32>(6.000/DV), static_cast<UINT32>(7.875/DV),
+	 static_cast<UINT32>(9.000/DV),static_cast<UINT32>(10.125/DV),static_cast<UINT32>(10.875/DV),static_cast<UINT32>(11.625/DV),
+	static_cast<UINT32>(12.000/DV),static_cast<UINT32>(12.750/DV),static_cast<UINT32>(13.125/DV),static_cast<UINT32>(13.500/DV),
+	static_cast<UINT32>(13.875/DV),static_cast<UINT32>(14.250/DV),static_cast<UINT32>(14.625/DV),static_cast<UINT32>(15.000/DV),
 	/* OCT 6 */
-	 0.000/DV, 6.000/DV, 9.000/DV,10.875/DV,
-	12.000/DV,13.125/DV,13.875/DV,14.625/DV,
-	15.000/DV,15.750/DV,16.125/DV,16.500/DV,
-	16.875/DV,17.250/DV,17.625/DV,18.000/DV,
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(6.000/DV), static_cast<UINT32>(9.000/DV),static_cast<UINT32>(10.875/DV),
+	static_cast<UINT32>(12.000/DV),static_cast<UINT32>(13.125/DV),static_cast<UINT32>(13.875/DV),static_cast<UINT32>(14.625/DV),
+	static_cast<UINT32>(15.000/DV),static_cast<UINT32>(15.750/DV),static_cast<UINT32>(16.125/DV),static_cast<UINT32>(16.500/DV),
+	static_cast<UINT32>(16.875/DV),static_cast<UINT32>(17.250/DV),static_cast<UINT32>(17.625/DV),static_cast<UINT32>(18.000/DV),
 	/* OCT 7 */
-	 0.000/DV, 9.000/DV,12.000/DV,13.875/DV,
-	15.000/DV,16.125/DV,16.875/DV,17.625/DV,
-	18.000/DV,18.750/DV,19.125/DV,19.500/DV,
-	19.875/DV,20.250/DV,20.625/DV,21.000/DV
+	 static_cast<UINT32>(0.000/DV), static_cast<UINT32>(9.000/DV),static_cast<UINT32>(12.000/DV),static_cast<UINT32>(13.875/DV),
+	static_cast<UINT32>(15.000/DV),static_cast<UINT32>(16.125/DV),static_cast<UINT32>(16.875/DV),static_cast<UINT32>(17.625/DV),
+	static_cast<UINT32>(18.000/DV),static_cast<UINT32>(18.750/DV),static_cast<UINT32>(19.125/DV),static_cast<UINT32>(19.500/DV),
+	static_cast<UINT32>(19.875/DV),static_cast<UINT32>(20.250/DV),static_cast<UINT32>(20.625/DV),static_cast<UINT32>(21.000/DV)
 };
 #undef DV
 
@@ -172,8 +172,8 @@ static const UINT32 KSL_TABLE[8*16]=
 /* 0 - 15: 0, 3, 6, 9,12,15,18,21,24,27,30,33,36,39,42,93 (dB)*/
 #define SC(db) (db*((3/EG_STEP)*(1<<ENV_BITS)))+EG_DST
 static const INT32 SL_TABLE[16]={
- SC( 0),SC( 1),SC( 2),SC(3 ),SC(4 ),SC(5 ),SC(6 ),SC( 7),
- SC( 8),SC( 9),SC(10),SC(11),SC(12),SC(13),SC(14),SC(31)
+ static_cast<INT32>(SC( 0)),static_cast<INT32>(SC( 1)),static_cast<INT32>(SC( 2)),static_cast<INT32>(SC(3 )),static_cast<INT32>(SC(4 )),static_cast<INT32>(SC(5 )),static_cast<INT32>(SC(6 )),static_cast<INT32>(SC( 7)),
+ static_cast<INT32>(SC( 8)),static_cast<INT32>(SC( 9)),static_cast<INT32>(SC(10)),static_cast<INT32>(SC(11)),static_cast<INT32>(SC(12)),static_cast<INT32>(SC(13)),static_cast<INT32>(SC(14)),static_cast<INT32>(SC(31))
 };
 #undef SC
 
@@ -198,8 +198,8 @@ static INT32 ENV_CURVE[2*EG_ENT+1];
 #define ML 2
 static const UINT32 MUL_TABLE[16]= {
 /* 1/2, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15 */
-   0.50*ML, 1.00*ML, 2.00*ML, 3.00*ML, 4.00*ML, 5.00*ML, 6.00*ML, 7.00*ML,
-   8.00*ML, 9.00*ML,10.00*ML,10.00*ML,12.00*ML,12.00*ML,15.00*ML,15.00*ML
+   static_cast<UINT32>(0.50*ML), static_cast<UINT32>(1.00*ML), static_cast<UINT32>(2.00*ML), static_cast<UINT32>(3.00*ML), static_cast<UINT32>(4.00*ML), static_cast<UINT32>(5.00*ML), static_cast<UINT32>(6.00*ML), static_cast<UINT32>(7.00*ML),
+   static_cast<UINT32>(8.00*ML), static_cast<UINT32>(9.00*ML),static_cast<UINT32>(10.00*ML),static_cast<UINT32>(10.00*ML),static_cast<UINT32>(12.00*ML),static_cast<UINT32>(12.00*ML),static_cast<UINT32>(15.00*ML),static_cast<UINT32>(15.00*ML)
 };
 #undef ML
 


### PR DESCRIPTION
XCode/LLVM project fails to compile without those - there seems to be
some aggressive standards-conforming code generation requirement.
