### PR TITLE
Cities zoom filter

### DIFF
--- a/src/Geoscape/Globe.cpp
+++ b/src/Geoscape/Globe.cpp
@@ -71,7 +71,7 @@ Uint8 Globe::oceanColor2 = Palette::blockOffset(13);
 
 namespace
 {
-	
+
 ///helper class for `Globe` for drawing earth globe with shadows
 struct GlobeStaticData
 {
@@ -79,7 +79,7 @@ struct GlobeStaticData
 	Sint16 shade_gradient[240];
 	///size of x & y of noise surface
 	const int random_surf_size;
-	
+
 	/**
 	 * Function returning normal vector of sphere surface
 	 * @param ox x cord of sphere center
@@ -112,8 +112,8 @@ struct GlobeStaticData
 			return ret;
 		}
 	}
-	
-	//initialization	
+
+	//initialization
 	GlobeStaticData() : random_surf_size(60)
 	{
 		//filling terminator gradient LUT
@@ -234,7 +234,7 @@ struct CreateShadow
 			}
 		}
 	}
-	
+
 	static inline void func(Uint8& dest, const Cord& earth, const Cord& sun, const Sint16& noise, const int&)
 	{
 		if (dest && earth.z)
@@ -285,7 +285,7 @@ Globe::Globe(Game* game, int cenX, int cenY, int width, int height, int x, int y
 	_cenLat = _game->getSavedGame()->getGlobeLatitude();
 	_zoom = _game->getSavedGame()->getGlobeZoom();
 	_zoomOld = _zoom;
-	
+
 	setupRadii(width, height);
 	setZoom(_zoom);
 
@@ -840,10 +840,10 @@ void Globe::cache(std::list<Polygon*> *polygons, std::list<Polygon*> *cache)
 void Globe::setPalette(SDL_Color *colors, int firstcolor, int ncolors)
 {
 	Surface::setPalette(colors, firstcolor, ncolors);
-	
+
 	_texture->setPalette(colors, firstcolor, ncolors);
 	_markerSet->setPalette(colors, firstcolor, ncolors);
-	
+
 	_countries->setPalette(colors, firstcolor, ncolors);
 	_markers->setPalette(colors, firstcolor, ncolors);
 	_radars->setPalette(colors, firstcolor, ncolors);
@@ -947,7 +947,7 @@ void Globe::drawLand()
 /**
  * Get position of sun from point on globe
  * @param lon longitude of position
- * @param lat latitude of position 
+ * @param lat latitude of position
  * @return position of sun
  */
 Cord Globe::getSunDirection(double lon, double lat) const
@@ -1004,13 +1004,13 @@ void Globe::drawShadow()
 {
 	ShaderMove<Cord> earth = ShaderMove<Cord>(_earthData[_zoom], getWidth(), getHeight());
 	ShaderRepeat<Sint16> noise = ShaderRepeat<Sint16>(_randomNoiseData, static_data.random_surf_size, static_data.random_surf_size);
-	
+
 	earth.setMove(_cenX-getWidth()/2, _cenY-getHeight()/2);
-	
+
 	lock();
 	ShaderDraw<CreateShadow>(ShaderSurface(this), earth, ShaderScalar(getSunDirection(_cenLon, _cenLat)), noise);
 	unlock();
-		
+
 }
 
 
@@ -1022,7 +1022,7 @@ void Globe::XuLine(Surface* surface, Surface* src, double x1, double y1, double 
 	bool inv;
 	Sint16 tcol;
 	double len,x0,y0,SX,SY;
-	if (abs((int)y2-(int)y1) > abs((int)x2-(int)x1)) 
+	if (abs((int)y2-(int)y1) > abs((int)x2-(int)x1))
 	{
 		len=abs((int)y2-(int)y1);
 		inv=false;
@@ -1033,7 +1033,7 @@ void Globe::XuLine(Surface* surface, Surface* src, double x1, double y1, double 
 		inv=true;
 	}
 
-	if (y2<y1) { 
+	if (y2<y1) {
 	SY=-1;
   } else if ( AreSame(deltay, 0.0) ) {
 	SY=0;
@@ -1139,7 +1139,7 @@ void Globe::drawRadars()
 
 				if (range>0) drawGlobeCircle(lat,lon,range,48);
 			}
-	
+
 		}
 
 		for (std::vector<Craft*>::iterator j = (*i)->getCrafts()->begin(); j != (*i)->getCrafts()->end(); ++j)
@@ -1338,10 +1338,13 @@ void Globe::drawDetail()
 				marker->setY(y - 1);
 				marker->blit(_countries);
 
-				label->setX(x - 40);
-				label->setY(y + 2);
-				label->setText(_game->getLanguage()->getString((*j)->getName()));
-				label->blit(_countries);
+				if (_zoom >= (*j)->getZoomLevel())
+				{
+					label->setX(x - 40);
+					label->setY(y + 2);
+					label->setText(_game->getLanguage()->getString((*j)->getName()));
+					label->blit(_countries);
+				}
 			}
 		}
 		// Draw bases names
@@ -1359,7 +1362,7 @@ void Globe::drawDetail()
 
 		delete label;
 	}
-	
+
 	static int debugType = 0;
 	static bool canSwitchDebugType = false;
 	if (_game->getSavedGame()->getDebugMode())
@@ -1500,7 +1503,7 @@ void Globe::drawFlights()
 			// Hide crafts docked at base
 			if ((*j)->getStatus() != "STR_OUT" || (*j)->getDestination() == 0 /*|| pointBack((*j)->getLongitude(), (*j)->getLatitude())*/)
 				continue;
-			
+
 			double lon1 = (*j)->getLongitude();
 			double lon2 = (*j)->getDestination()->getLongitude();
 			double lat1 = (*j)->getLatitude();
@@ -1722,7 +1725,7 @@ void Globe::mouseRelease(Action *action, State *state)
  * @param state State that the action handlers belong to.
  */
 void Globe::mouseClick(Action *action, State *state)
-{	
+{
 	if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
 	{
 		zoomIn();
@@ -1734,7 +1737,7 @@ void Globe::mouseClick(Action *action, State *state)
 
 	double lon, lat;
 	cartToPolar((Sint16)floor(action->getAbsoluteXMouse()), (Sint16)floor(action->getAbsoluteYMouse()), &lon, &lat);
-	
+
 	// The following is the workaround for a rare problem where sometimes
 	// the mouse-release event is missed for any reason.
 	// However if the SDL is also missed the release event, then it is to no avail :(

--- a/src/Ruleset/City.cpp
+++ b/src/Ruleset/City.cpp
@@ -29,7 +29,7 @@ namespace OpenXcom
  * @param lon Longitude of the city.
  * @param lat Latitude of the city.
  */
-City::City(const std::string &name, double lon, double lat): _name(name), _lon(lon), _lat(lat)
+City::City(const std::string &name, double lon, double lat): _name(name), _lon(lon), _lat(lat), _zoomLevel(3)
 {
 }
 
@@ -49,6 +49,7 @@ void City::load(const YAML::Node &node)
 	_name = node["name"].as<std::string>(_name);
 	_lon = node["lon"].as<double>(_lon) * M_PI / 180;
 	_lat = node["lat"].as<double>(_lat) * M_PI / 180;
+	_zoomLevel = node["zoom"].as<size_t>(_zoomLevel);
 }
 
 /**
@@ -76,6 +77,15 @@ double City::getLatitude() const
 double City::getLongitude() const
 {
 	return _lon;
+}
+
+/**
+ * Returns the the minimal zoom level that is required to show name of city on geoscape.
+ * @return The required zoom level.
+ */
+size_t City::getZoomLevel() const
+{
+	return _zoomLevel;
 }
 
 }

--- a/src/Ruleset/City.h
+++ b/src/Ruleset/City.h
@@ -34,6 +34,7 @@ class City
 private:
 	std::string _name;
 	double _lon, _lat;
+	size_t _zoomLevel;
 public:
 	/// Creates a new city at a certain position.
 	City(const std::string &name, double lon, double lat);
@@ -47,6 +48,8 @@ public:
 	double getLatitude() const;
 	/// Gets the city's longitude.
 	double getLongitude() const;
+	/// Gets the level of zoom that show city name.
+	size_t getZoomLevel() const;
 };
 
 }


### PR DESCRIPTION
Small patch adding removing mess if you have lot of cities.
Every city have now new property `zoom` (def val 3) that determine on what minimum zoom level is require to show name of that city.

As bonus, some rogue white space clean up.