### PR TITLE
Fix: "space available" of the ManageAlienContainmentState

### DIFF
--- a/src/Basescape/ManageAlienContainmentState.cpp
+++ b/src/Basescape/ManageAlienContainmentState.cpp
@@ -122,7 +122,7 @@ ManageAlienContainmentState::ManageAlienContainmentState(Base *base, OptionsOrig
 	_txtDeadAliens->setWordWrap(true);
 	_txtDeadAliens->setVerticalAlign(ALIGN_BOTTOM);
 
-	_txtAvailable->setText(tr("STR_SPACE_AVAILABLE").arg(_base->getAvailableContainment() - _base->getUsedContainment()));
+	_txtAvailable->setText(tr("STR_SPACE_AVAILABLE").arg(_base->getAvailableContainment() - _base->getUsedContainment() - _researchedAliens));
 
 	_txtUsed->setText(tr("STR_SPACE_USED").arg( _base->getUsedContainment() + _researchedAliens));
 


### PR DESCRIPTION
ManageAlienContainmentState after loading. The field "Space available" shows wrong data. Must be -16.
One alien went to interrogation :)
![screen065](https://cloud.githubusercontent.com/assets/3616568/6094319/f693d2a0-af35-11e4-8430-f9e3ab32b842.png)

If i want to kill 3 aliens, the field shows right data.
![screen066](https://cloud.githubusercontent.com/assets/3616568/6094322/1acfd3c6-af36-11e4-8f19-9f34897d8764.png)