### PR TITLE
Workaround for russian letter "Ё"/"ё" (unicode U+0401/U+0451) garbling u...

### DIFF
--- a/src/Interface/TextEdit.cpp
+++ b/src/Interface/TextEdit.cpp
@@ -487,6 +487,9 @@ void TextEdit::keyboardPress(Action *action, State *state)
 				(!_numerical && ((key >= L' ' && key <= L'~') || key >= 160))) &&
 				!exceedsMaxWidth((wchar_t)key))
 			{
+				// Workaround for that one cyrillic letter
+				if (key == 0x0451) { action->getDetails()->key.keysym.unicode = 0x00EB; }
+				if (key == 0x0401) { action->getDetails()->key.keysym.unicode = 0x00CB; }
 				_value.insert(_caretPos, 1, (wchar_t)action->getDetails()->key.keysym.unicode);
 				_caretPos++;
 			}


### PR DESCRIPTION
...p TextEdit.

(We just substitute them with Latin U+00CB/U+00EB which look exactly the same but are actually present in the font)
