### PR TITLE
Fix explosiveEfficacy logic error

### DIFF
--- a/src/Battlescape/AlienBAIState.cpp
+++ b/src/Battlescape/AlienBAIState.cpp
@@ -1510,8 +1510,7 @@ bool AlienBAIState::explosiveEfficacy(Position targetPos, BattleUnit *attackingU
 		if (!(*i)->isOut() &&
 			(*i) != attackingUnit &&
 			(*i) != target &&
-			((*i)->getPosition().z >= targetPos.z + Options::battleExplosionHeight ||
-			(*i)->getPosition().z <= targetPos.z - Options::battleExplosionHeight) &&
+			abs((*i)->getPosition().z - targetPos.z) <= Options::battleExplosionHeight &&
 			_save->getTileEngine()->distance((*i)->getPosition(), targetPos) <= radius)
 		{
 			if ((*i)->getFaction() == FACTION_PLAYER && (*i)->getTurnsSinceSpotted() > _intelligence)


### PR DESCRIPTION
There was a logic error that caused the explosiveEfficacy function to not correctly check whom the explosion would affect. This lead to grenades nearly not being thrown by the AI even if it would kill up to 9 people without any casualties on it own side. I would also cause the AI to throw grenades where it would only kill themselves.
