### PR TITLE
Fix: incorrect rearming of Craft weapons

### DIFF
--- a/src/Savegame/Craft.cpp
+++ b/src/Savegame/Craft.cpp
@@ -791,7 +791,7 @@ std::string Craft::rearm(Ruleset *rules)
 			{
 				int used = (*i)->rearm(available, rules->getItem(clip)->getClipSize());
 
-				if (used > available)
+				if (used == available && (*i)->isRearming())
 				{
 					ammo = clip;
 					(*i)->setRearming(false);

--- a/src/Savegame/CraftWeapon.cpp
+++ b/src/Savegame/CraftWeapon.cpp
@@ -130,30 +130,20 @@ void CraftWeapon::setRearming(bool rearming)
  */
 int CraftWeapon::rearm(const int available, const int clipSize)
 {
-	int used = 0;
+	int needed = 0;
 
 	if (clipSize > 0)
-	{
-		const int needed = std::max(1, (_rules->getAmmoMax() - _ammo) / clipSize);
-		used = std::min(_rules->getRearmRate() / clipSize, needed);
+	{	// +(clipSize - 1) for correct rounding up
+		needed = std::min(_rules->getRearmRate(), _rules->getAmmoMax() - _ammo + clipSize - 1) / clipSize;
 	}
 
-	if (available >= used)
-	{
-		setAmmo(_ammo + _rules->getRearmRate());
-	}
-	else
-	{
-		setAmmo(_ammo + (clipSize * available));
-	}
+	int ammoUsed = (available >= needed)? _rules->getRearmRate() : available * clipSize;
 
-	if (_ammo >= _rules->getAmmoMax())
-	{
-		_ammo = _rules->getAmmoMax();
-		_rearming = false;
-	}
+	setAmmo(_ammo + ammoUsed);
 
-	return used;
+	_rearming = _ammo < _rules->getAmmoMax();
+
+	return (clipSize <= 0)? 0 : ammoUsed / clipSize;
 }
 
 /*


### PR DESCRIPTION
In fact, calculation of craft weapons rearming is bugged.
For example, rearming will be incorrect if:
1. A craft has a cannon.
2. Remaining ammo of the cannon is 101-149 rounds (101 for instance).
3. Remaining ammo on a base is only one clip (x50).

Then the cannon will be fully rearmed, but must have only 151 rounds.
Link to test save: https://dl.dropboxusercontent.com/u/73411168/test.7z
