### PR TITLE
initialize Screen::_flags (avoid UMR)

### DIFF
--- a/src/Engine/Screen.cpp
+++ b/src/Engine/Screen.cpp
@@ -107,7 +107,7 @@ void Screen::makeVideoFlags()
  * Initializes a new display screen for the game to render contents to.
  * The screen is set up based on the current options.
  */
-Screen::Screen() : _baseWidth(ORIGINAL_WIDTH), _baseHeight(ORIGINAL_HEIGHT), _scaleX(1.0), _scaleY(1.0), _numColors(0), _firstColor(0), _pushPalette(false), _surface(0)
+Screen::Screen() : _baseWidth(ORIGINAL_WIDTH), _baseHeight(ORIGINAL_HEIGHT), _scaleX(1.0), _scaleY(1.0), _flags(0), _numColors(0), _firstColor(0), _pushPalette(false), _surface(0)
 {
 	resetDisplay();	
 	memset(deferredPalette, 0, 256*sizeof(SDL_Color));


### PR DESCRIPTION
_flags is initialized in makeVideoFlags, which gets called from resetDisplay, but resetDisplay first remembers (uninitialized) _flags as oldFlags and uses it.
