### PR TITLE
check strength penalty on turn 1

### DIFF
--- a/src/Battlescape/InventoryState.cpp
+++ b/src/Battlescape/InventoryState.cpp
@@ -474,6 +474,17 @@ void InventoryState::btnOkClick(Action *)
 				_battleGame->setSelectedUnit(inventoryTile->getUnit());
 			}
 		}
+
+		// initialize xcom units for battle
+		for (std::vector<BattleUnit*>::iterator j = _battleGame->getUnits()->begin(); j != _battleGame->getUnits()->end(); ++j)
+		{
+			if ((*j)->getOriginalFaction() != FACTION_PLAYER || (*j)->isOut())
+			{
+				continue;
+			}
+
+			(*j)->prepareNewTurn();
+		}
 	}
 }
 


### PR DESCRIPTION
code to check strength penalty on turn 1 was missing.  this adds it in so overencumbered soldiers have their TUs properly reduced on turn 1

Fixes http://openxcom.org/bugs/openxcom/issues/768
