### PR TITLE
Fix: fixed weapons should be always mounted to "hands".

### DIFF
--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -1042,6 +1042,20 @@ bool BattlescapeGenerator::addItem(BattleItem *item, BattleUnit *unit, bool allo
 			}
 		}
 	}
+	// fixed weapon should be always placed in hand slots
+	if (item->getRules()->isFixed())
+	{
+		if (!rightWeapon || !leftWeapon)
+		{
+			item->moveToOwner(unit);
+			item->setSlot(!rightWeapon ? rightHand : leftHand);
+			placed = true;
+			_save->getItems()->push_back(item);
+			item->setXCOMProperty(unit->getFaction() == FACTION_PLAYER);
+		}
+		return placed;
+	}
+
 	bool keep = true;
 	switch (item->getRules()->getBattleType())
 	{
@@ -1060,7 +1074,7 @@ bool BattlescapeGenerator::addItem(BattleItem *item, BattleUnit *unit, bool allo
 				item->setSlot(rightHand);
 				placed = true;
 			}
-			if (!placed && !leftWeapon && (unit->getFaction() != FACTION_PLAYER || item->getRules()->isFixed()))
+			else if (!leftWeapon && unit->getFaction() != FACTION_PLAYER)
 			{
 				item->moveToOwner(unit);
 				item->setSlot(leftHand);


### PR DESCRIPTION
Fixed weapons should be always mounted to "hands".
Because if I sets "fixedWeapon: true", then I expect this weapon will be mounted to turret.
Because I cannot use the fixed weapon if they mounted to "backpack".

![screen007](https://cloud.githubusercontent.com/assets/3616568/4350227/b69f2552-41dd-11e4-93f5-3ed4efe902f1.png)
