### PR TITLE
Tftd video corrections.

### DIFF
--- a/bin/data/Ruleset/Xcom1Ruleset.rul
+++ b/bin/data/Ruleset/Xcom1Ruleset.rul
@@ -9323,7 +9323,7 @@ alienItemLevels:
 cutscenes:
   - type: intro
     videos:
-      - UFOINTRO\UFOINT.FLI
+      - UFOINTRO/UFOINT.FLI
 MCDPatches:
 # pathFinding Hacks.
 # bigWall 1 = regular bigwall, no movement allowed.

--- a/src/Engine/FlcPlayer.h
+++ b/src/Engine/FlcPlayer.h
@@ -68,7 +68,7 @@ private:
 	int _screenDepth;
 	int _dx, _dy;
 	int _offset;
-	bool _quit;
+	int _playingState;
 	bool _hasAudio;
 	int _videoDelay;
 
@@ -111,6 +111,7 @@ private:
 	void decodeAudio(int frames);
 	void waitForNextFrame(Uint32 delay);
 	void SDLPolling();
+	bool shouldQuit();
 
 	void playVideoFrame();
 	void color256();

--- a/src/Menu/IntroState.cpp
+++ b/src/Menu/IntroState.cpp
@@ -51,13 +51,19 @@ IntroState::IntroState(bool wasLetterBoxed) : _wasLetterBoxed(wasLetterBoxed)
 	const std::map<std::string, RuleVideo*> *videoRulesets = rules->getVideos();
 
 
-	const RuleVideo *videoRule = videoRulesets->find("intro")->second;
-	const std::vector<std::string> *videos = videoRule->getVideos();
+	std::map<std::string, RuleVideo*>::const_iterator videoRuleIt = videoRulesets->find("intro");
 
-	std::vector<std::string>::const_iterator it;
-	for(it = videos->begin(); it != videos->end(); ++it)
+	if(videoRuleIt != videoRulesets->end())
 	{
-		_introFiles.push_back(CrossPlatform::getDataFile(*it));
+		const RuleVideo *videoRule = videoRuleIt->second;
+
+		const std::vector<std::string> *videos = videoRule->getVideos();
+
+		std::vector<std::string>::const_iterator it;
+		for(it = videos->begin(); it != videos->end(); ++it)
+		{
+			_introFiles.push_back(CrossPlatform::getDataFile(*it));
+		}
 	}
 
 	_introSoundFileDOS = CrossPlatform::getDataFile("SOUND/INTRO.CAT");


### PR DESCRIPTION
Pressing a mouse button or a keyboard button should skip the video without waiting.
Corrected the video path, the default should be linux one.
Fixed a crash when no video is found.
Fixed black pixels in the Earth sequence, thanks to AndO3131.