### PR TITLE
stop aiming after melee attack

### DIFF
--- a/src/Battlescape/ProjectileFlyBState.cpp
+++ b/src/Battlescape/ProjectileFlyBState.cpp
@@ -718,5 +718,6 @@ void ProjectileFlyBState::performMeleeAttack()
 	}
 	_parent->getMap()->setCursorType(CT_NONE);
 	_parent->statePushNext(new ExplosionBState(_parent, voxel, _action.weapon, _action.actor));
+	_unit->aim(false);
 }
 }


### PR DESCRIPTION
During a melee attack, the unit set set to be aiming.  After the attack, the aiming status is not undone.  When UnitWalkBState::think is later called, it does not handle the aiming status and the turn never finishes.  This is clearly not always a problem; in many cases, something else apparently sets status.
