### PR TITLE
Fix use of abs() for floating point arguments

### DIFF
--- a/src/Battlescape/ProjectileFlyBState.cpp
+++ b/src/Battlescape/ProjectileFlyBState.cpp
@@ -651,7 +651,7 @@ int ProjectileFlyBState::getMaxThrowDistance(int weight, int strength, int level
         if (curZ < 0 && dz < 0) //roll back
         {
             dz = std::max(dz, -1.0);
-            if (abs(dz)>1e-10) //rollback horizontal
+            if (std::abs(dz)>1e-10) //rollback horizontal
                 dist -= curZ / dz;
             break;
         }

--- a/src/Geoscape/Globe.cpp
+++ b/src/Geoscape/Globe.cpp
@@ -1217,12 +1217,12 @@ void Globe::drawVHLine(Surface *surface, double lon1, double lat1, double lon2, 
 
 	if (fabs(sx)<0.01)
 	{
-		seg = abs( sy/(2*M_PI)*48 );
+		seg = std::abs(sy/(2*M_PI)*48);
 		if (seg == 0) ++seg;
 	}
 	else
 	{
-		seg = abs( sx/(2*M_PI)*96 );
+		seg = std::abs(sx/(2*M_PI)*96);
 		if (seg == 0) ++seg;
 	}
 


### PR DESCRIPTION
I noticed this warning when building with Clang. The naked `abs` function is the integral one from the C library. By contrast, `std::abs` has integral and floating overloads.
