### PR TITLE
Now articles in UFOPaedia can be switched by pressing keys

### DIFF
--- a/bin/data/Language/en-GB.yml
+++ b/bin/data/Language/en-GB.yml
@@ -1350,3 +1350,5 @@ en-GB:
   STR_NO_MORE_EQUIPMENT_ALLOWED:
     one: "NO MORE EQUIPMENT ALLOWED ON BOARD!{SMALLLINE}You are only allowed to take a maximum of {N} item of equipment on this craft."
     other: "NO MORE EQUIPMENT ALLOWED ON BOARD!{SMALLLINE}You are only allowed to take a maximum of {N} items of equipment on this craft."
+  STR_PREV_OBJECT: "Previous object"
+  STR_NEXT_OBJECT: "Next object"

--- a/bin/data/Language/en-US.yml
+++ b/bin/data/Language/en-US.yml
@@ -1350,3 +1350,5 @@ en-US:
   STR_NO_MORE_EQUIPMENT_ALLOWED:
     one: "NO MORE EQUIPMENT ALLOWED ON BOARD!{SMALLLINE}You are only allowed to take a maximum of {N} item of equipment on this craft."
     other: "NO MORE EQUIPMENT ALLOWED ON BOARD!{SMALLLINE}You are only allowed to take a maximum of {N} items of equipment on this craft."
+  STR_PREV_OBJECT: "Previous object"
+  STR_NEXT_OBJECT: "Next object"

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -201,6 +201,8 @@ void create()
 	_info.push_back(OptionInfo("keyFps", &keyFps, SDLK_F7, "STR_FPS_COUNTER", "STR_GENERAL"));
 	_info.push_back(OptionInfo("keyQuickSave", &keyQuickSave, SDLK_F5, "STR_QUICK_SAVE", "STR_GENERAL"));
 	_info.push_back(OptionInfo("keyQuickLoad", &keyQuickLoad, SDLK_F9, "STR_QUICK_LOAD", "STR_GENERAL"));
+	_info.push_back(OptionInfo("keyPrev", &keyPrev, SDLK_LEFT, "STR_PREV_OBJECT", "STR_GENERAL"));
+	_info.push_back(OptionInfo("keyNext", &keyNext, SDLK_RIGHT, "STR_NEXT_OBJECT", "STR_GENERAL"));
 	_info.push_back(OptionInfo("keyGeoLeft", &keyGeoLeft, SDLK_LEFT, "STR_ROTATE_LEFT", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("keyGeoRight", &keyGeoRight, SDLK_RIGHT, "STR_ROTATE_RIGHT", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("keyGeoUp", &keyGeoUp, SDLK_UP, "STR_ROTATE_UP", "STR_GEOSCAPE"));

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -14,7 +14,7 @@ OPT SaveSort saveOrder;
 OPT MusicFormat preferredMusic;
 OPT SoundFormat preferredSound;
 OPT SDL_GrabMode captureMouse;
-OPT SDLKey keyOk, keyCancel, keyScreenshot, keyFps, keyQuickLoad, keyQuickSave;
+OPT SDLKey keyOk, keyCancel, keyScreenshot, keyFps, keyQuickLoad, keyQuickSave, keyPrev, keyNext;
 
 // Geoscape options
 OPT int geoClockSpeed, dogfightSpeed, geoScrollSpeed, geoDragScrollButton, geoscapeScale;

--- a/src/Ufopaedia/ArticleState.cpp
+++ b/src/Ufopaedia/ArticleState.cpp
@@ -107,8 +107,10 @@ namespace OpenXcom
 		_btnOk->onKeyboardPress((ActionHandler)&ArticleState::btnOkClick,Options::keyCancel);
 		_btnPrev->setText(L"<<");
 		_btnPrev->onMouseClick((ActionHandler)&ArticleState::btnPrevClick);
+		_btnPrev->onKeyboardPress((ActionHandler)&ArticleState::btnPrevClick,Options::keyPrev);
 		_btnNext->setText(L">>");
 		_btnNext->onMouseClick((ActionHandler)&ArticleState::btnNextClick);
+		_btnNext->onKeyboardPress((ActionHandler)&ArticleState::btnNextClick,Options::keyNext);
 	}
 
 	/**


### PR DESCRIPTION
Now articles in UFOPaedia can be switched by pressing keyPrev and keyNext buttons (left and right arrows by default)