### PR TITLE
Enable -Wall for C++ too

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ AS_IF([test x"$enable_werror" != "xno"], [
 AS_IF([test x"$GCC" = xyes], [
 	# Be tough with warnings and produce less careless code
 	CFLAGS="$CFLAGS -Wall -pedantic"
+	CXXFLAGS="$CXXFLAGS -Wall"
 	LDFLAGS="$LDFLAGS -Wl,--as-needed"
 ])
 


### PR DESCRIPTION
-Wall is turned on (by default) for C but not C++.

I'd add -pedantic too, but g++ chokes on 2685821657736338717LL from RNG.cpp unless you add -std=c++11.  I'm not sure if that would work on older gcc.
