### PR TITLE
Fix for infinite loop and memory leak in reaction code.

### DIFF
--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -1160,7 +1160,7 @@ int BattleUnit::getActionTUs(BattleActionType actionType, RuleItem *item)
 	// if it's a percentage, apply it to unit TUs
 	if (!item->getFlatRate() || actionType == BA_THROW || actionType == BA_PRIME)
 	{
-		cost = (int)floor(getStats()->tu * cost / 100.0f);
+		cost = std::max(1, (int)floor(getStats()->tu * cost / 100.0f));
 	}
 
 	return cost;


### PR DESCRIPTION
If the TU % cost of the weapon action is low enough, the calculated cost get to 0, so the unit will always be able to react.

Fixes http://openxcom.org/bugs/openxcom/issues/818
