### PR TITLE
Fix data install dir in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -657,8 +657,8 @@ dist-hook:
 	fi
 
 install-data-local:
-	@mkdir -p $(DESTDIR)$(pkgdatadir); \
-	cp -r $(top_srcdir)/bin/data/* $(DESTDIR)$(pkgdatadir)/ ; \
+	@mkdir -p $(DESTDIR)$(pkgdatadir)/data; \
+	cp -r $(top_srcdir)/bin/data/* $(DESTDIR)$(pkgdatadir)/data/ ; \
 	find $(DESTDIR)$(pkgdatadir) | xargs chmod a=rX,u+w
 
 # NOTE: this might wipe user unpacked xcom if it is in the dir, as there


### PR DESCRIPTION
It previously installed data into "openxcom/" while the program looks for data in "openxcom/data".
