### PR TITLE
Fix: wrong color of rows in the ManageAlienContainmentState

### DIFF
--- a/src/Basescape/ManageAlienContainmentState.cpp
+++ b/src/Basescape/ManageAlienContainmentState.cpp
@@ -402,7 +402,7 @@ void ManageAlienContainmentState::updateStrings()
 	ss << qty;
 	ss2 << _qtys[_sel];
 
-	_lstAliens->setRowColor(_sel, (qty != 0)? _lstAliens->getSecondaryColor() : _lstAliens->getColor());
+	_lstAliens->setRowColor(_sel, (qty == 0)? _lstAliens->getSecondaryColor() : _lstAliens->getColor());
 	_lstAliens->setCellText(_sel, 1, ss.str());
 	_lstAliens->setCellText(_sel, 2, ss2.str());
 


### PR DESCRIPTION
Looks like a programmer confused the conditions. Should be uplight only rows where all aliens will be killed.

Default Alien containment state:
![screen065](https://cloud.githubusercontent.com/assets/3616568/6065954/2f3e2ce4-ad7a-11e4-9329-2d7968cc4c14.png)

If I want to kill several specimens:
![screen066](https://cloud.githubusercontent.com/assets/3616568/6065988/876a014a-ad7a-11e4-95fa-bff4ddb4673c.png)

How should be:
![screen067](https://cloud.githubusercontent.com/assets/3616568/6066006/aa2276fe-ad7a-11e4-81c0-5b0973d08cae.png)