### PR TITLE
Only do HQX if it is enabled

### DIFF
--- a/src/Engine/Zoom.cpp
+++ b/src/Engine/Zoom.cpp
@@ -718,7 +718,7 @@ int Zoom::_zoomSurfaceY(SDL_Surface * src, SDL_Surface * dst, int flipx, int fli
 	int dgap;
 	static bool proclaimed = false;
 
-	if (Options::useHQXFilter)
+	if (Screen::isHQXEnabled())
 	{
 		static bool initDone = false;
 


### PR DESCRIPTION
this resolves http://openxcom.org/bugs/openxcom/issues/692

Because HQX is not "enabled" (resolution is 1024x768, Geoscape scale is 1/3), the actual bpp=8 and so the hqx code exceeds the array bounds.
