### PR TITLE
Ok, Aliens_Pick_Up_Weapons suggestions:

### DIFF
--- a/bin/data/Ruleset/Aliens_Pick_Up_Weapons.rul
+++ b/bin/data/Ruleset/Aliens_Pick_Up_Weapons.rul
@@ -3,24 +3,24 @@ items:
   - type: STR_HEAVY_PLASMA
     attraction: 10
   - type: STR_HEAVY_PLASMA_CLIP
-    attraction: 10
+    attraction: 9
   - type: STR_PLASMA_RIFLE
     attraction: 10
   - type: STR_PLASMA_RIFLE_CLIP
-    attraction: 10
+    attraction: 9
   - type: STR_PLASMA_PISTOL
     attraction: 10
   - type: STR_PLASMA_PISTOL_CLIP
-    attraction: 10
+    attraction: 9
   - type: STR_BLASTER_LAUNCHER
-    attraction: 10
+    attraction: 12
   - type: STR_BLASTER_BOMB
-    attraction: 10
+    attraction: 9
   - type: STR_SMALL_LAUNCHER
     attraction: 10
   - type: STR_STUN_BOMB
-    attraction: 10
+    attraction: 9
   - type: STR_MIND_PROBE
-    attraction: 10
+    attraction: 6
   - type: STR_ALIEN_GRENADE
     attraction: 6 # pick up grenades they're standing on, but don't chase after ones they throw


### PR DESCRIPTION
- Mind Probe shouldn't be chased too, because technically it is not a weapon
- Clips should be chased less than the weapons themselves, so the true weapons should be the main target. (assuming they are loaded in most cases)
- Blaster Launcher should have a higher attraction (12), since that is a superior weapon after all.
