### PR TITLE
Fix gcc compiler warnings from -Wall

### DIFF
--- a/src/Basescape/CraftSoldiersState.cpp
+++ b/src/Basescape/CraftSoldiersState.cpp
@@ -175,7 +175,7 @@ void CraftSoldiersState::init()
  */
 void CraftSoldiersState::lstItemsLeftArrowClick(Action *action)
 {
-	int row = _lstSoldiers->getSelectedRow();
+	unsigned int row = _lstSoldiers->getSelectedRow();
 	if (row > 0)
 	{
 		if (action->getDetails()->button.button == SDL_BUTTON_LEFT)
@@ -195,7 +195,7 @@ void CraftSoldiersState::lstItemsLeftArrowClick(Action *action)
  * @param row Selected soldier row.
  * @param max Move the soldier to the top?
  */
-void CraftSoldiersState::moveSoldierUp(Action *action, int row, bool max)
+void CraftSoldiersState::moveSoldierUp(Action *action, unsigned int row, bool max)
 {
 	Soldier *s = _base->getSoldiers()->at(row);
 	if (max)
@@ -225,9 +225,9 @@ void CraftSoldiersState::moveSoldierUp(Action *action, int row, bool max)
  */
 void CraftSoldiersState::lstItemsRightArrowClick(Action *action)
 {
-	int row = _lstSoldiers->getSelectedRow();
+	unsigned int row = _lstSoldiers->getSelectedRow();
 	size_t numSoldiers = _base->getSoldiers()->size();
-	if (0 < numSoldiers && INT_MAX >= numSoldiers && row < (int)numSoldiers - 1)
+	if (0 < numSoldiers && INT_MAX >= numSoldiers && row < numSoldiers - 1)
 	{
 		if (action->getDetails()->button.button == SDL_BUTTON_LEFT)
 		{
@@ -246,7 +246,7 @@ void CraftSoldiersState::lstItemsRightArrowClick(Action *action)
  * @param row Selected soldier row.
  * @param max Move the soldier to the bottom?
  */
-void CraftSoldiersState::moveSoldierDown(Action *action, int row, bool max)
+void CraftSoldiersState::moveSoldierDown(Action *action, unsigned int row, bool max)
 {
 	Soldier *s = _base->getSoldiers()->at(row);
 	if (max)
@@ -322,7 +322,7 @@ void CraftSoldiersState::lstSoldiersMousePress(Action *action)
 {
 	if (Options::changeValueByMouseWheel == 0)
 		return;
-	int row = _lstSoldiers->getSelectedRow();
+	unsigned int row = _lstSoldiers->getSelectedRow();
 	size_t numSoldiers = _base->getSoldiers()->size();
 	if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP &&
 		row > 0)
@@ -334,7 +334,7 @@ void CraftSoldiersState::lstSoldiersMousePress(Action *action)
 		}
 	}
 	else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN &&
-			 0 < numSoldiers && INT_MAX >= numSoldiers && row < (int)numSoldiers - 1)
+			 0 < numSoldiers && INT_MAX >= numSoldiers && row < numSoldiers - 1)
 	{
 		if (action->getAbsoluteXMouse() >= _lstSoldiers->getArrowsLeftEdge() &&
 			action->getAbsoluteXMouse() <= _lstSoldiers->getArrowsRightEdge())

--- a/src/Basescape/CraftSoldiersState.h
+++ b/src/Basescape/CraftSoldiersState.h
@@ -56,11 +56,11 @@ public:
 	/// Handler for clicking the Soldiers reordering button.
 	void lstItemsLeftArrowClick(Action *action);
 	/// Moves a soldier up.
-	void moveSoldierUp(Action *action, int row, bool max = false);
+	void moveSoldierUp(Action *action, unsigned int row, bool max = false);
 	/// Handler for clicking the Soldiers reordering button.
 	void lstItemsRightArrowClick(Action *action);
 	/// Moves a soldier down.
-	void moveSoldierDown(Action *action, int row, bool max = false);
+	void moveSoldierDown(Action *action, unsigned int row, bool max = false);
 	/// Handler for clicking the Soldiers list.
 	void lstSoldiersClick(Action *action);
 	/// Handler for pressing-down a mouse-button in the list.

--- a/src/Basescape/NewManufactureListState.cpp
+++ b/src/Basescape/NewManufactureListState.cpp
@@ -146,7 +146,7 @@ void NewManufactureListState::btnOkClick(Action *)
 */
 void NewManufactureListState::lstProdClick(Action *)
 {
-	RuleManufacture *rule;
+	RuleManufacture *rule = 0;
 	for (std::vector<RuleManufacture *>::iterator it = _possibleProductions.begin(); it != _possibleProductions.end(); ++it)
 	{
 		if ((*it)->getName().c_str() == _displayedStrings[_lstManufacture->getSelectedRow()])

--- a/src/Basescape/SoldiersState.cpp
+++ b/src/Basescape/SoldiersState.cpp
@@ -138,7 +138,7 @@ SoldiersState::~SoldiersState()
 void SoldiersState::init()
 {
 	State::init();
-	int row = 0;
+	unsigned int row = 0;
 	_lstSoldiers->clearList();
 	for (std::vector<Soldier*>::iterator i = _base->getSoldiers()->begin(); i != _base->getSoldiers()->end(); ++i)
 	{

--- a/src/Battlescape/AlienBAIState.cpp
+++ b/src/Battlescape/AlienBAIState.cpp
@@ -1114,7 +1114,7 @@ bool AlienBAIState::selectPointNearTarget(BattleUnit *target, int maxTUs) const
 	int size = _unit->getArmor()->getSize();
 	int targetsize = target->getArmor()->getSize();
 	bool returnValue = false;
-	int distance = 1000;
+	unsigned int distance = 1000;
 	for (int z = -1; z <= 1; ++z)
 	{
 		for (int x = -size; x <= targetsize; ++x)

--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -1620,7 +1620,7 @@ int BattlescapeGenerator::loadMAP(MapBlock *mapblock, int xoff, int yoff, RuleTe
 	unsigned char value[4];
 	std::ostringstream filename;
 	filename << "MAPS/" << mapblock->getName() << ".MAP";
-	int terrainObjectID;
+	unsigned int terrainObjectID;
 
 	// Load file
 	std::ifstream mapFile (CrossPlatform::getDataFile(filename.str()).c_str(), std::ios::in| std::ios::binary);
@@ -1666,11 +1666,11 @@ int BattlescapeGenerator::loadMAP(MapBlock *mapblock, int xoff, int yoff, RuleTe
 	{
 		for (int part = 0; part < 4; part++)
 		{
-			terrainObjectID = (int)((unsigned char)value[part]);
+			terrainObjectID = ((unsigned char)value[part]);
 			if (terrainObjectID>0)
 			{
 				int mapDataSetID = mapDataSetOffset;
-				int mapDataID = terrainObjectID;
+				unsigned int mapDataID = terrainObjectID;
 				MapData *md = terrain->getMapData(&mapDataID, &mapDataSetID);
 				_save->getTile(Position(x, y, z))->setMapData(md, mapDataID, mapDataSetID, part);
 			}

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -604,7 +604,7 @@ void BattlescapeState::mapOver(Action *action)
 		if ((SDL_GetMouseState(0,0)&SDL_BUTTON(Options::battleDragScrollButton)) == 0)
 		{ // so we missed again the mouse-release :(
 			// Check if we have to revoke the scrolling, because it was too short in time, so it was a click
-			if ((!_mouseMovedOverThreshold) && (SDL_GetTicks() - _mouseScrollingStartTime <= (Options::dragScrollTimeTolerance)))
+			if ((!_mouseMovedOverThreshold) && ((int)(SDL_GetTicks() - _mouseScrollingStartTime) <= (Options::dragScrollTimeTolerance)))
 			{
 				_map->getCamera()->setMapOffset(_mapOffsetBeforeMouseScrolling);
 			}
@@ -727,7 +727,7 @@ void BattlescapeState::mapClick(Action *action)
 		&& (SDL_GetMouseState(0,0)&SDL_BUTTON(Options::battleDragScrollButton)) == 0)
 		{   // so we missed again the mouse-release :(
 			// Check if we have to revoke the scrolling, because it was too short in time, so it was a click
-			if ((!_mouseMovedOverThreshold) && (SDL_GetTicks() - _mouseScrollingStartTime <= (Options::dragScrollTimeTolerance)))
+			if ((!_mouseMovedOverThreshold) && ((int)(SDL_GetTicks() - _mouseScrollingStartTime) <= (Options::dragScrollTimeTolerance)))
 			{
 				_map->getCamera()->setMapOffset(_mapOffsetBeforeMouseScrolling);
 			}
@@ -750,7 +750,7 @@ void BattlescapeState::mapClick(Action *action)
 			return;
 		}
 		// Check if we have to revoke the scrolling, because it was too short in time, so it was a click
-		if ((!_mouseMovedOverThreshold) && (SDL_GetTicks() - _mouseScrollingStartTime <= (Options::dragScrollTimeTolerance)))
+		if ((!_mouseMovedOverThreshold) && ((int)(SDL_GetTicks() - _mouseScrollingStartTime) <= (Options::dragScrollTimeTolerance)))
 		{
 			_isMouseScrolled = false;
 			stopScrolling(action);

--- a/src/Battlescape/MedikitView.cpp
+++ b/src/Battlescape/MedikitView.cpp
@@ -70,7 +70,7 @@ void MedikitView::draw()
 	int red = 3;
 
 	this->lock();
-	for (int i = 0; i < set->getTotalFrames(); i++)
+	for (unsigned int i = 0; i < set->getTotalFrames(); i++)
 	{
 		int wound = _unit->getFatalWound(i);
 		Surface * surface = set->getFrame (i);
@@ -100,7 +100,7 @@ void MedikitView::mouseClick (Action *action, State *)
 	SurfaceSet *set = _game->getResourcePack()->getSurfaceSet("MEDIBITS.DAT");
 	int x = action->getRelativeXMouse() / action->getXScale();
 	int y = action->getRelativeYMouse() / action->getYScale();
-	for (int i = 0; i < set->getTotalFrames(); i++)
+	for (unsigned int i = 0; i < set->getTotalFrames(); i++)
 	{
 		Surface * surface = set->getFrame (i);
 		if (surface->getPixel(x, y))

--- a/src/Battlescape/MiniMapView.cpp
+++ b/src/Battlescape/MiniMapView.cpp
@@ -219,7 +219,7 @@ void MiniMapView::mouseClick(Action *action, State *state)
 		if (action->getDetails()->button.button != Options::battleDragScrollButton
 		&& 0==(SDL_GetMouseState(0,0)&SDL_BUTTON(Options::battleDragScrollButton))) { // so we missed again the mouse-release :(
 			// Check if we have to revoke the scrolling, because it was too short in time, so it was a click
-			if ((!_mouseMovedOverThreshold) && (SDL_GetTicks() - _mouseScrollingStartTime <= (Options::dragScrollTimeTolerance)))
+			if ((!_mouseMovedOverThreshold) && ((int)(SDL_GetTicks() - _mouseScrollingStartTime) <= (Options::dragScrollTimeTolerance)))
 				{ _camera->centerOnPosition(_posBeforeMouseScrolling); _redraw = true; }
 			_isMouseScrolled = _isMouseScrolling = false;
 			stopScrolling(action);
@@ -240,7 +240,7 @@ void MiniMapView::mouseClick(Action *action, State *state)
 			return;
 		}
 		// Check if we have to revoke the scrolling, because it was too short in time, so it was a click
-		if ((!_mouseMovedOverThreshold) && (SDL_GetTicks() - _mouseScrollingStartTime <= (Options::dragScrollTimeTolerance)))
+		if ((!_mouseMovedOverThreshold) && ((int)(SDL_GetTicks() - _mouseScrollingStartTime) <= (Options::dragScrollTimeTolerance)))
 		{
 			_isMouseScrolled = false;
 			stopScrolling(action);
@@ -288,7 +288,7 @@ void MiniMapView::mouseOver(Action *action, State *state)
 		// (checking: is the dragScroll-mouse-button still pressed?)
 		if (0==(SDL_GetMouseState(0,0)&SDL_BUTTON(Options::battleDragScrollButton))) { // so we missed again the mouse-release :(
 			// Check if we have to revoke the scrolling, because it was too short in time, so it was a click
-			if ((!_mouseMovedOverThreshold) && (SDL_GetTicks() - _mouseScrollingStartTime <= (Options::dragScrollTimeTolerance)))
+			if ((!_mouseMovedOverThreshold) && ((int)(SDL_GetTicks() - _mouseScrollingStartTime) <= (Options::dragScrollTimeTolerance)))
 			{
 					_camera->centerOnPosition(_posBeforeMouseScrolling);
 					_redraw = true;

--- a/src/Battlescape/UnitSprite.cpp
+++ b/src/Battlescape/UnitSprite.cpp
@@ -1382,14 +1382,10 @@ void UnitSprite::drawRoutine11()
 		s->blit(this);
 	}
 
-	int turretOffsetX;
-	int turretOffsetY;
+	int turretOffsetX = 0;
+	int turretOffsetY = 0;
 	switch (_part)
 	{
-		case 0:
-			turretOffsetX = 0;
-			turretOffsetY = 0;
-			break;
 		case 1:
 			turretOffsetX = -16;
 			turretOffsetY = -8;

--- a/src/Engine/Adlib/adlplayer.cpp
+++ b/src/Engine/Adlib/adlplayer.cpp
@@ -146,8 +146,8 @@ int adl_gv_tempo_run = 60;
 int adl_gv_tempo_inc = 70;
 unsigned char* adl_gv_samples_addr = 0;
 unsigned char* adl_gv_subtracks[128];
-int adl_gv_instruments_count = 0;
-int adl_gv_subtracks_count = 0;
+unsigned int adl_gv_instruments_count = 0;
+unsigned int adl_gv_subtracks_count = 0;
 int adl_gv_polyphony_level = 0;
 unsigned char adl_gv_chorus_instruments[16];
 int adl_gv_FORMAT = 0;//0 = without title, 1=with title
@@ -401,7 +401,7 @@ void adlib_set_instrument_pitch(int instrument, int pitch)
 int adlib_get_unused_channel(int sample_id, bool* same_sample)
 {
 	int maxchan=0, maxdur=0, i;
-	bool empty=false;
+	//bool empty=false;
 
 	for (i=0; i<12; ++i)
 		++adlib_channels[i].duration;
@@ -416,7 +416,7 @@ int adlib_get_unused_channel(int sample_id, bool* same_sample)
 		if (adlib_channels[i].cur_note == 0) //empty channel
 		{
 			maxchan = i;
-			empty = true;
+			//empty = true;
 			break;
 		}
 	}

--- a/src/Engine/Adlib/fmopl.cpp
+++ b/src/Engine/Adlib/fmopl.cpp
@@ -753,7 +753,7 @@ static void OPLWriteReg(FM_OPL *OPL, int r, int v)
 {
 	OPL_CH *CH;
 	int slot;
-	int block_fnum;
+	unsigned int block_fnum;
 
 	switch(r&0xe0)
 	{

--- a/src/Engine/Palette.cpp
+++ b/src/Engine/Palette.cpp
@@ -143,8 +143,6 @@ void Palette::setColors(SDL_Color* pal, int ncolors)
 	_colors = new SDL_Color[_count];
 	memset(_colors, 0, sizeof(SDL_Color) * _count);
 
-	Uint8 value[3];
-
 	for (int i = 0; i < _count; ++i)
 	{
 		// Correct X-Com colors to RGB colors

--- a/src/Engine/Screen.cpp
+++ b/src/Engine/Screen.cpp
@@ -368,11 +368,9 @@ void Screen::resetDisplay(bool resetVideo)
 	_clear.w = getWidth();
 	_clear.h = getHeight();
 
-	double pixelRatioX = 1.0;
 	double pixelRatioY = 1.0;
 	if (Options::nonSquarePixelRatio && !Options::allowResize)
 	{
-		pixelRatioX = 0.75;
 		pixelRatioY = 1.2;
 	}
 	bool cursorInBlackBands;

--- a/src/Engine/Zoom.cpp
+++ b/src/Engine/Zoom.cpp
@@ -72,6 +72,7 @@ namespace OpenXcom
  * @param dst The zoomed surface (output).
  * @return 0 for success or -1 for error.
  */
+/*
 static int zoomSurface2X_64bit(SDL_Surface *src, SDL_Surface *dst)
 {
 	Uint64 dataSrc;
@@ -96,6 +97,7 @@ static int zoomSurface2X_64bit(SDL_Surface *src, SDL_Surface *dst)
 			dataSrc = *((Uint64*) pixelSrc);
 			// boo
 			(void)SDL_SwapLE64(dataSrc);
+*/
 /* expanded form of of data shift: 
 			dataDst = (dataSrc & 0xFF) | ((dataSrc & 0xFF) << 8) | 
 				((dataSrc & 0xFF00 ) << 8) | ((dataSrc & 0xFF00)) << 16)  | 
@@ -103,6 +105,7 @@ static int zoomSurface2X_64bit(SDL_Surface *src, SDL_Surface *dst)
 				((dataSrc & 0xFF000000) << 24) | ((dataSrc & 0xFF000000) << 32);
 */
 			// compact form, combining terms with equal multipliers (shifts)
+/*
 			dataDst = (dataSrc & 0xFF) | ((dataSrc & 0xFFFF) << 8) | 
 				((dataSrc & 0xFFFF00) << 16)  | 
 				((dataSrc & 0xFFFF0000) << 24) |
@@ -128,6 +131,7 @@ static int zoomSurface2X_64bit(SDL_Surface *src, SDL_Surface *dst)
 	
 	return 0;
 }
+*/
 
 
 #if defined(__WORDSIZE) && (__WORDSIZE == 64) || defined(SIZE_MAX) && (SIZE_MAX > 0xFFFFFFFF)
@@ -204,6 +208,7 @@ static int zoomSurface2X_32bit(SDL_Surface *src, SDL_Surface *dst)
  * @param dst The zoomed surface (output).
  * @return 0 for success or -1 for error.
  */
+/*
 static int zoomSurface4X_64bit(SDL_Surface *src, SDL_Surface *dst)
 {
 	Uint64 dataSrc;
@@ -228,12 +233,14 @@ static int zoomSurface4X_64bit(SDL_Surface *src, SDL_Surface *dst)
 			dataSrc = *((Uint64*) pixelSrc);
 			// boo
 			(void)SDL_SwapLE64(dataSrc);
+*/
 			/* expanded form of of data shift:
 			dataDst = (dataSrc & 0xFF) | ((dataSrc & 0xFF) << 8) | 
 				((dataSrc & 0xFF) << 16 | ((datasrc & 0xFF) << 24) |
 				((dataSrc & 0xFF00 ) << 24) | ((dataSrc & 0xFF00) << 32)  | 
 				((dataSrc & 0xFF00 ) << 40) | ((dataSrc & 0xFF00) << 48) ;
 				 */
+/*
 			for (int i = 0; i < 4; ++i)
 			{
 				// compact form, combining terms with equal multipliers (shifts)
@@ -254,6 +261,7 @@ static int zoomSurface4X_64bit(SDL_Surface *src, SDL_Surface *dst)
 	
 	return 0;
 }
+*/
 
 
 #if defined(__WORDSIZE) && (__WORDSIZE == 64) || defined(SIZE_MAX) && (SIZE_MAX > 0xFFFFFFFF)
@@ -327,6 +335,7 @@ static int zoomSurface4X_32bit(SDL_Surface *src, SDL_Surface *dst)
  * @param dst The zoomed surface (output).
  * @return 0 for success or -1 for error.
  */
+/*
 static int zoomSurface2X_XAxis_32bit(SDL_Surface *src, SDL_Surface *dst)
 {
 	Uint32 dataSrc;
@@ -401,6 +410,7 @@ static int zoomSurface2X_XAxis_32bit(SDL_Surface *src, SDL_Surface *dst)
 	
 	return 0;
 }
+*/
 
 
 /**
@@ -413,6 +423,7 @@ static int zoomSurface2X_XAxis_32bit(SDL_Surface *src, SDL_Surface *dst)
  * @param dst The zoomed surface (output).
  * @return 0 for success or -1 for error.
  */
+/*
 static int zoomSurface4X_XAxis_32bit(SDL_Surface *src, SDL_Surface *dst)
 {
 	Uint32 dataSrc;
@@ -487,6 +498,7 @@ static int zoomSurface4X_XAxis_32bit(SDL_Surface *src, SDL_Surface *dst)
 	
 	return 0;
 }
+*/
 
 #ifdef __SSE2__
 /**
@@ -500,6 +512,7 @@ static int zoomSurface4X_XAxis_32bit(SDL_Surface *src, SDL_Surface *dst)
  * @param dst The zoomed surface (output).
  * @return 0 for success or -1 for error.
  */
+/*
 static int zoomSurface4X_SSE2(SDL_Surface *src, SDL_Surface *dst)
 {
 	__m128i dataSrc;
@@ -527,13 +540,14 @@ static int zoomSurface4X_SSE2(SDL_Surface *src, SDL_Surface *dst)
 
 			__m128i halfDone = _mm_unpacklo_epi8(dataSrc, dataSrc); 
 			dataDst = _mm_unpacklo_epi8(halfDone, halfDone);
-
+*/
 /* #define WRITE_DST if ((char*)pixelDst4 + 128 > (char*)dst->pixels+(dst->w*dst->pitch)) { Log(LOG_ERROR) << "HELL"; exit(0); } \ */
 #define WRITE_DST			*(pixelDst++) = dataDst; \
 			*(pixelDst2++) = dataDst; \
 			*(pixelDst3++) = dataDst; \
 			*(pixelDst4++) = dataDst; \
 			
+/*
 			WRITE_DST;
 			
 			dataDst = _mm_unpackhi_epi8(halfDone, halfDone);
@@ -553,6 +567,7 @@ static int zoomSurface4X_SSE2(SDL_Surface *src, SDL_Surface *dst)
 
 	return 0;
 }
+*/
 
 /**
  * Optimized 8-bit zoomer for resizing by a factor of 2. Doesn't flip.
@@ -565,6 +580,7 @@ static int zoomSurface4X_SSE2(SDL_Surface *src, SDL_Surface *dst)
  * @param dst The zoomed surface (output).
  * @return 0 for success or -1 for error.
  */
+/*
 static int zoomSurface2X_SSE2(SDL_Surface *src, SDL_Surface *dst)
 {
 	__m128i dataSrc;
@@ -605,6 +621,7 @@ static int zoomSurface2X_SSE2(SDL_Surface *src, SDL_Surface *dst)
 	
 	return 0;
 }
+*/
 
 /**
  * Checks the SSE2 feature bit returned by the CPUID instruction
@@ -613,7 +630,7 @@ static int zoomSurface2X_SSE2(SDL_Surface *src, SDL_Surface *dst)
 bool Zoom::haveSSE2()
 {
 #ifdef __GNUC__
-	unsigned int CPUInfo[4];
+	unsigned int CPUInfo[4] = {0, 0, 0, 0};
 	__get_cpuid(1, CPUInfo, CPUInfo+1, CPUInfo+2, CPUInfo+3);
 #elif _WIN32
 	int CPUInfo[4];

--- a/src/Geoscape/DogfightState.cpp
+++ b/src/Geoscape/DogfightState.cpp
@@ -234,7 +234,7 @@ const int DogfightState::_projectileBlobs[4][6][3] =
  * @param craft Pointer to the craft intercepting.
  * @param ufo Pointer to the UFO being intercepted.
  */
-DogfightState::DogfightState(Globe *globe, Craft *craft, Ufo *ufo) : _globe(globe), _craft(craft), _ufo(ufo), _timeout(50), _currentDist(640), _targetDist(560), _end(false), _destroyUfo(false), _destroyCraft(false), _ufoBreakingOff(false), _weapon1Enabled(true), _weapon2Enabled(true), _minimized(false), _endDogfight(false), _animatingHit(false), _ufoSize(0), _craftHeight(0), _currentCraftDamageColor(13), _interceptionsCount(0), _interceptionNumber(0), _x(0), _y(0), _minimizedIconX(0), _minimizedIconY(0)
+DogfightState::DogfightState(Globe *globe, Craft *craft, Ufo *ufo) : _globe(globe), _craft(craft), _ufo(ufo), _timeout(50), _currentDist(640), _targetDist(560), _end(false), _destroyUfo(false), _destroyCraft(false), _ufoBreakingOff(false), _weapon1Enabled(true), _weapon2Enabled(true), _minimized(false), _endDogfight(false), _animatingHit(false), _ufoSize(0), _craftHeight(0), _currentCraftDamageColor(13), _interceptionNumber(0), _interceptionsCount(0), _x(0), _y(0), _minimizedIconX(0), _minimizedIconY(0)
 {
 	_screen = false;
 
@@ -393,7 +393,7 @@ DogfightState::DogfightState(Globe *globe, Craft *craft, Ufo *ufo) : _globe(glob
 	_txtInterceptionNumber->setText(ss1.str());
 	_txtInterceptionNumber->setVisible(false);
 
-	for (int i = 0; i < _craft->getRules()->getWeapons(); ++i)
+	for (unsigned int i = 0; i < _craft->getRules()->getWeapons(); ++i)
 	{
 		CraftWeapon *w = _craft->getWeapons()->at(i);
 		if (w == 0)
@@ -910,7 +910,7 @@ void DogfightState::move()
 		}
 
 		// Handle weapons and craft distance.
-		for (int i = 0; i < _craft->getRules()->getWeapons(); ++i)
+		for (unsigned int i = 0; i < _craft->getRules()->getWeapons(); ++i)
 		{
 			CraftWeapon *w = _craft->getWeapons()->at(i);
 			if (w == 0)

--- a/src/Geoscape/Globe.cpp
+++ b/src/Geoscape/Globe.cpp
@@ -1830,7 +1830,7 @@ void Globe::mouseOver(Action *action, State *state)
 		if (0 == (SDL_GetMouseState(0, 0)&SDL_BUTTON(Options::geoDragScrollButton)))
 		{ // so we missed again the mouse-release :(
 			// Check if we have to revoke the scrolling, because it was too short in time, so it was a click
-			if ((!_mouseMovedOverThreshold) && (SDL_GetTicks() - _mouseScrollingStartTime <= (Options::dragScrollTimeTolerance)))
+			if ((!_mouseMovedOverThreshold) && ((int)(SDL_GetTicks() - _mouseScrollingStartTime) <= (Options::dragScrollTimeTolerance)))
 			{
 				center(_lonBeforeMouseScrolling, _latBeforeMouseScrolling);
 			}
@@ -1965,7 +1965,7 @@ void Globe::mouseClick(Action *action, State *state)
 			&& 0 == (SDL_GetMouseState(0, 0)&SDL_BUTTON(Options::geoDragScrollButton)))
 		{ // so we missed again the mouse-release :(
 			// Check if we have to revoke the scrolling, because it was too short in time, so it was a click
-			if ((!_mouseMovedOverThreshold) && (SDL_GetTicks() - _mouseScrollingStartTime <= (Options::dragScrollTimeTolerance)))
+			if ((!_mouseMovedOverThreshold) && ((int)(SDL_GetTicks() - _mouseScrollingStartTime) <= (Options::dragScrollTimeTolerance)))
 			{
 				center(_lonBeforeMouseScrolling, _latBeforeMouseScrolling);
 			}
@@ -1988,7 +1988,7 @@ void Globe::mouseClick(Action *action, State *state)
 			return;
 		}
 		// Check if we have to revoke the scrolling, because it was too short in time, so it was a click
-		if ((!_mouseMovedOverThreshold) && (SDL_GetTicks() - _mouseScrollingStartTime <= (Options::dragScrollTimeTolerance)))
+		if ((!_mouseMovedOverThreshold) && ((int)(SDL_GetTicks() - _mouseScrollingStartTime) <= (Options::dragScrollTimeTolerance)))
 		{
 			_isMouseScrolled = false;
 			stopScrolling(action);

--- a/src/Interface/NumberText.cpp
+++ b/src/Interface/NumberText.cpp
@@ -30,7 +30,7 @@ namespace OpenXcom
  * @param x X position in pixels.
  * @param y Y position in pixels.
  */
-NumberText::NumberText(int width, int height, int x, int y) : Surface(width, height, x, y), _value(0), _color(0), _bordered(false)
+NumberText::NumberText(int width, int height, int x, int y) : Surface(width, height, x, y), _value(0), _bordered(false), _color(0)
 {
 	_chars[0] = new Surface(3, 5);
 	_chars[0]->lock();

--- a/src/Interface/TextList.cpp
+++ b/src/Interface/TextList.cpp
@@ -285,7 +285,7 @@ void TextList::addRow(int cols, ...)
 		if (_dot && i < cols - 1)
 		{
 			std::wstring buf = txt->getText();
-			int w = txt->getTextWidth();
+			unsigned int w = txt->getTextWidth();
 			while (w < _columns[i])
 			{
 				w += _font->getChar('.')->getCrop()->w + _font->getSpacing();
@@ -603,7 +603,7 @@ void TextList::setCondensed(bool condensed)
  * list is selectable.
  * @return Selected row, -1 if none.
  */
-int TextList::getSelectedRow() const
+unsigned int TextList::getSelectedRow() const
 {
 	if (_rows.empty() || _selRow >= _rows.size())
 	{

--- a/src/Interface/TextList.h
+++ b/src/Interface/TextList.h
@@ -136,7 +136,7 @@ public:
 	/// Sets the background for the selector.
 	void setBackground(Surface *bg);
 	/// Gets the selected row in the list.
-	int getSelectedRow() const;
+	unsigned int getSelectedRow() const;
 	/// Sets the margin of the text list.
 	void setMargin(int margin);
 	/// Gets the margin of the text list.

--- a/src/Menu/ListGamesState.h
+++ b/src/Menu/ListGamesState.h
@@ -50,7 +50,7 @@ protected:
 	OptionsOrigin _origin;
 	bool _showMsg, _noUI;
 	std::vector<SaveInfo> _saves;
-	int _firstValidRow;
+	unsigned int _firstValidRow;
 	bool _autoquick, _sortable;
 
 	void updateArrows();

--- a/src/Menu/NewGameState.cpp
+++ b/src/Menu/NewGameState.cpp
@@ -132,7 +132,7 @@ NewGameState::~NewGameState()
  */
 void NewGameState::btnOkClick(Action *)
 {
-	GameDifficulty diff;
+	GameDifficulty diff = DIFF_BEGINNER;
 	if (_difficulty == _btnBeginner)
 	{
 		diff = DIFF_BEGINNER;

--- a/src/Menu/OptionsAudioState.cpp
+++ b/src/Menu/OptionsAudioState.cpp
@@ -130,7 +130,7 @@ OptionsAudioState::OptionsAudioState(OptionsOrigin origin) : OptionsBaseState(or
 	std::vector<std::wstring> samplesText;
 
 	int samples[] = {8000, 11025, 16000, 22050, 32000, 44100, 48000};
-	for (int i = 0; i < sizeof(samples) / sizeof(samples[0]); ++i)
+	for (unsigned int i = 0; i < sizeof(samples) / sizeof(samples[0]); ++i)
 	{
 		_sampleRates.push_back(samples[i]);
 		ss << samples[i] << L" Hz";

--- a/src/Menu/OptionsControlsState.cpp
+++ b/src/Menu/OptionsControlsState.cpp
@@ -202,7 +202,7 @@ void OptionsControlsState::lstControlsClick(Action *action)
 	}
 	if (_selected != -1)
 	{
-		int selected = _selected;
+		unsigned int selected = _selected;
 		_lstControls->setCellColor(_selected, 0, _colorNormal);
 		_lstControls->setCellColor(_selected, 1, _colorNormal);
 		_selected = -1;

--- a/src/Ruleset/RuleCraft.cpp
+++ b/src/Ruleset/RuleCraft.cpp
@@ -171,7 +171,7 @@ int RuleCraft::getAcceleration() const
  * can be equipped onto the craft.
  * @return The weapon capacity.
  */
-int RuleCraft::getWeapons() const
+unsigned int RuleCraft::getWeapons() const
 {
 	return _weapons;
 }

--- a/src/Ruleset/RuleCraft.h
+++ b/src/Ruleset/RuleCraft.h
@@ -70,7 +70,7 @@ public:
 	/// Gets the craft's acceleration.
 	int getAcceleration() const;
 	/// Gets the craft's weapon capacity.
-	int getWeapons() const;
+	unsigned int getWeapons() const;
 	/// Gets the craft's soldier capacity.
 	int getSoldiers() const;
 	/// Gets the craft's vehicle capacity.

--- a/src/Ruleset/RuleTerrain.cpp
+++ b/src/Ruleset/RuleTerrain.cpp
@@ -170,7 +170,7 @@ MapBlock* RuleTerrain::getMapBlock(const std::string &name)
  * @param mapDataSetID The id of the map data set.
  * @return Pointer to MapData object.
  */
-MapData *RuleTerrain::getMapData(int *id, int *mapDataSetID) const
+MapData *RuleTerrain::getMapData(unsigned int *id, int *mapDataSetID) const
 {
 	MapDataSet* mdf = 0;
 

--- a/src/Ruleset/RuleTerrain.h
+++ b/src/Ruleset/RuleTerrain.h
@@ -64,7 +64,7 @@ public:
 	/// Gets a mapblock given its name.
 	MapBlock *getMapBlock(const std::string &name);
 	/// Gets the mapdata object.
-	MapData *getMapData(int *id, int *mapDataSetID) const;
+	MapData *getMapData(unsigned int *id, int *mapDataSetID) const;
 	/// Gets the maximum amount of large blocks in this terrain.
 	int getLargeBlockLimit() const;
 	void resetMapBlocks();

--- a/src/Ruleset/Ruleset.cpp
+++ b/src/Ruleset/Ruleset.cpp
@@ -70,7 +70,7 @@ namespace OpenXcom
 /**
  * Creates a ruleset with blank sets of rules.
  */
-Ruleset::Ruleset() : _costSoldier(0), _costEngineer(0), _costScientist(0), _timePersonnel(0), _initialFunding(0), _startingTime(6, 1, 1, 1999, 12, 0, 0), _modIndex(0), _facilityListOrder(0), _craftListOrder(0), _itemListOrder(0), _researchListOrder(0),  _manufactureListOrder(0), _ufopaediaListOrder(0), _invListOrder(0), _alienFuel("")
+Ruleset::Ruleset() : _costSoldier(0), _costEngineer(0), _costScientist(0), _timePersonnel(0), _initialFunding(0), _alienFuel(""), _startingTime(6, 1, 1, 1999, 12, 0, 0), _modIndex(0), _facilityListOrder(0), _craftListOrder(0), _itemListOrder(0), _researchListOrder(0),  _manufactureListOrder(0), _ufopaediaListOrder(0), _invListOrder(0)
 {
     // Check in which data dir the folder is stored
     std::string path = CrossPlatform::getDataFolder("SoldierName/");

--- a/src/Savegame/AlienMission.cpp
+++ b/src/Savegame/AlienMission.cpp
@@ -426,7 +426,7 @@ void AlienMission::ufoReachedWaypoint(Ufo &ufo, Game &engine, const Globe &globe
 				error << "Mission number: " << getId() << " in region: " << getRegion() << " trying to land at lon: " << ufo.getLongitude() << " lat: " << ufo.getLatitude() << " ufo is on flightpath: " << ufo.getTrajectory().getID() << " at point: " << ufo.getTrajectoryPoint() << ", no city found.";
 				Log(LOG_FATAL) << error.str();
 				std::vector<MissionArea> cityZones = rules.getRegion(getRegion())->getMissionZones().at(RuleRegion::CITY_MISSION_ZONE).areas;
-				for (int i = 0; i != cityZones.size(); ++i)
+				for (unsigned int i = 0; i != cityZones.size(); ++i)
 				{
 					error.str("");
 					error << "Zone " << i  << ": Longitudes: " << cityZones.at(i).lonMin * M_PI / 180 << " to " << cityZones.at(i).lonMax * M_PI / 180 << " Latitudes: " << cityZones.at(i).latMin * M_PI / 180 << " to " << cityZones.at(i).latMax * M_PI / 180;

--- a/src/Savegame/Base.cpp
+++ b/src/Savegame/Base.cpp
@@ -639,7 +639,7 @@ double Base::getIgnoredStores()
 					if (clip != "" && available > 0)
 					{
 						int clipSize = _rule->getItem(clip)->getClipSize();
-						int needed;
+						int needed = 0;
 						if (clipSize > 0)
 						{
 							needed = ((*w)->getRules()->getAmmoMax() - (*w)->getAmmo()) / clipSize;

--- a/src/Savegame/Craft.cpp
+++ b/src/Savegame/Craft.cpp
@@ -53,7 +53,7 @@ Craft::Craft(RuleCraft *rules, Base *base, int id) : MovingTarget(), _rules(rule
 	{
 		_id = id;
 	}
-	for (int i = 0; i < _rules->getWeapons(); ++i)
+	for (unsigned int i = 0; i < _rules->getWeapons(); ++i)
 	{
 		_weapons.push_back(0);
 	}
@@ -274,7 +274,7 @@ void Craft::changeRules(RuleCraft *rules)
 {
 	_rules = rules;
 	_weapons.clear();
-	for (int i = 0; i < _rules->getWeapons(); ++i)
+	for (unsigned int i = 0; i < _rules->getWeapons(); ++i)
 	{
 		_weapons.push_back(0);
 	}

--- a/src/Ufopaedia/ArticleStateTFTD.cpp
+++ b/src/Ufopaedia/ArticleStateTFTD.cpp
@@ -74,8 +74,6 @@ namespace OpenXcom
 		_txtTitle->setAlign(ALIGN_CENTER);
 		_txtTitle->setText(tr(defs->title));
 
-		int text_height = _txtTitle->getTextHeight();
-
 		_txtInfo = new Text(152, 64, 168, 40);
 		add(_txtInfo);
 


### PR DESCRIPTION
I posted in the forum on this, but it looks like pull requests are the way to go...

I'm attempting to build a package on Fedora 20.  It adds the compiler flag -Wall, so (along with -Werror from configure) I get a lot of build failures.  I've attached a patch to fix various problems including

unused variables or methods (-Wunused)
uninitialized variables (-Wuninitialized)
signed/unsigned comparisons (-Wsign-compare)
order of initiliazers (-Wreorder)
