### PR TITLE
Don't include deprecated malloc.h

### DIFF
--- a/src/Engine/Scalers/scalebit.cpp
+++ b/src/Engine/Scalers/scalebit.cpp
@@ -36,7 +36,6 @@
 
 #include <assert.h>
 #include <stdlib.h>
-#include <malloc.h>
 
 #define SSDST(bits, num) (scale2x_uint##bits *)dst##num
 #define SSSRC(bits, num) (const scale2x_uint##bits *)src##num


### PR DESCRIPTION
(malloc() and friends are provided by stdlib.h)
