### PR TITLE
Fixing uninitialized variable in new FlcPlayer code.

### DIFF
--- a/src/Engine/FlcPlayer.cpp
+++ b/src/Engine/FlcPlayer.cpp
@@ -478,7 +478,7 @@ void FlcPlayer::color256()
 {
 	Uint8 *pSrc;
 	Uint16 numColorPackets;
-	Uint16 numColors;
+	Uint16 numColors = 0;
 	Uint8 numColorsSkip;
 
 	pSrc = _chunkData + 6;


### PR DESCRIPTION
This was causing a warning with GCC 4.8 on Ubuntu 14.04.

With the default of -Werror on, it was causing the build to fail (as it should).
Only the variable causing the warning was changed, other variables were not checked for use while uninitialized beyond compiler warnings.
