### PR TITLE
Feature Request #152: Change Soldier to Ship in Soldier Screen

### DIFF
--- a/bin/data/Language/en-GB.yml
+++ b/bin/data/Language/en-GB.yml
@@ -1350,3 +1350,5 @@ en-GB:
   STR_NO_MORE_EQUIPMENT_ALLOWED:
     one: "NO MORE EQUIPMENT ALLOWED ON BOARD!{SMALLLINE}You are only allowed to take a maximum of {N} item of equipment on this craft."
     other: "NO MORE EQUIPMENT ALLOWED ON BOARD!{SMALLLINE}You are only allowed to take a maximum of {N} items of equipment on this craft."
+  STR_WOUNDED_SOLDIER_TITLE: "WOUNDED SOLDIERS"
+  STR_WOUNDED_SOLDIER_NOTICE: "Wounded soldiers cannot be assigned to craft!"

--- a/bin/data/Language/en-US.yml
+++ b/bin/data/Language/en-US.yml
@@ -1350,3 +1350,5 @@ en-US:
   STR_NO_MORE_EQUIPMENT_ALLOWED:
     one: "NO MORE EQUIPMENT ALLOWED ON BOARD!{SMALLLINE}You are only allowed to take a maximum of {N} item of equipment on this craft."
     other: "NO MORE EQUIPMENT ALLOWED ON BOARD!{SMALLLINE}You are only allowed to take a maximum of {N} items of equipment on this craft."
+  STR_WOUNDED_SOLDIER_TITLE: "WOUNDED SOLDIERS"
+  STR_WOUNDED_SOLDIER_NOTICE: "Wounded soldiers cannot be assigned to craft!"

--- a/src/Basescape/SoldiersState.cpp
+++ b/src/Basescape/SoldiersState.cpp
@@ -45,7 +45,7 @@ namespace OpenXcom
 	 * @param game Pointer to the core game.
 	 * @param base Pointer to the base to get info from.
 	 */
-	SoldiersState::SoldiersState(Base *base) : _base(base), _curCraftInList(-2)
+	SoldiersState::SoldiersState(Base *base) : _base(base)
 	{
 		bool isPsiBtnVisible = Options::anytimePsiTraining && _base->getAvailablePsiLabs() > 0;
 
@@ -123,6 +123,8 @@ namespace OpenXcom
 		_lstSoldiers->setBackground(_window);
 		_lstSoldiers->setMargin(8);
 		_lstSoldiers->onMouseClick((ActionHandler)&SoldiersState::lstSoldiersClick);
+
+		_curCraftInList = CRAFT_LIST_INDEX_INIT;
 	}
 
 	/**
@@ -205,7 +207,7 @@ namespace OpenXcom
 		else if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
 		{
 			// reset the group craft list index
-			_curCraftInList = -2;
+			_curCraftInList = CRAFT_LIST_INDEX_INIT;
 		}
 	}
 
@@ -228,6 +230,7 @@ namespace OpenXcom
 			return;
 		}
 
+		// if any of the soldiers we're attempting to assign to a craft are wounded, warn the player and disallow
 		if (checkForWoundedSelectedSoldiers())
 		{
 			_game->pushState(new WoundedNoticeState);
@@ -245,7 +248,7 @@ namespace OpenXcom
 				Craft *tempCraft = 0;
 				
 				// if this is the first time iterating through the list for this group, set it up
-				if (_curCraftInList == -2)
+				if (_curCraftInList == CRAFT_LIST_INDEX_INIT)
 				{
 					tempCraft = (*selectedSoldiers.begin())->getCraft();
 					_curCraftInList = findCraftAmongstAllCrafts(tempCraft);
@@ -269,8 +272,6 @@ namespace OpenXcom
 					else
 					{
 						tempCraft = crafts->at(_curCraftInList);
-
-						// TODO: Put in code to handle if ship is currently out (can't select those soldiers?).  Ditto for wounded soldiers.
 
 						// if the craft is out, then we can't assign anyone to it; move along
 						if (tempCraft->getStatus() == "STR_OUT") 
@@ -297,6 +298,7 @@ namespace OpenXcom
 			color = Palette::blockOffset(13) + 10;
 		}
 
+		// assign the chosen craft (or lack thereof) to selected soldiers
 		std::map<Soldier*, size_t> soldiersWithRows = getSelectedSoldiersWithRows();
 		std::wstring craftName = (craftToAssign == 0 ? tr("STR_NONE_UC") : craftToAssign->getName(_game->getLanguage()));
 

--- a/src/Basescape/SoldiersState.cpp
+++ b/src/Basescape/SoldiersState.cpp
@@ -35,6 +35,7 @@
 #include "../Ruleset/RuleCraft.h"
 #include "SoldierInfoState.h"
 #include "SoldierMemorialState.h"
+#include "WoundedNoticeState.h"
 
 namespace OpenXcom
 {
@@ -227,6 +228,12 @@ namespace OpenXcom
 			return;
 		}
 
+		if (checkForWoundedSelectedSoldiers())
+		{
+			_game->pushState(new WoundedNoticeState);
+			return;
+		}
+
 		Craft *craftToAssign = 0;
 		Uint8 color = color = Palette::blockOffset(13) + 10;
 
@@ -264,7 +271,14 @@ namespace OpenXcom
 						tempCraft = crafts->at(_curCraftInList);
 
 						// TODO: Put in code to handle if ship is currently out (can't select those soldiers?).  Ditto for wounded soldiers.
-						// TODO: Test assigning soldiers to ship if the destination ship is out.
+
+						// if the craft is out, then we can't assign anyone to it; move along
+						if (tempCraft->getStatus() == "STR_OUT") 
+						{
+							continue;
+						}
+
+						// if there's room enough on the craft, make the assignment!
 						if (tempCraft->getSpaceAvailable() >= selectedSoldiers.size())
 						{
 							craftToAssign = tempCraft;
@@ -292,6 +306,28 @@ namespace OpenXcom
 			_lstSoldiers->setCellText(soldiersWithRows[(*it)], 2, craftName);
 			_lstSoldiers->setRowColor(soldiersWithRows[(*it)], color);
 		}
+	}
+
+	/**
+	  * Checks to see if any of the selected soldiers are wounded.
+	  * @return bool Returns true iff at least one of the selected soldiers is wounded.
+	  */
+	bool SoldiersState::checkForWoundedSelectedSoldiers()
+	{
+		bool haveWoundedSoldiers = false;
+
+		std::vector<Soldier*> selectedSoldiers = getSelectedSoldiers();
+
+		for (std::vector<Soldier*>::iterator it = selectedSoldiers.begin(); it != selectedSoldiers.end(); ++it)
+		{
+			if ((*it)->getWoundRecovery() != 0)
+			{
+				haveWoundedSoldiers = true;
+				break;
+			}
+		}
+
+		return haveWoundedSoldiers;
 	}
 
 	/**

--- a/src/Basescape/SoldiersState.cpp
+++ b/src/Basescape/SoldiersState.cpp
@@ -17,6 +17,7 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "SoldiersState.h"
+#include "../Engine/Action.h"
 #include <string>
 #include "../Engine/Game.h"
 #include "../Resource/ResourcePack.h"
@@ -38,157 +39,341 @@
 namespace OpenXcom
 {
 
-/**
- * Initializes all the elements in the Soldiers screen.
- * @param game Pointer to the core game.
- * @param base Pointer to the base to get info from.
- */
-SoldiersState::SoldiersState(Base *base) : _base(base)
-{
-	bool isPsiBtnVisible = Options::anytimePsiTraining && _base->getAvailablePsiLabs() > 0;
-
-	// Create objects
-	_window = new Window(this, 320, 200, 0, 0);
-	if (isPsiBtnVisible)
+	/**
+	 * Initializes all the elements in the Soldiers screen.
+	 * @param game Pointer to the core game.
+	 * @param base Pointer to the base to get info from.
+	 */
+	SoldiersState::SoldiersState(Base *base) : _base(base), _curCraftInList(-2)
 	{
-		_btnOk = new TextButton(96, 16, 216, 176);
-		_btnPsiTraining = new TextButton(96, 16, 112, 176);
-		_btnMemorial = new TextButton(96, 16, 8, 176);
-	}
-	else
-	{
-		_btnOk = new TextButton(148, 16, 164, 176);
-		_btnPsiTraining = new TextButton(148, 16, 164, 176);
-		_btnMemorial = new TextButton(148, 16, 8, 176);
-	}
-	_txtTitle = new Text(310, 17, 5, 8);
-	_txtName = new Text(114, 9, 16, 32);
-	_txtRank = new Text(102, 9, 130, 32);
-	_txtCraft = new Text(82, 9, 222, 32);
-	_lstSoldiers = new TextList(288, 128, 8, 40);
+		bool isPsiBtnVisible = Options::anytimePsiTraining && _base->getAvailablePsiLabs() > 0;
 
-	// Set palette
-	setPalette("PAL_BASESCAPE", 2);
-
-	add(_window);
-	add(_btnOk);
-	add(_btnPsiTraining);
-	add(_btnMemorial);
-	add(_txtTitle);
-	add(_txtName);
-	add(_txtRank);
-	add(_txtCraft);
-	add(_lstSoldiers);
-
-	centerAllSurfaces();
-
-	// Set up objects
-	_window->setColor(Palette::blockOffset(15)+1);
-	_window->setBackground(_game->getResourcePack()->getSurface("BACK02.SCR"));
-
-	_btnOk->setColor(Palette::blockOffset(13)+10);
-	_btnOk->setText(tr("STR_OK"));
-	_btnOk->onMouseClick((ActionHandler)&SoldiersState::btnOkClick);
-	_btnOk->onKeyboardPress((ActionHandler)&SoldiersState::btnOkClick, Options::keyCancel);
-
-	_btnPsiTraining->setColor(Palette::blockOffset(13)+10);
-	_btnPsiTraining->setText(tr("STR_PSIONIC_TRAINING"));
-	_btnPsiTraining->onMouseClick((ActionHandler)&SoldiersState::btnPsiTrainingClick);
-	_btnPsiTraining->setVisible(isPsiBtnVisible);
-
-	_btnMemorial->setColor(Palette::blockOffset(13)+10);
-	_btnMemorial->setText(tr("STR_MEMORIAL"));
-	_btnMemorial->onMouseClick((ActionHandler)&SoldiersState::btnMemorialClick);
-
-	_txtTitle->setColor(Palette::blockOffset(13)+10);
-	_txtTitle->setBig();
-	_txtTitle->setAlign(ALIGN_CENTER);
-	_txtTitle->setText(tr("STR_SOLDIER_LIST"));
-
-	_txtName->setColor(Palette::blockOffset(15)+1);
-	_txtName->setText(tr("STR_NAME_UC"));
-
-	_txtRank->setColor(Palette::blockOffset(15)+1);
-	_txtRank->setText(tr("STR_RANK"));
-
-	_txtCraft->setColor(Palette::blockOffset(15)+1);
-	_txtCraft->setText(tr("STR_CRAFT"));
-
-	_lstSoldiers->setColor(Palette::blockOffset(13)+10);
-	_lstSoldiers->setArrowColor(Palette::blockOffset(15)+1);
-	_lstSoldiers->setColumns(3, 114, 92, 74);
-	_lstSoldiers->setSelectable(true);
-	_lstSoldiers->setBackground(_window);
-	_lstSoldiers->setMargin(8);
-	_lstSoldiers->onMouseClick((ActionHandler)&SoldiersState::lstSoldiersClick);
-}
-
-/**
- *
- */
-SoldiersState::~SoldiersState()
-{
-
-}
-
-/**
- * Updates the soldiers list
- * after going to other screens.
- */
-void SoldiersState::init()
-{
-	State::init();
-	unsigned int row = 0;
-	_lstSoldiers->clearList();
-	for (std::vector<Soldier*>::iterator i = _base->getSoldiers()->begin(); i != _base->getSoldiers()->end(); ++i)
-	{
-		_lstSoldiers->addRow(3, (*i)->getName(true).c_str(), tr((*i)->getRankString()).c_str(), (*i)->getCraftString(_game->getLanguage()).c_str());
-		if ((*i)->getCraft() == 0)
+		// Create objects
+		_window = new Window(this, 320, 200, 0, 0);
+		if (isPsiBtnVisible)
 		{
-			_lstSoldiers->setRowColor(row, Palette::blockOffset(15)+6);
+			_btnOk = new TextButton(96, 16, 216, 176);
+			_btnPsiTraining = new TextButton(96, 16, 112, 176);
+			_btnMemorial = new TextButton(96, 16, 8, 176);
 		}
-		row++;
+		else
+		{
+			_btnOk = new TextButton(148, 16, 164, 176);
+			_btnPsiTraining = new TextButton(148, 16, 164, 176);
+			_btnMemorial = new TextButton(148, 16, 8, 176);
+		}
+		_txtTitle = new Text(310, 17, 5, 8);
+		_txtName = new Text(114, 9, 16, 32);
+		_txtRank = new Text(102, 9, 130, 32);
+		_txtCraft = new Text(82, 9, 222, 32);
+		_lstSoldiers = new TextList(288, 128, 8, 40);
+
+		// Set palette
+		setPalette("PAL_BASESCAPE", 2);
+
+		add(_window);
+		add(_btnOk);
+		add(_btnPsiTraining);
+		add(_btnMemorial);
+		add(_txtTitle);
+		add(_txtName);
+		add(_txtRank);
+		add(_txtCraft);
+		add(_lstSoldiers);
+
+		centerAllSurfaces();
+
+		// Set up objects
+		_window->setColor(Palette::blockOffset(15) + 1);
+		_window->setBackground(_game->getResourcePack()->getSurface("BACK02.SCR"));
+
+		_btnOk->setColor(Palette::blockOffset(13) + 10);
+		_btnOk->setText(tr("STR_OK"));
+		_btnOk->onMouseClick((ActionHandler)&SoldiersState::btnOkClick);
+		_btnOk->onKeyboardPress((ActionHandler)&SoldiersState::btnOkClick, Options::keyCancel);
+
+		_btnPsiTraining->setColor(Palette::blockOffset(13) + 10);
+		_btnPsiTraining->setText(tr("STR_PSIONIC_TRAINING"));
+		_btnPsiTraining->onMouseClick((ActionHandler)&SoldiersState::btnPsiTrainingClick);
+		_btnPsiTraining->setVisible(isPsiBtnVisible);
+
+		_btnMemorial->setColor(Palette::blockOffset(13) + 10);
+		_btnMemorial->setText(tr("STR_MEMORIAL"));
+		_btnMemorial->onMouseClick((ActionHandler)&SoldiersState::btnMemorialClick);
+
+		_txtTitle->setColor(Palette::blockOffset(13) + 10);
+		_txtTitle->setBig();
+		_txtTitle->setAlign(ALIGN_CENTER);
+		_txtTitle->setText(tr("STR_SOLDIER_LIST"));
+
+		_txtName->setColor(Palette::blockOffset(15) + 1);
+		_txtName->setText(tr("STR_NAME_UC"));
+
+		_txtRank->setColor(Palette::blockOffset(15) + 1);
+		_txtRank->setText(tr("STR_RANK"));
+
+		_txtCraft->setColor(Palette::blockOffset(15) + 1);
+		_txtCraft->setText(tr("STR_CRAFT"));
+
+		_lstSoldiers->setColor(Palette::blockOffset(13) + 10);
+		_lstSoldiers->setArrowColor(Palette::blockOffset(15) + 1);
+		_lstSoldiers->setColumns(3, 114, 92, 74);
+		_lstSoldiers->setMultiSelectable(true);
+		_lstSoldiers->setBackground(_window);
+		_lstSoldiers->setMargin(8);
+		_lstSoldiers->onMouseClick((ActionHandler)&SoldiersState::lstSoldiersClick);
 	}
-	if (row > 0 && _lstSoldiers->getScroll() >= row)
+
+	/**
+	 *
+	 */
+	SoldiersState::~SoldiersState()
 	{
-		_lstSoldiers->scrollTo(0);
+
 	}
-}
 
-/**
- * Returns to the previous screen.
- * @param action Pointer to an action.
- */
-void SoldiersState::btnOkClick(Action *)
-{
-	_game->popState();
-}
+	/**
+	 * Updates the soldiers list
+	 * after going to other screens.
+	 */
+	void SoldiersState::init()
+	{
+		State::init();
+		unsigned int row = 0;
+		_lstSoldiers->clearList();
+		for (std::vector<Soldier*>::iterator i = _base->getSoldiers()->begin(); i != _base->getSoldiers()->end(); ++i)
+		{
+			_lstSoldiers->addRow(3, (*i)->getName(true).c_str(), tr((*i)->getRankString()).c_str(), (*i)->getCraftString(_game->getLanguage()).c_str());
+			if ((*i)->getCraft() == 0)
+			{
+				_lstSoldiers->setRowColor(row, Palette::blockOffset(15) + 6);
+			}
+			row++;
+		}
+		if (row > 0 && _lstSoldiers->getScroll() >= row)
+		{
+			_lstSoldiers->scrollTo(0);
+		}
+	}
 
-/**
- * Opens the Psionic Training screen.
- * @param action Pointer to an action.
- */
-void SoldiersState::btnPsiTrainingClick(Action *)
-{
-	_game->pushState(new AllocatePsiTrainingState(_base));
-}
+	/**
+	 * Returns to the previous screen.
+	 * @param action Pointer to an action.
+	 */
+	void SoldiersState::btnOkClick(Action *)
+	{
+		_game->popState();
+	}
 
-/**
- * Opens the Memorial screen.
- * @param action Pointer to an action.
- */
-void SoldiersState::btnMemorialClick(Action *)
-{
-	_game->pushState(new SoldierMemorialState);
-}
+	/**
+	 * Opens the Psionic Training screen.
+	 * @param action Pointer to an action.
+	 */
+	void SoldiersState::btnPsiTrainingClick(Action *)
+	{
+		_game->pushState(new AllocatePsiTrainingState(_base));
+	}
 
-/**
- * Shows the selected soldier's info.
- * @param action Pointer to an action.
- */
-void SoldiersState::lstSoldiersClick(Action *)
-{
-	_game->pushState(new SoldierInfoState(_base, _lstSoldiers->getSelectedRow()));
-}
+	/**
+	 * Opens the Memorial screen.
+	 * @param action Pointer to an action.
+	 */
+	void SoldiersState::btnMemorialClick(Action *)
+	{
+		_game->pushState(new SoldierMemorialState);
+	}
 
+	/**
+	 * Shows the selected soldier's info.
+	 * @param action Pointer to an action.
+	 */
+	void SoldiersState::lstSoldiersClick(Action *action)
+	{
+		if (action->getDetails()->button.button == SDL_BUTTON_LEFT)
+		{
+			// only edit a soldier's info if there are currently no soldiers in "multi-select"
+			if (_lstSoldiers->getNumSelectedRows() == 0)
+			{
+				_game->pushState(new SoldierInfoState(_base, _lstSoldiers->getSelectedRow()));
+			}
+			else
+			{
+				changeCraft();
+			}
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
+		{
+			// reset the group craft list index
+			_curCraftInList = -2;
+		}
+	}
+
+	/**
+	  * Updates the selected soldiers' assigned craft by cycling through the available ships with each call.
+	  */
+	void SoldiersState::changeCraft()
+	{
+		std::vector<Craft*> *crafts = _base->getCrafts();
+
+		if (crafts->empty())
+		{
+			return;
+		}
+
+		std::vector<Soldier*> selectedSoldiers = getSelectedSoldiers();
+
+		if (selectedSoldiers.empty())
+		{
+			return;
+		}
+
+		Craft *craftToAssign = 0;
+
+		if (checkSameCraftAssignments())
+		{
+			// move on to the next possible craft selection; if there's only 1, then remove the assignment
+			if (crafts->size() > 1)
+			{
+				Craft *tempCraft = 0;
+				
+				// if this is the first time iterating through the list for this group, set it up
+				if (_curCraftInList == -2)
+				{
+					tempCraft = (*selectedSoldiers.begin())->getCraft();
+					_curCraftInList = findCraftAmongstAllCrafts(tempCraft);
+				}
+
+				bool done = false;
+
+				// loop through until we find a desirable craft to assign
+				while (!done)
+				{
+					_curCraftInList++;
+
+					// assign to "NONE" if we've reached the end of the list
+					if (_curCraftInList == crafts->size())
+					{
+						_curCraftInList = -1;
+						craftToAssign = 0;
+						done = true;
+					}
+					else
+					{
+						tempCraft = crafts->at(_curCraftInList);
+
+						// TODO: Put in code to handle if ship is currently out (can't select those soldiers?).  Ditto for wounded soldiers.
+						// TODO: Test assigning soldiers to ship if the destination ship is out.
+						if (tempCraft->getSpaceAvailable() >= selectedSoldiers.size())
+						{
+							craftToAssign = tempCraft;
+							done = true;
+						}
+					}
+				}
+			}
+		}
+		else
+		{
+			// find the first craft for the selected soldiers and assign it to all selected soldiers
+			craftToAssign = (*selectedSoldiers.begin())->getCraft();
+			_curCraftInList = findCraftAmongstAllCrafts(craftToAssign);
+		}
+
+		std::map<Soldier*, size_t> soldiersWithRows = getSelectedSoldiersWithRows();
+		std::wstring craftName = (craftToAssign == 0 ? tr("STR_NONE_UC") : craftToAssign->getName(_game->getLanguage()));
+
+		for (std::vector<Soldier*>::iterator it = selectedSoldiers.begin(); it != selectedSoldiers.end(); ++it)
+		{
+			(*it)->setCraft(craftToAssign);
+			_lstSoldiers->setCellText(soldiersWithRows[(*it)], 2, craftName);
+		}
+	}
+
+	/**
+	  * Finds the passed-in craft amongst the overall crafts.
+	  * @param craft The craft to find.
+	  * @return int Returns the index in the vector if craft is found; -1 otherwise.
+	  */
+	int SoldiersState::findCraftAmongstAllCrafts(Craft *craft)
+	{
+		int index = -1;
+
+		std::vector<Craft*> *crafts = _base->getCrafts();
+
+		if (crafts->empty())
+		{
+			return index;
+		}
+
+		for (int i = 0; i < crafts->size(); ++i)
+		{			
+			if (crafts->at(i) == craft)
+			{
+				index = i;
+				break;
+			}
+		}
+
+		return index;
+	}
+
+	/**
+	  * Check if all selected soldiers are on the same craft.
+	  * @return bool True iff all selected soldiers belong to the same craft.
+	  */
+	bool SoldiersState::checkSameCraftAssignments()
+	{
+		std::vector<Soldier*> selectedSoldiers = getSelectedSoldiers();
+		bool allSame = true;
+
+		if (selectedSoldiers.size() > 1)
+		{
+			Craft *craft = (*selectedSoldiers.begin())->getCraft();
+
+			for (std::vector<Soldier*>::iterator it = ++(selectedSoldiers.begin()); it != selectedSoldiers.end(); ++it)
+			{
+				if ((*it)->getCraft() != craft)
+				{
+					allSame = false;
+					break;
+				}
+			}			
+		}
+		
+		return allSame;
+	}
+
+	/**
+	  * Sends back a vector of all soldiers corresponding to the selections made in the list.
+	  * @return std::vector<Soldier*> Vector of all selected soldiers.
+	  */
+	std::vector<Soldier*> SoldiersState::getSelectedSoldiers()
+	{
+		std::vector<Soldier*> selectedSoldiers;
+		std::vector<size_t> selectedRows = _lstSoldiers->getSelectedRows();
+
+		for (std::vector<size_t>::iterator it = selectedRows.begin(); it != selectedRows.end(); ++it)
+		{
+			selectedSoldiers.push_back(_base->getSoldiers()->at(*it));
+		}
+		
+		return selectedSoldiers;
+	}
+
+	/**
+	* Sends back a map of all soldiers with associated row numbers corresponding to the selections made in the list.
+	* @return std::map<Soldier*, size_t> Map of all selected soldiers along with respective row numbers.
+	*/
+	std::map<Soldier*, size_t> SoldiersState::getSelectedSoldiersWithRows()
+	{
+		std::map<Soldier*, size_t> selectedSoldiers;
+		std::vector<size_t> selectedRows = _lstSoldiers->getSelectedRows();
+
+		for (std::vector<size_t>::iterator it = selectedRows.begin(); it != selectedRows.end(); ++it)
+		{
+			selectedSoldiers[_base->getSoldiers()->at(*it)] = *it;
+		}
+
+		return selectedSoldiers;
+	}
 }

--- a/src/Basescape/SoldiersState.cpp
+++ b/src/Basescape/SoldiersState.cpp
@@ -228,11 +228,12 @@ namespace OpenXcom
 		}
 
 		Craft *craftToAssign = 0;
+		Uint8 color = color = Palette::blockOffset(13) + 10;
 
 		if (checkSameCraftAssignments())
 		{
-			// move on to the next possible craft selection; if there's only 1, then remove the assignment
-			if (crafts->size() > 1)
+			// move on to the next possible craft selection
+			if (crafts->size() > 0)
 			{
 				Craft *tempCraft = 0;
 				
@@ -255,6 +256,7 @@ namespace OpenXcom
 					{
 						_curCraftInList = -1;
 						craftToAssign = 0;
+						color = Palette::blockOffset(15) + 6;
 						done = true;
 					}
 					else
@@ -266,6 +268,7 @@ namespace OpenXcom
 						if (tempCraft->getSpaceAvailable() >= selectedSoldiers.size())
 						{
 							craftToAssign = tempCraft;
+							color = Palette::blockOffset(13) + 10;
 							done = true;
 						}
 					}
@@ -277,6 +280,7 @@ namespace OpenXcom
 			// find the first craft for the selected soldiers and assign it to all selected soldiers
 			craftToAssign = (*selectedSoldiers.begin())->getCraft();
 			_curCraftInList = findCraftAmongstAllCrafts(craftToAssign);
+			color = Palette::blockOffset(13) + 10;
 		}
 
 		std::map<Soldier*, size_t> soldiersWithRows = getSelectedSoldiersWithRows();
@@ -286,6 +290,7 @@ namespace OpenXcom
 		{
 			(*it)->setCraft(craftToAssign);
 			_lstSoldiers->setCellText(soldiersWithRows[(*it)], 2, craftName);
+			_lstSoldiers->setRowColor(soldiersWithRows[(*it)], color);
 		}
 	}
 

--- a/src/Basescape/SoldiersState.h
+++ b/src/Basescape/SoldiersState.h
@@ -57,6 +57,8 @@ private:
 	std::map<Soldier*, size_t> getSelectedSoldiersWithRows();
 	/// Find the passed-in craft amongst the overall crafts.
 	int findCraftAmongstAllCrafts(Craft *craft);
+	/// Check if any of the selected soldiers are wounded.
+	bool checkForWoundedSelectedSoldiers();
 public:
 	/// Creates the Soldiers state.
 	SoldiersState(Base *base);

--- a/src/Basescape/SoldiersState.h
+++ b/src/Basescape/SoldiersState.h
@@ -20,6 +20,7 @@
 #define OPENXCOM_SOLDIERSSTATE_H
 
 #include "../Engine/State.h"
+#include <map>
 
 namespace OpenXcom
 {
@@ -29,6 +30,8 @@ class Window;
 class Text;
 class TextList;
 class Base;
+class Soldier;
+class Craft;
 
 /**
  * Soldiers screen that lets the player
@@ -42,6 +45,18 @@ private:
 	Text *_txtTitle, *_txtName, *_txtRank, *_txtCraft;
 	TextList *_lstSoldiers;
 	Base *_base;
+	int _curCraftInList;
+
+	/// Updates the selected soldiers' assigned craft.
+	void changeCraft();
+	/// Check if all selected soldiers are on the same craft.
+	bool checkSameCraftAssignments();
+	/// Returns a vector of pointers to all selected soldiers.
+	std::vector<Soldier*> getSelectedSoldiers();
+	/// Return a map of all soldiers with associated row numbers corresponding to the selections made in the list.
+	std::map<Soldier*, size_t> getSelectedSoldiersWithRows();
+	/// Find the passed-in craft amongst the overall crafts.
+	int findCraftAmongstAllCrafts(Craft *craft);
 public:
 	/// Creates the Soldiers state.
 	SoldiersState(Base *base);

--- a/src/Basescape/SoldiersState.h
+++ b/src/Basescape/SoldiersState.h
@@ -47,6 +47,8 @@ private:
 	Base *_base;
 	int _curCraftInList;
 
+	const int CRAFT_LIST_INDEX_INIT = -2;
+
 	/// Updates the selected soldiers' assigned craft.
 	void changeCraft();
 	/// Check if all selected soldiers are on the same craft.

--- a/src/Basescape/WoundedNoticeState.cpp
+++ b/src/Basescape/WoundedNoticeState.cpp
@@ -1,0 +1,90 @@
+/*
+* Copyright 2010-2014 OpenXcom Developers.
+*
+* This file is part of OpenXcom.
+*
+* OpenXcom is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* OpenXcom is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "WoundedNoticeState.h"
+#include "../Engine/Game.h"
+#include "../Resource/ResourcePack.h"
+#include "../Engine/Language.h"
+#include "../Engine/Palette.h"
+#include "../Engine/Options.h"
+#include "../Interface/TextButton.h"
+#include "../Interface/Window.h"
+#include "../Interface/Text.h"
+#include "../Savegame/Base.h"
+
+namespace OpenXcom
+{
+
+	/**
+	 * Initializes all the elements in the Wounded Notice window.
+	 * @param base Pointer to the destination base.
+	 */
+	WoundedNoticeState::WoundedNoticeState()
+	{
+		_screen = false;
+
+		// Create objects
+		_window = new Window(this, 250, 100, 30, 50);
+		_btnOk = new TextButton(50, 16, 130, 118);
+		_txtTitle = new Text(160, 17, 75, 70);
+		_txtNotice = new Text(210, 17, 50, 90);
+
+		// Set palette
+		setPalette("PAL_BASESCAPE", 2);
+
+		add(_window);
+		add(_btnOk);
+		add(_txtTitle);
+		add(_txtNotice);
+
+		centerAllSurfaces();
+
+		// Set up objects
+		_window->setColor(Palette::blockOffset(15) + 1);
+		_window->setBackground(_game->getResourcePack()->getSurface("BACK02.SCR"));
+
+		_btnOk->setColor(Palette::blockOffset(13) + 10);
+		_btnOk->setText(tr("STR_OK"));
+		_btnOk->onMouseClick((ActionHandler)&WoundedNoticeState::btnOkClick);
+		_btnOk->onKeyboardPress((ActionHandler)&WoundedNoticeState::btnOkClick, Options::keyOk);
+
+		_txtTitle->setColor(Palette::blockOffset(13) + 10);
+		_txtTitle->setBig();
+		_txtTitle->setAlign(ALIGN_CENTER);
+		_txtTitle->setText(tr("STR_WOUNDED_SOLDIER_TITLE"));
+
+		_txtNotice->setColor(Palette::blockOffset(15) + 1);
+		_txtNotice->setText(tr("STR_WOUNDED_SOLDIER_NOTICE"));
+	}
+
+	/**
+	 *
+	 */
+	WoundedNoticeState::~WoundedNoticeState()
+	{
+	}
+
+	/**
+	 * Dismisses the notice.
+	 * @param action Pointer to an action.
+	 */
+	void WoundedNoticeState::btnOkClick(Action *)
+	{
+		_game->popState();
+	}
+}

--- a/src/Basescape/WoundedNoticeState.h
+++ b/src/Basescape/WoundedNoticeState.h
@@ -1,0 +1,54 @@
+/*
+* Copyright 2010-2014 OpenXcom Developers.
+*
+* This file is part of OpenXcom.
+*
+* OpenXcom is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* OpenXcom is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPENXCOM_WOUNDEDNOTICE_H
+#define OPENXCOM_WOUNDEDNOTICE_H
+
+#include "../Engine/State.h"
+
+namespace OpenXcom
+{
+
+	class TextButton;
+	class Window;
+	class Text;
+	class Base;
+
+	/**
+	* Window to notify the player that wounded soldiers are trying to be used illegally.
+	*/
+	class WoundedNoticeState : public State
+	{
+	private:
+		TextButton *_btnOk;
+		Window *_window;
+		Text *_txtTitle, *_txtNotice;
+		Base *_base;
+
+	public:
+		/// Creates the Wounded Notice state.
+		WoundedNoticeState();
+		/// Cleans up the Wounded Notice state.
+		~WoundedNoticeState();
+		/// Handler for clicking the OK button.
+		void btnOkClick(Action *action);
+	};
+
+}
+
+#endif

--- a/src/Interface/TextList.cpp
+++ b/src/Interface/TextList.cpp
@@ -38,7 +38,7 @@ namespace OpenXcom
  * @param x X position in pixels.
  * @param y Y position in pixels.
  */
-TextList::TextList(int width, int height, int x, int y) : InteractiveSurface(width, height, x, y), _big(0), _small(0), _font(0), _scroll(0), _visibleRows(0), _selRow(0), _color(0), _dot(false), _selectable(false), _condensed(false), _contrast(false), _wrap(false),
+TextList::TextList(int width, int height, int x, int y) : InteractiveSurface(width, height, x, y), _big(0), _small(0), _font(0), _scroll(0), _visibleRows(0), _selRow(0), _color(0), _dot(false), _selectable(false), _multiSelectable(false), _condensed(false), _contrast(false), _wrap(false),
 																								   _bg(0), _selector(0), _margin(0), _scrolling(true), _arrowPos(-1), _scrollPos(4), _arrowType(ARROW_VERTICAL),
 																								   _leftClick(0), _leftPress(0), _leftRelease(0), _rightClick(0), _rightPress(0), _rightRelease(0), _arrowsLeftEdge(0), _arrowsRightEdge(0), _comboBox(0), _numSelectedRows(0), _shiftSelect(false), _lastRowSelected(-1)
 {

--- a/src/Interface/TextList.cpp
+++ b/src/Interface/TextList.cpp
@@ -635,16 +635,19 @@ unsigned int TextList::getSelectedRow() const
 * list is selectable or multi-selectable.
 * @return Selected row, -1 if none.
 */
-unsigned int TextList::getSelectedRows() const
+std::vector<size_t> TextList::getSelectedRows()
 {
-	if (_rows.empty() || _selRow >= _rows.size())
-	{
-		return -1;
+	std::vector<size_t> rows;
+
+	if (!_rows.empty() && _numSelectedRows > 0)
+	{		
+		for (std::map<size_t, Surface*>::iterator i = _selRows.begin(); i != _selRows.end(); ++i)
+		{
+			rows.push_back(i->first);
+		}		
 	}
-	else
-	{
-		return _rows[_selRow];
-	}
+
+	return rows;
 }
 
 /**

--- a/src/Interface/TextList.cpp
+++ b/src/Interface/TextList.cpp
@@ -40,7 +40,7 @@ namespace OpenXcom
  */
 TextList::TextList(int width, int height, int x, int y) : InteractiveSurface(width, height, x, y), _big(0), _small(0), _font(0), _scroll(0), _visibleRows(0), _selRow(0), _color(0), _dot(false), _selectable(false), _condensed(false), _contrast(false), _wrap(false),
 																								   _bg(0), _selector(0), _margin(0), _scrolling(true), _arrowPos(-1), _scrollPos(4), _arrowType(ARROW_VERTICAL),
-																								   _leftClick(0), _leftPress(0), _leftRelease(0), _rightClick(0), _rightPress(0), _rightRelease(0), _arrowsLeftEdge(0), _arrowsRightEdge(0), _comboBox(0)
+																								   _leftClick(0), _leftPress(0), _leftRelease(0), _rightClick(0), _rightPress(0), _rightRelease(0), _arrowsLeftEdge(0), _arrowsRightEdge(0), _comboBox(0), _numSelectedRows(0), _shiftSelect(false), _lastRowSelected(-1)
 {
 	_up = new ArrowButton(ARROW_BIG_UP, 13, 14, getX() + getWidth() + _scrollPos, getY());
 	_up->setVisible(false);
@@ -74,6 +74,11 @@ TextList::~TextList()
 	{
 		delete *i;
 	}
+	for (std::map<size_t, Surface*>::iterator i = _selRows.begin(); i != _selRows.end(); ++i)
+	{
+		delete i->second;
+	}
+	
 	delete _selector;
 	delete _up;
 	delete _down;
@@ -559,6 +564,16 @@ void TextList::setSelectable(bool selectable)
 }
 
 /**
+* If enabled, the list will respond to player input,
+* highlighting selected rows and receiving clicks.
+* @param multiSelectable Multi-selectable setting.
+*/
+void TextList::setMultiSelectable(bool multiSelectable)
+{
+	_multiSelectable = multiSelectable;
+}
+
+/**
  * Changes the text list to use the big-size font.
  */
 void TextList::setBig()
@@ -613,6 +628,32 @@ unsigned int TextList::getSelectedRow() const
 	{
 		return _rows[_selRow];
 	}
+}
+
+/**
+* Returns the currently selected rows if the text
+* list is selectable or multi-selectable.
+* @return Selected row, -1 if none.
+*/
+unsigned int TextList::getSelectedRows() const
+{
+	if (_rows.empty() || _selRow >= _rows.size())
+	{
+		return -1;
+	}
+	else
+	{
+		return _rows[_selRow];
+	}
+}
+
+/**
+  * Returns the number of currently selected rows.
+  @ return Number of selected rows.
+  */
+unsigned int TextList::getNumSelectedRows() const
+{
+	return _numSelectedRows;
 }
 
 /**
@@ -906,6 +947,12 @@ void TextList::blit(Surface *surface)
 	if (_visible && !_hidden)
 	{
 		_selector->blit(surface);
+
+		for (std::map<size_t, Surface*>::iterator i = _selRows.begin(); i != _selRows.end(); ++i)
+		{
+			buildRowSelector(i->second, i->first);
+			i->second->blit(surface);
+		}
 	}
 	Surface::blit(surface);
 	if (_visible && !_hidden)
@@ -1020,7 +1067,7 @@ void TextList::mouseRelease(Action *action, State *state)
 }
 
 /**
- * Ignores any mouse clicks that aren't on a row.
+ * Ignores any mouse clicks that aren't on a row.  Multi-select does not apply to combo boxes.
  * @param action Pointer to an action.
  * @param state State that the action handlers belong to.
  */
@@ -1038,6 +1085,57 @@ void TextList::mouseClick(Action *action, State *state)
 			}
 		}
 	}
+	else if (_multiSelectable && action->getDetails()->button.button == SDL_BUTTON_RIGHT)
+	{
+		int h = _font->getHeight() + _font->getSpacing();
+		size_t rowSel = std::max(0, (int)(_scroll + (int)floor(action->getRelativeYMouse() / (h * action->getYScale()))));
+
+		// continguous select; overrides current selection
+		if (_shiftSelect)
+		{
+			for (std::map<size_t, Surface*>::iterator i = _selRows.begin(); i != _selRows.end(); ++i)
+			{
+				delete i->second;
+			}
+
+			size_t startRow = 0;
+
+			// if we already have items here, grab the start row as the last row that was selected
+			if (_lastRowSelected > -1)
+			{
+				startRow = _lastRowSelected;
+			}
+
+			_selRows.clear();
+
+			size_t startIndex = std::min(startRow, rowSel);
+			size_t endIndex = std::max(startRow, rowSel);
+
+			for (size_t i = startIndex; i <= endIndex; ++i)
+			{
+				_selRows[i] = new Surface(*_selector);
+				buildRowSelector(_selRows[i], i);
+				++_numSelectedRows;
+			}
+		}
+		else
+		{
+			// if the row was already selected, deselect it; otherwise, add it to the selection set
+			std::map<size_t, Surface*>::iterator it;
+			if ((it = _selRows.find(rowSel)) != _selRows.end())
+			{
+				delete it->second;
+				_selRows.erase(it);
+				--_numSelectedRows;
+			}
+			else
+			{
+				_selRows[rowSel] = new Surface(*_selector);
+				_lastRowSelected = rowSel;
+				++_numSelectedRows;
+			}
+		}
+	}
 	else
 	{
 		InteractiveSurface::mouseClick(action, state);
@@ -1051,53 +1149,113 @@ void TextList::mouseClick(Action *action, State *state)
  */
 void TextList::mouseOver(Action *action, State *state)
 {
-	if (_selectable)
+	if (_selectable || _multiSelectable)
 	{
 		int h = _font->getHeight() + _font->getSpacing();
 		_selRow = std::max(0, (int)(_scroll + (int)floor(action->getRelativeYMouse() / (h * action->getYScale()))));
-		if (_selRow < _rows.size())
-		{
-			Text *selText = _texts[_rows[_selRow]].front();
-			int y = getY() + selText->getY();
-			int h = selText->getHeight() + _font->getSpacing();
-			if (y < getY() || y + h > getY() + getHeight())
-			{
-				h /= 2;
-			}
-			if (y < getY())
-			{
-				y = getY();
-			}
-			if (_selector->getHeight() != h)
-			{
-				// resizing doesn't work, but recreating does, so let's do that!
-				delete _selector;
-				_selector = new Surface(getWidth(), h, getX(), y);
-				_selector->setPalette(getPalette());
-			}
-			_selector->setY(y);
-			_selector->copy(_bg);
-			if (_contrast)
-			{
-				_selector->offset(-10, 1);
-			}
-			else if (_comboBox)
-			{
-				_selector->offset(+1, Palette::backPos);
-			}
-			else
-			{
-				_selector->offset(-10, Palette::backPos);
-			}
-			_selector->setVisible(true);
-		}
-		else
-		{
-			_selector->setVisible(false);
-		}
+
+		buildRowSelector(_selector, _selRow);
 	}
 
 	InteractiveSurface::mouseOver(action, state);
+}
+
+/**
+  * Flags any keyboard input, mostly for multi-select.
+  * @param action Pointer to an action.
+  * @param state State that the action handlers belong to.
+  */
+void TextList::keyboardPress(Action *action, State *state)
+{
+	SDLKey key = action->getDetails()->key.keysym.sym;
+
+	if (key == SDLK_LSHIFT || key == SDLK_RSHIFT)
+	{
+		_shiftSelect = true;
+	}
+
+	InteractiveSurface::keyboardPress(action, state);
+}
+
+/**
+* Un-flags any keyboard input, mostly for multi-select.
+* @param action Pointer to an action.
+* @param state State that the action handlers belong to.
+*/
+void TextList::keyboardRelease(Action *action, State *state)
+{
+	SDLKey key = action->getDetails()->key.keysym.sym;
+
+	if (key == SDLK_LSHIFT || key == SDLK_RSHIFT)
+	{
+		_shiftSelect = false;
+	}
+
+	InteractiveSurface::keyboardRelease(action, state);
+}
+
+/**
+  * Builds a row selector, using the passed-in selector and the (absolute) row selection.
+  * @param selector Pointer to a valid selector surface.
+  * @param rowSel The absolute row position in the text list.
+  */
+void TextList::buildRowSelector(Surface *selector, size_t rowSel)
+{
+	if (rowSel < _rows.size())
+	{
+		Text *selText = _texts[_rows[rowSel]].front();
+		int y = getY() + selText->getY();
+		int h = selText->getHeight() + _font->getSpacing();
+		if (y < getY() || y + h > getY() + getHeight())
+		{
+			h /= 2;
+		}
+		if (y < getY())
+		{
+			y = getY();
+		}
+		if (selector->getHeight() != h)
+		{
+			// resizing doesn't work, but recreating does, so let's do that!
+			delete selector;
+			selector = new Surface(getWidth(), h, getX(), y);
+			selector->setPalette(getPalette());
+		}
+		selector->setY(y);
+		selector->copy(_bg);
+		if (_contrast)
+		{
+			selector->offset(-10, 1);
+		}
+		else if (_comboBox)
+		{
+			selector->offset(+1, Palette::backPos);
+		}
+		else
+		{
+			selector->offset(-10, Palette::backPos);
+		}
+
+		if (_multiSelectable)
+		{
+			if (rowSel >= _scroll && rowSel < (_scroll + _visibleRows))
+			{
+				selector->setVisible(true);
+			}
+			else
+			{
+				selector->setVisible(false);
+			}
+		}
+		else
+		{
+			selector->setVisible(true);
+		}
+	}
+	else
+	{
+		selector->setVisible(false);
+	}
 }
 
 /**

--- a/src/Interface/TextList.h
+++ b/src/Interface/TextList.h
@@ -46,10 +46,12 @@ private:
 	std::vector<size_t> _columns, _rows;
 	Font *_big, *_small, *_font;
 	Language *_lang;
-	size_t _scroll, _visibleRows, _selRow;
+	size_t _scroll, _visibleRows, _selRow, _numSelectedRows;
+	int _lastRowSelected;
+	std::map<size_t, Surface*> _selRows;
 	Uint8 _color, _color2;
 	std::map<int, TextHAlign> _align;
-	bool _dot, _selectable, _condensed, _contrast, _wrap;
+	bool _dot, _selectable, _multiSelectable, _condensed, _contrast, _wrap, _shiftSelect;
 	Surface *_bg, *_selector;
 	ArrowButton *_up, *_down;
 	ScrollBar *_scrollbar;
@@ -66,6 +68,8 @@ private:
 	void updateArrows();
 	/// Updates the visible rows.
 	void updateVisible();
+	/// Builds a row selector, using the passed-in selector and the (absolute) row selection.
+	void buildRowSelector(Surface *selector, size_t rowSel);
 public:
 	/// Creates a text list with the specified size and position.
 	TextList(int width, int height, int x = 0, int y = 0);
@@ -127,6 +131,8 @@ public:
 	void setDot(bool dot);
 	/// Sets whether the list is selectable.
 	void setSelectable(bool selectable);
+	/// Sets whether the list is multi-selectable (i.e. using ctrl+click and/or shift+click).
+	void setMultiSelectable(bool multiSelectable);
 	/// Sets the text size to big.
 	void setBig();
 	/// Sets the text size to small.
@@ -137,6 +143,10 @@ public:
 	void setBackground(Surface *bg);
 	/// Gets the selected row in the list.
 	unsigned int getSelectedRow() const;
+	/// Gets the selected rows in the list currently selected.
+	unsigned int getSelectedRows() const;
+	/// Gets the number of currently selected rows (most useful during multi-select).
+	unsigned int getNumSelectedRows() const;
 	/// Sets the margin of the text list.
 	void setMargin(int margin);
 	/// Gets the margin of the text list.
@@ -183,6 +193,10 @@ public:
 	void mouseOver(Action *action, State *state);
 	/// Special handling for mouse hovering out.
 	void mouseOut(Action *action, State *state);
+	/// Processes a keyboard key press event.
+	void keyboardPress(Action *action, State *state);
+	/// Processes a keyboard key release event.
+	void keyboardRelease(Action *action, State *state);	
 	/// get the scroll depth
 	size_t getScroll();
 	/// set the scroll depth

--- a/src/Interface/TextList.h
+++ b/src/Interface/TextList.h
@@ -144,7 +144,7 @@ public:
 	/// Gets the selected row in the list.
 	unsigned int getSelectedRow() const;
 	/// Gets the selected rows in the list currently selected.
-	unsigned int getSelectedRows() const;
+	std::vector<size_t> getSelectedRows();
 	/// Gets the number of currently selected rows (most useful during multi-select).
 	unsigned int getNumSelectedRows() const;
 	/// Sets the margin of the text list.


### PR DESCRIPTION
This works as follows:
- Right-clicking on one/more soldiers multi-selects the soldier(s), akin to Ctrl+click.
- Shift-right clicking selects a block of soldiers at once, starting from the most-recently selected soldier.
- After the above, left-clicking cycles through the available craft and assigns the soldiers if there's room.  If any of the soldiers are wounded, a warning appears and disallows the selected soldiers from being assigned.
- Crafts with no room or that are out at the moment are not considered for selection.
- If NO soldiers are currently selected via right-click, then left clicking will bring up a soldier's info screen as per normal.

This pull request also includes a change to the TextList class and allows for multi-selection by use of a new boolean flag.  Shift+right click block selection is built in, and right-clicking is akin to ctrl+clicking.

Looking forward to feedback/corrections/bugs/etc.
