### PR TITLE
Don't alter the "Days/Hours Left" display when selling items

### DIFF
--- a/src/Basescape/ManufactureState.cpp
+++ b/src/Basescape/ManufactureState.cpp
@@ -201,7 +201,11 @@ void ManufactureState::fillProductionList()
 		std::wostringstream s3;
 		s3 << Text::formatFunding((*iter)->getRules()->getManufactureCost());
 		std::wostringstream s4;
-		if ((*iter)->getAssignedEngineers() > 0)
+		if ((*iter)->getInfiniteAmount())
+		{
+			s4 << Language::utf8ToWstr("∞");
+		}
+		else if ((*iter)->getAssignedEngineers() > 0)
 		{
 			int timeLeft = (*iter)->getAmountTotal() * (*iter)->getRules()->getManufactureTime() - (*iter)->getTimeSpent();
 			timeLeft /= (*iter)->getAssignedEngineers();


### PR DESCRIPTION
The numbers displayed for "Days/Hours Left" are different when selling manufacturing items.  From looking at older versions, it looks like this was used when selling was triggered by setting the # manufactured to infinity (days left would then also be infinity).  The display doesn't really make any sense to me (ahead/behind schedule?), especially now that you can sell items without setting the # produced to be infinity.
