### PR TITLE
Show 'Damage' text-header on ammo and grenades in Ufopaedia.

### DIFF
--- a/src/Ufopaedia/ArticleStateItem.cpp
+++ b/src/Ufopaedia/ArticleStateItem.cpp
@@ -237,6 +237,12 @@ namespace OpenXcom
 			case BT_GRENADE:
 			case BT_PROXIMITYGRENADE:
 			case BT_MELEE:
+				_txtDamage = new Text(82, 10, 194, 7);
+				add(_txtDamage);
+				_txtDamage->setColor(Palette::blockOffset(14)+15);
+				_txtDamage->setAlign(ALIGN_CENTER);
+				_txtDamage->setText(tr("STR_DAMAGE_UC"));
+
 				_txtAmmoType[0]->setText(tr(getDamageTypeText(item->getDamageType())));
 
 				ss.str(L"");ss.clear();


### PR DESCRIPTION
Please merge this before 1.0
http://kepfeltoltes.hu/140607/UfoPediaDamage_www.kepfeltoltes.hu_.png
