### PR TITLE
make late missions possible

### DIFF
--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -2163,19 +2163,28 @@ void GeoscapeState::determineAlienMissions(bool atGameStart)
 		// One randomly selected mission.
 		//
 		AlienStrategy &strategy = _game->getSavedGame()->getAlienStrategy();
-		const std::string &targetRegion = strategy.chooseRandomRegion(_game->getRuleset());
-		const std::string &targetMission = strategy.chooseRandomMission(targetRegion);
-		// Choose race for this mission.
-		const RuleAlienMission &missionRules = *_game->getRuleset()->getAlienMission(targetMission);
-		const std::string &missionRace = missionRules.generateRace(_game->getSavedGame()->getMonthsPassed());
-		AlienMission *otherMission = new AlienMission(missionRules);
-		otherMission->setId(_game->getSavedGame()->getId("ALIEN_MISSIONS"));
-		otherMission->setRegion(targetRegion, *_game->getRuleset());
-		otherMission->setRace(missionRace);
-		otherMission->start();
-		_game->getSavedGame()->getAlienMissions().push_back(otherMission);
-		// Make sure this combination never comes up again.
-		strategy.removeMission(targetRegion, targetMission);
+		int _monthcounter = 0;
+		while (true){
+			const std::string &targetRegion = strategy.chooseRandomRegion(_game->getRuleset());
+			const std::string &targetMission = strategy.chooseRandomMission(targetRegion);
+			// Choose race for this mission.
+			const RuleAlienMission &missionRules = *_game->getRuleset()->getAlienMission(targetMission);
+			if (_game->getSavedGame()->getMonthsPassed() >= missionRules.determineLowestMonth())
+			{
+				const std::string &missionRace = missionRules.generateRace(_game->getSavedGame()->getMonthsPassed());
+				AlienMission *otherMission = new AlienMission(missionRules);
+				otherMission->setId(_game->getSavedGame()->getId("ALIEN_MISSIONS"));
+				otherMission->setRegion(targetRegion, *_game->getRuleset());
+				otherMission->setRace(missionRace);
+				otherMission->start();
+				_game->getSavedGame()->getAlienMissions().push_back(otherMission);
+				// Make sure this combination never comes up again.
+				strategy.removeMission(targetRegion, targetMission);
+				break;
+			}
+			else if ( _monthcounter > 1000 ) strategy.removeMission(targetRegion, targetMission);			
+			_monthcounter++;
+		}
 	}
 	else
 	{

--- a/src/Ruleset/RuleAlienMission.cpp
+++ b/src/Ruleset/RuleAlienMission.cpp
@@ -156,4 +156,21 @@ int RuleAlienMission::getPoints() const
 	return _points;
 }
 
+/**
+ * Determines the lowest available month for this missiontype.
+ * that way missions with month >0 can only start later.
+ * @return The lowest int number of month for this mission.
+ */
+const int RuleAlienMission::determineLowestMonth() const
+{
+	std::vector<std::pair<size_t, WeightedOptions*> >::const_reverse_iterator rc = _raceDistribution.rbegin();
+	int _minmonth = std::numeric_limits<int>::max();
+	for (std::vector<std::pair<size_t, WeightedOptions*> >::const_iterator ii = _raceDistribution.begin(); ii != _raceDistribution.end(); ++ii)
+	{
+		_minmonth = (_minmonth > ii->first) ? ii->first : _minmonth;
+	}
+	return _minmonth;
+}
+
+;
 }

--- a/src/Ruleset/RuleAlienMission.h
+++ b/src/Ruleset/RuleAlienMission.h
@@ -78,6 +78,8 @@ public:
 	const MissionWave &getWave(size_t index) const { return _waves[index]; }
 	/// Gets the score for this mission.
 	int getPoints() const;
+	/// Gets lowest available month (allows late missions).
+	const int determineLowestMonth() const;
 private:
 	/// The mission's type ID.
 	std::string _type;


### PR DESCRIPTION
this change allows modded missions to start later in game
the idea ist a mission can start at the earliest in the month where they have a raceweight entry >0
the regions/missions are still selected by random choice
if a mission is selected that is too early i random-select a new one, 
  if that mission is too early i random-select a new one , 
     if that mission is too early i random-select a new one , 
       if that mission is too early i random-select a new one  ... 
i give it 1000 tries (first hit breaks loop so should not hinder vanilla/normal games - vanilla missions have all raceweight: 0: somerace - so these missions always fit)
after 1000 tries  i start to delete the selected missions because its likely that some modder put a STR_NEWMISSION: raceweight: 200: STR_SECTOIDS:100 in a mod so before month 200 it never can take this mission and i would otherwise end in an infinite loop
if the posible mission list is empty it will be newly generated from ruleset
and then i should find new missions and break the loop