### PR TITLE
Fixed: DragScrolling the Globe and using the MouseWheel to Zoom in/out at the same time caused flickering.

### DIFF
--- a/src/Geoscape/Globe.cpp
+++ b/src/Geoscape/Globe.cpp
@@ -677,6 +677,12 @@ void Globe::setZoom(size_t zoom)
 	_zoom = std::min(std::max(zoom, (size_t)0u), _zoomRadius.size() - 1);
 	_radius = _zoomRadius[_zoom];
 	_game->getSavedGame()->setGlobeZoom(_zoom);
+	if (_isMouseScrolling)
+	{
+		_lonBeforeMouseScrolling = _cenLon;
+		_latBeforeMouseScrolling = _cenLat;
+		_totalMouseMoveX = 0; _totalMouseMoveY = 0;
+	}
 	invalidate();
 }
 


### PR DESCRIPTION
Please Merge this before 1.0 !!
