### PR TITLE
Feature: Hyperwave decoder sometimes cannot intercept transmissions.

### DIFF
--- a/src/Savegame/Base.cpp
+++ b/src/Savegame/Base.cpp
@@ -381,11 +381,18 @@ int Base::detect(Target *target) const
 	{
 		if ((*i)->getRules()->getRadarRange() >= distance && (*i)->getBuildTime() == 0)
 		{
+			int radarChance = (*i)->getRules()->getRadarChance();
 			if ((*i)->getRules()->isHyperwave())
 			{
-				return 2;
+				if (radarChance == 100 || RNG::percent(radarChance))
+				{
+					return 2;
+				}
 			}
-			chance += (*i)->getRules()->getRadarChance();
+			else
+			{
+				chance += radarChance;
+			}
 		}
 	}
 	if (chance == 0) return 0;


### PR DESCRIPTION
Hyperwave decoder has the rule "radarChance: 100".
https://github.com/SupSuper/OpenXcom/blob/master/bin/data/Ruleset/Xcom1Ruleset.rul#L1139
But this rule not used.
I suggest take this rule into account.