### PR TITLE
fix typo in error checking code in MapBlock

### DIFF
--- a/src/Ruleset/MapBlock.cpp
+++ b/src/Ruleset/MapBlock.cpp
@@ -49,7 +49,7 @@ void MapBlock::load(const YAML::Node &node)
 	_size_x = node["width"].as<int>(_size_x);
 	_size_y = node["length"].as<int>(_size_y);
 	_size_z = node["height"].as<int>(_size_z);
-	if (_size_x & 10 != 0 || _size_y % 10 != 0)
+	if ((_size_x % 10) != 0 || (_size_y % 10) != 0)
 	{
 		std::stringstream ss;
 		ss << "MapBlock " << _name << ": Size must be divisible by ten";


### PR DESCRIPTION
Fixes what I appears to be a typo (& instead of % for determining divisibility) and clarifies operator precedence.

gcc-4.8.3 helped find this with the warning:
src/Ruleset/MapBlock.cpp:52:14: warning: & has lower precedence than !=; != will be evaluated first [-Wparentheses]
 if (_size_x & 10 != 0 || _size_y % 10 != 0)
             ^~~~~~~~~
src/Ruleset/MapBlock.cpp:52:14: note: place parentheses around the '!=' expression to silence this warning
 if (_size_x & 10 != 0 || _size_y % 10 != 0)
             ^
               (      )
src/Ruleset/MapBlock.cpp:52:14: note: place parentheses around the & expression to evaluate it first
 if (_size_x & 10 != 0 || _size_y % 10 != 0)
             ^
     (           )
