### PR TITLE
Make it easy to tell if a unit is kneeling by changing the arrow

### DIFF
--- a/src/Battlescape/Map.h
+++ b/src/Battlescape/Map.h
@@ -52,13 +52,13 @@ private:
 	Game *_game;
 	SavedBattleGame *_save;
 	ResourcePack *_res;
-	Surface *_arrow;
+	Surface *_arrow, *_arrow_kneel;
 	int _spriteWidth, _spriteHeight;
 	int _selectorX, _selectorY;
 	int _mouseX, _mouseY;
 	CursorType _cursorType;
 	int _cursorSize;
-	int _animFrame;
+	int _animFrame, _cursorFrame;
 	Projectile *_projectile;
 	bool _projectileInFOV;
 	std::list<Explosion *> _explosions;


### PR DESCRIPTION
It's hard to tell sometimes if a unit is kneeling or not. This changes the shape of the arrow above their heads if the unit is kneeling. It also creates a more smooth arrow bob
![avsyni6](https://cloud.githubusercontent.com/assets/312503/3174942/a1c00ea4-ebf6-11e3-95d9-909011fe9374.png)
