### PR TITLE
If making infinite items, don't set a minimum.

### DIFF
--- a/src/Savegame/Production.cpp
+++ b/src/Savegame/Production.cpp
@@ -105,7 +105,15 @@ productionProgress_e Production::step(Base * b, SavedGame * g, const Ruleset *r)
 	_timeSpent += _engineers;
 	if (done < getAmountProduced ())
 	{
-		int produced = std::min(getAmountProduced(), _amount) - done; // std::min is required because we don't want to overproduce
+		int produced;
+		if (!getInfiniteAmount())
+		{
+			produced = std::min(getAmountProduced(), _amount) - done; // std::min is required because we don't want to overproduce
+		}
+		else
+		{
+			produced = getAmountProduced() - done;
+		}
 		int count = 0;
 		do
 		{


### PR DESCRIPTION
Right-clicking the manufacturing button to set infinite production sets a boolean flag, but doesn't change the stored amount-to-produce integer, so the std::min function always comes out to the last non-infinite value.
