### PR TITLE
Show ammo capacity for craft weapons in UFOpaedia.

### DIFF
--- a/src/Ufopaedia/ArticleStateCraftWeapon.cpp
+++ b/src/Ufopaedia/ArticleStateCraftWeapon.cpp
@@ -90,6 +90,9 @@ namespace OpenXcom
 		_lstInfo->addRow(2, tr("STR_RE_LOAD_TIME").c_str(), tr("STR_SECONDS").arg(weapon->getStandardReload()).c_str());
 		_lstInfo->setCellColor(3, 1, Palette::blockOffset(15)+4);
 
+		_lstInfo->addRow(2, tr("STR_ROUNDS").c_str(), Text::formatNumber(weapon->getAmmoMax()).c_str());
+		_lstInfo->setCellColor(4, 1, Palette::blockOffset(15)+4);
+
 		centerAllSurfaces();
 	}
 


### PR DESCRIPTION
Show ammo capacity:

![screen011](https://cloud.githubusercontent.com/assets/81112/4693607/47343636-57a3-11e4-9cea-3ac64dd1caea.png)
