### PR TITLE
Avoid crashing setting a poking _numWaypid

### DIFF
--- a/src/Battlescape/Map.cpp
+++ b/src/Battlescape/Map.cpp
@@ -1024,7 +1024,10 @@ void Map::drawTerrain(Surface *surface)
 	}
 	if (pathfinderTurnedOn)
 	{
-		_numWaypid->setBordered(true); // give it a border for the pathfinding display, makes it more visible on snow, etc.
+		if (_numWaypid)
+		{
+			_numWaypid->setBordered(true); // give it a border for the pathfinding display, makes it more visible on snow, etc.
+		}
 		for (int itZ = beginZ; itZ <= endZ; itZ++)
 		{
 			for (int itX = beginX; itX <= endX; itX++)
@@ -1088,7 +1091,10 @@ void Map::drawTerrain(Surface *surface)
 				}
 			}
 		}
-		_numWaypid->setBordered(false); // make sure we remove the border in case it's being used for missile waypoints.
+		if (_numWaypid)
+		{
+			_numWaypid->setBordered(false); // make sure we remove the border in case it's being used for missile waypoints.
+		}
 	}
 	unit = (BattleUnit*)_save->getSelectedUnit();
 	if (unit && (_save->getSide() == FACTION_PLAYER || _save->getDebugMode()) && unit->getPosition().z <= _camera->getViewLevel())


### PR DESCRIPTION
If pathfinderTurnedOn is true, but _previewSetting is not PATH_TU_COST, then _runWaypid will be null.
