### PR TITLE
Simple custom recolors

### DIFF
--- a/bin/data/Ruleset/Xcom1Ruleset/armors.rul
+++ b/bin/data/Ruleset/Xcom1Ruleset/armors.rul
@@ -2,6 +2,10 @@ armors:
   - type: STR_NONE_UC
     spriteSheet: XCOM_0.PCK
     spriteInv: MAN_0
+    spriteFaceGroup: 6
+    spriteFaceColor: [96, 96, 96, 96, 160, 160, 163, 163] #M0 F0 M1 F1 M2 F2 M3 F3
+    spriteHairGroup: 9
+    spriteHairColor: [144, 144, 164, 164, 245, 245, 166, 166] #M0 F0 M1 F1 M2 F2 M3 F3
     storeItem: STR_NONE
     corpseBattle:
       - STR_CORPSE
@@ -24,6 +28,10 @@ armors:
   - type: STR_PERSONAL_ARMOR_UC
     spriteSheet: XCOM_1.PCK
     spriteInv: MAN_1
+    spriteFaceGroup: 6
+    spriteFaceColor: [96, 96, 96, 96, 160, 160, 163, 163] #M0 F0 M1 F1 M2 F2 M3 F3
+    spriteHairGroup: 9
+    spriteHairColor: [144, 144, 164, 164, 245, 245, 166, 166] #M0 F0 M1 F1 M2 F2 M3 F3
     corpseBattle:
       - STR_CORPSE_ARMOR
     storeItem: STR_PERSONAL_ARMOR

--- a/src/Battlescape/UnitSprite.cpp
+++ b/src/Battlescape/UnitSprite.cpp
@@ -632,7 +632,7 @@ void UnitSprite::drawRoutine1()
 	if (_unit->getStatus() == STATUS_COLLAPSING)
 	{
 		torso = _unitSurface->getFrame(die + _unit->getFallingPhase());
-		torso->blit(this);
+		drawRecolored(torso);
 		return;
 	}
 
@@ -744,14 +744,14 @@ void UnitSprite::drawRoutine1()
 	// blit order depends on unit direction.
 	switch (unitDir)
 	{
-	case 0: itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); leftArm->blit(this); torso->blit(this); rightArm->blit(this); break;
-	case 1: leftArm->blit(this); torso->blit(this); rightArm->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
-	case 2: leftArm->blit(this); torso->blit(this); rightArm->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void();  break;
-	case 3:	torso->blit(this); leftArm->blit(this); rightArm->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
-	case 4:	torso->blit(this); leftArm->blit(this); rightArm->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
-	case 5:	rightArm->blit(this); torso->blit(this); leftArm->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
-	case 6: rightArm->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); torso->blit(this); leftArm->blit(this); break;
-	case 7:	rightArm->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); leftArm->blit(this); torso->blit(this); break;
+	case 0: itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); drawRecolored(leftArm); drawRecolored(torso); drawRecolored(rightArm); break;
+	case 1: drawRecolored(leftArm); drawRecolored(torso); drawRecolored(rightArm); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
+	case 2: drawRecolored(leftArm); drawRecolored(torso); drawRecolored(rightArm); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void();  break;
+	case 3:	drawRecolored(torso); drawRecolored(leftArm); drawRecolored(rightArm); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
+	case 4:	drawRecolored(torso); drawRecolored(leftArm); drawRecolored(rightArm); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
+	case 5:	drawRecolored(rightArm); drawRecolored(torso); drawRecolored(leftArm); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
+	case 6: drawRecolored(rightArm); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); drawRecolored(torso); drawRecolored(leftArm); break;
+	case 7:	drawRecolored(rightArm); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); drawRecolored(leftArm); drawRecolored(torso); break;
 	}
 	torso->setX(0);
 	leftArm->setX(0);
@@ -785,12 +785,12 @@ void UnitSprite::drawRoutine2()
 	if (_part > 0 && hoverTank != 0)
 	{
 		s = _unitSurface->getFrame(104 + ((_part-1) * 8) + _animationFrame);
-		s->blit(this);
+		drawRecolored(s);
 	}
 
 	// draw the tank itself
 	s = _unitSurface->getFrame(hoverTank + (_part * 8) + _unit->getDirection());
-	s->blit(this);
+	drawRecolored(s);
 
 	// draw the turret, together with the last part
 	if (_part == 3 && turret != -1)
@@ -805,7 +805,7 @@ void UnitSprite::drawRoutine2()
 		}
 		s->setX(turretOffsetX);
 		s->setY(turretOffsetY);
-		s->blit(this);
+		drawRecolored(s);
 	}
 
 }
@@ -827,12 +827,12 @@ void UnitSprite::drawRoutine3()
 	if (_part > 0)
 	{
 		s = _unitSurface->getFrame(32 + ((_part-1) * 8) + _animationFrame);
-		s->blit(this);
+		drawRecolored(s);
 	}
 
 	s = _unitSurface->getFrame((_part * 8) + _unit->getDirection());
 
-	s->blit(this);
+	drawRecolored(s);
 }
 
 /**
@@ -882,7 +882,7 @@ void UnitSprite::drawRoutine4()
 	if (_unit->getStatus() == STATUS_COLLAPSING)
 	{
 		s = _unitSurface->getFrame(die + _unit->getFallingPhase());
-		s->blit(this);
+		drawRecolored(s);
 		return;
 	}
 	else if (_unit->getStatus() == STATUS_WALKING)
@@ -961,14 +961,14 @@ void UnitSprite::drawRoutine4()
 	}
 	switch (unitDir)
 	{
-	case 0: itemB?itemB->blit(this):void(); itemA?itemA->blit(this):void(); s->blit(this); break;
-	case 1: itemB?itemB->blit(this):void(); s->blit(this); itemA?itemA->blit(this):void(); break;
-	case 2: s->blit(this); itemB?itemB->blit(this):void(); itemA?itemA->blit(this):void(); break;
-	case 3: s->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
-	case 4: s->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
-	case 5: itemA?itemA->blit(this):void(); s->blit(this); itemB?itemB->blit(this):void(); break;
-	case 6: itemA?itemA->blit(this):void(); s->blit(this); itemB?itemB->blit(this):void(); break;
-	case 7: itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); s->blit(this); break;
+	case 0: itemB?itemB->blit(this):void(); itemA?itemA->blit(this):void(); drawRecolored(s); break;
+	case 1: itemB?itemB->blit(this):void(); drawRecolored(s); itemA?itemA->blit(this):void(); break;
+	case 2: drawRecolored(s); itemB?itemB->blit(this):void(); itemA?itemA->blit(this):void(); break;
+	case 3: drawRecolored(s); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
+	case 4: drawRecolored(s); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
+	case 5: itemA?itemA->blit(this):void(); drawRecolored(s); itemB?itemB->blit(this):void(); break;
+	case 6: itemA?itemA->blit(this):void(); drawRecolored(s); itemB?itemB->blit(this):void(); break;
+	case 7: itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); drawRecolored(s); break;
 	}
 	s->setX(0);
 	if (itemA)
@@ -999,7 +999,7 @@ void UnitSprite::drawRoutine5()
 		s = _unitSurface->getFrame((_part * 8) + _unit->getDirection());
 	}
 
-	s->blit(this);
+	drawRecolored(s);
 }
 
 /**
@@ -1033,7 +1033,7 @@ void UnitSprite::drawRoutine6()
 	if (_unit->getStatus() == STATUS_COLLAPSING)
 	{
 		torso = _unitSurface->getFrame(die + _unit->getFallingPhase());
-		torso->blit(this);
+		drawRecolored(torso);
 		return;
 	}
 
@@ -1179,14 +1179,14 @@ void UnitSprite::drawRoutine6()
 	// blit order depends on unit direction.
 	switch (unitDir)
 	{
-	case 0: itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); leftArm->blit(this); legs->blit(this); torso->blit(this); rightArm->blit(this); break;
-	case 1: leftArm->blit(this); legs->blit(this); itemB?itemB->blit(this):void(); torso->blit(this); itemA?itemA->blit(this):void(); rightArm->blit(this); break;
-	case 2: leftArm->blit(this); legs->blit(this); torso->blit(this); rightArm->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
-	case 3: legs->blit(this); torso->blit(this); leftArm->blit(this); rightArm->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void();	break;
-	case 4:	rightArm->blit(this); legs->blit(this); torso->blit(this); leftArm->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
-	case 5:	rightArm->blit(this); legs->blit(this); torso->blit(this); leftArm->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
-	case 6: rightArm->blit(this); legs->blit(this); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); torso->blit(this); leftArm->blit(this); break;
-	case 7:	itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); leftArm->blit(this); rightArm->blit(this); legs->blit(this); torso->blit(this); break;
+	case 0: itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); drawRecolored(leftArm); drawRecolored(legs); drawRecolored(torso); drawRecolored(rightArm); break;
+	case 1: drawRecolored(leftArm); drawRecolored(legs); itemB?itemB->blit(this):void(); drawRecolored(torso); itemA?itemA->blit(this):void(); drawRecolored(rightArm); break;
+	case 2: drawRecolored(leftArm); drawRecolored(legs); drawRecolored(torso); drawRecolored(rightArm); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
+	case 3: drawRecolored(legs); drawRecolored(torso); drawRecolored(leftArm); drawRecolored(rightArm); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void();	break;
+	case 4:	drawRecolored(rightArm); drawRecolored(legs); drawRecolored(torso); drawRecolored(leftArm); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
+	case 5:	drawRecolored(rightArm); drawRecolored(legs); drawRecolored(torso); drawRecolored(leftArm); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); break;
+	case 6: drawRecolored(rightArm); drawRecolored(legs); itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); drawRecolored(torso); drawRecolored(leftArm); break;
+	case 7:	itemA?itemA->blit(this):void(); itemB?itemB->blit(this):void(); drawRecolored(leftArm); drawRecolored(rightArm); drawRecolored(legs); drawRecolored(torso); break;
 	}
 	torso->setX(0);
 	legs->setX(0);
@@ -1222,7 +1222,7 @@ void UnitSprite::drawRoutine7()
 	if (_unit->getStatus() == STATUS_COLLAPSING)
 	{
 		torso = _unitSurface->getFrame(die + _unit->getFallingPhase());
-		torso->blit(this);
+		drawRecolored(torso);
 		return;
 	}
 
@@ -1254,14 +1254,14 @@ void UnitSprite::drawRoutine7()
 	// blit order depends on unit direction
 	switch (unitDir)
 	{
-	case 0: leftArm->blit(this); legs->blit(this); torso->blit(this); rightArm->blit(this); break;
-	case 1: leftArm->blit(this); legs->blit(this); torso->blit(this); rightArm->blit(this); break;
-	case 2: leftArm->blit(this); legs->blit(this); torso->blit(this); rightArm->blit(this); break;
-	case 3: legs->blit(this); torso->blit(this); leftArm->blit(this); rightArm->blit(this); break;
-	case 4: rightArm->blit(this); legs->blit(this); torso->blit(this); leftArm->blit(this); break;
-	case 5: rightArm->blit(this); legs->blit(this); torso->blit(this); leftArm->blit(this); break;
-	case 6: rightArm->blit(this); legs->blit(this); torso->blit(this); leftArm->blit(this); break;
-	case 7: leftArm->blit(this); rightArm->blit(this); legs->blit(this); torso->blit(this); break;
+	case 0: drawRecolored(leftArm); drawRecolored(legs); drawRecolored(torso); drawRecolored(rightArm); break;
+	case 1: drawRecolored(leftArm); drawRecolored(legs); drawRecolored(torso); drawRecolored(rightArm); break;
+	case 2: drawRecolored(leftArm); drawRecolored(legs); drawRecolored(torso); drawRecolored(rightArm); break;
+	case 3: drawRecolored(legs); drawRecolored(torso); drawRecolored(leftArm); drawRecolored(rightArm); break;
+	case 4: drawRecolored(rightArm); drawRecolored(legs); drawRecolored(torso); drawRecolored(leftArm); break;
+	case 5: drawRecolored(rightArm); drawRecolored(legs); drawRecolored(torso); drawRecolored(leftArm); break;
+	case 6: drawRecolored(rightArm); drawRecolored(legs); drawRecolored(torso); drawRecolored(leftArm); break;
+	case 7: drawRecolored(leftArm); drawRecolored(rightArm); drawRecolored(legs); drawRecolored(torso); break;
 	}
 }
 
@@ -1290,7 +1290,7 @@ void UnitSprite::drawRoutine8()
 	if (_unit->getStatus() == STATUS_AIMING)
 		legs = _unitSurface->getFrame(aim);
 
-	legs->blit(this);
+	drawRecolored(legs);
 }
 
 /**
@@ -1314,7 +1314,7 @@ void UnitSprite::drawRoutine9()
 	if (_unit->getStatus() == STATUS_COLLAPSING)
 		torso = _unitSurface->getFrame(die + _unit->getFallingPhase());
 
-	torso->blit(this);
+	drawRecolored(torso);
 }
 
 /**
@@ -1341,7 +1341,7 @@ void UnitSprite::drawRoutine11()
 
 	Surface *s = _unitSurface->getFrame(body + (_part * 4) + 16 * _unit->getDirection() + animFrame);
 	s->setY(4);
-	s->blit(this);
+	drawRecolored(s);
 
 	int turret = _unit->getTurretType();
 	// draw the turret, overlapping all 4 parts
@@ -1350,7 +1350,7 @@ void UnitSprite::drawRoutine11()
 		s = _unitSurface->getFrame(256 + (turret * 8) + _unit->getTurretDirection());
 		s->setX(offTurretX[_unit->getDirection()]);
 		s->setY(offTurretY[_unit->getDirection()]);
-		s->blit(this);
+		drawRecolored(s);
 	}
 
 }
@@ -1376,11 +1376,11 @@ void UnitSprite::drawRoutine12()
 	{
 		// biodrone death frames
 		s = _unitSurface->getFrame(die + _unit->getFallingPhase());
-		s->blit(this);
+		drawRecolored(s);
 		return;
 	}
 
-	s->blit(this);
+	drawRecolored(s);
 }
 
 /**
@@ -1401,7 +1401,7 @@ void UnitSprite::drawRoutine19()
 	if (_unit->getStatus() == STATUS_COLLAPSING)
 	{
 		s = _unitSurface->getFrame(die + _unit->getFallingPhase());
-		s->blit(this);
+		drawRecolored(s);
 		return;
 	}
 
@@ -1414,7 +1414,7 @@ void UnitSprite::drawRoutine19()
 		s = _unitSurface->getFrame(stand + _unit->getDirection());
 	}
 
-	s->blit(this);
+	drawRecolored(s);
 }
 
 /**
@@ -1439,7 +1439,7 @@ void UnitSprite::drawRoutine20()
 		s = _unitSurface->getFrame(5 * (_part + 4 * _unit->getDirection()));
 	}
 
-	s->blit(this);
+	drawRecolored(s);
 }
 
 /**
@@ -1458,7 +1458,7 @@ void UnitSprite::drawRoutine21()
 	s = _unitSurface->getFrame((_part * 4) + (_unit->getDirection() * 16) + (_animationFrame % 4));
 	_redraw = true;
 
-	s->blit(this);
+	drawRecolored(s);
 }
 
 /**

--- a/src/Battlescape/UnitSprite.cpp
+++ b/src/Battlescape/UnitSprite.cpp
@@ -328,11 +328,11 @@ void UnitSprite::drawRoutine0()
 		}
 	}
 
-	
+
 	// when walking, torso(fixed sprite) has to be animated up/down
 	if (_unit->getStatus() == STATUS_WALKING)
 	{
-		
+
 		if (_drawingRoutine == 10)
 			torsoHandsWeaponY = mutonYoffWalk[walkPhase];
 		else if (_drawingRoutine == 13 || _drawingRoutine == 14)
@@ -646,7 +646,7 @@ void UnitSprite::drawRoutine1()
 		// unit is drawn as an item
 		return;
 	}
-	
+
 	if (_unit->getStatus() == STATUS_COLLAPSING)
 	{
 		torso = _unitSurface->getFrame(die + _unit->getFallingPhase());
@@ -968,7 +968,7 @@ void UnitSprite::drawRoutine4()
 			itemB->setY(offY3[unitDir]);
 		}
 	}
-	
+
 	if (_unit->getStatus() == STATUS_AIMING)
 	{
 		s->setX(offXAiming);

--- a/src/Battlescape/UnitSprite.h
+++ b/src/Battlescape/UnitSprite.h
@@ -40,6 +40,8 @@ private:
 	SurfaceSet *_unitSurface, *_itemSurfaceA, *_itemSurfaceB;
 	int _part, _animationFrame, _drawingRoutine;
 	bool _helmet;
+	std::pair<Uint8, Uint8> _colorA, _colorB;
+
 	/// Drawing routine for XCom soldiers in overalls, sectoids (routine 0),
 	/// mutons (routine 10),
 	/// aquanauts (routine 13),
@@ -76,6 +78,8 @@ private:
 	void drawRoutine21();
 	/// sort two handed sprites out.
 	void sortRifles();
+	/// Draw surface with changed colors.
+	void drawRecolored(Surface *src);
 public:
 	/// Creates a new UnitSprite at the specified position and size.
 	UnitSprite(int width, int height, int x, int y, bool helmet);

--- a/src/Resource/XcomResourcePack.cpp
+++ b/src/Resource/XcomResourcePack.cpp
@@ -53,8 +53,11 @@ namespace OpenXcom
 
 namespace
 {
-	
-struct HairBleach
+
+/**
+ * Recolor class used in UFO
+ */
+struct HairXCOM1
 {
 	static const Uint8 ColorShade = 15;
 
@@ -62,15 +65,31 @@ struct HairBleach
 	static const Uint8 Face = 6 << 4;
 	static inline void func(Uint8& src, const Uint8& cutoff, int, int, int)
 	{
-		if (src > cutoff && src <= Face + 15)
+		if (src > cutoff && src <= Face + ColorShade)
 		{
 			src = Hair + (src & ColorShade) - 6; //make hair color like male in xcom_0.pck
 		}
 	}
 };
 
+/**
+ * Recolor class used in TFTD
+ */
+struct HairXCOM2
+{
+	static const Uint8 HairMan = 4 << 4;
+	static const Uint8 HairWoman = 1 << 4;
+	static inline void func(Uint8& src, int, int, int, int)
+	{
+		if (src >= HairMan && src <= HairMan + HairXCOM1::ColorShade)
+		{
+			src = HairWoman + (src & HairXCOM1::ColorShade);
+		}
+	}
+};
+
 }
-	
+
 /**
  * Initializes the resource pack by loading all the resources
  * contained in the original game folder.
@@ -864,11 +883,14 @@ void XcomResourcePack::loadBattlescapeResources()
 	//"fix" of hair color of male personal armor
 	if (Options::battleHairBleach)
 	{
-		if (_sets.find("XCOM_1.PCK") != _sets.end())
-		{
-			SurfaceSet *xcom_1 = _sets["XCOM_1.PCK"];
+		std::string name;
 
-			for (int i = 0; i < 16; ++i)
+		name = "XCOM_1.PCK";
+		if (_sets.find(name) != _sets.end())
+		{
+			SurfaceSet *xcom_1 = _sets[name];
+
+			for (int i = 0; i < 8; ++i)
 			{
 				//chest frame
 				Surface *surf = xcom_1->getFrame(4 * 8 + i);
@@ -878,11 +900,11 @@ void XcomResourcePack::loadBattlescapeResources()
 				dim.beg_y = 6;
 				dim.end_y = 9;
 				head.setDomain(dim);
-				ShaderDraw<HairBleach>(head, ShaderScalar<Uint8>(HairBleach::Face + 5));
+				ShaderDraw<HairXCOM1>(head, ShaderScalar<Uint8>(HairXCOM1::Face + 5));
 				dim.beg_y = 9;
 				dim.end_y = 10;
 				head.setDomain(dim);
-				ShaderDraw<HairBleach>(head, ShaderScalar<Uint8>(HairBleach::Face + 6));
+				ShaderDraw<HairXCOM1>(head, ShaderScalar<Uint8>(HairXCOM1::Face + 6));
 				surf->unlock();
 			}
 
@@ -898,8 +920,26 @@ void XcomResourcePack::loadBattlescapeResources()
 				dim.end_x = 20;
 				head.setDomain(dim);
 				surf->lock();
-				ShaderDraw<HairBleach>(head, ShaderScalar<Uint8>(HairBleach::Face + 6));
+				ShaderDraw<HairXCOM1>(head, ShaderScalar<Uint8>(HairXCOM1::Face + 6));
 				surf->unlock();
+			}
+		}
+
+		name = "TDXCOM_?.PCK";
+		for (int j = 0; j < 3; ++j)
+		{
+			name[7] = '0' + j;
+			if (_sets.find(name) != _sets.end())
+			{
+				SurfaceSet *xcom_2 = _sets[name];
+				for (int i = 0; i < 8; ++i)
+				{
+					//male chest frame
+					Surface *surf = xcom_2->getFrame(270 + i);
+					surf->lock();
+					ShaderDraw<HairXCOM2>(ShaderSurface(surf));
+					surf->unlock();
+				}
 			}
 		}
 	}

--- a/src/Resource/XcomResourcePack.cpp
+++ b/src/Resource/XcomResourcePack.cpp
@@ -113,7 +113,7 @@ XcomResourcePack::XcomResourcePack(Ruleset *rules) : ResourcePack()
 		_palettes[s2] = new Palette();
 		_palettes[s2]->loadDat(CrossPlatform::getDataFile(s1), 128);
 	}
-	
+
 	// Correct Battlescape palette
 	{
 		std::string s1 = "GEODATA/PALETTES.DAT";
@@ -193,11 +193,11 @@ XcomResourcePack::XcomResourcePack(Ruleset *rules) : ResourcePack()
 			newGeo->setPixel(newWidth+x, newHeight+y, oldGeo->getPixel(x, y));
 			newGeo->setPixel(newWidth-x-1, newHeight+y, oldGeo->getPixel(x, y));
 			newGeo->setPixel(newWidth*3-x-1, newHeight+y, oldGeo->getPixel(x, y));
-			
+
 			newGeo->setPixel(newWidth+x, newHeight-y-1, oldGeo->getPixel(x, y));
 			newGeo->setPixel(newWidth-x-1, newHeight-y-1, oldGeo->getPixel(x, y));
 			newGeo->setPixel(newWidth*3-x-1, newHeight-y-1, oldGeo->getPixel(x, y));
-			
+
 			newGeo->setPixel(newWidth+x, newHeight*3-y-1, oldGeo->getPixel(x, y));
 			newGeo->setPixel(newWidth-x-1, newHeight*3-y-1, oldGeo->getPixel(x, y));
 			newGeo->setPixel(newWidth*3-x-1, newHeight*3-y-1, oldGeo->getPixel(x, y));
@@ -314,8 +314,8 @@ XcomResourcePack::XcomResourcePack(Ruleset *rules) : ResourcePack()
 		delete gmcat;
 		delete adlibcat;
 		delete aintrocat;
-#endif		
-		
+#endif
+
 		if (rules->getSoundDefinitions()->empty())
 		{
 			// Load sounds
@@ -387,7 +387,7 @@ XcomResourcePack::XcomResourcePack(Ruleset *rules) : ResourcePack()
 				}
 			}
 		}
-		
+
 
 		if (CrossPlatform::fileExists(CrossPlatform::getDataFile("SOUND/INTRO.CAT")))
 		{
@@ -408,7 +408,7 @@ XcomResourcePack::XcomResourcePack(Ruleset *rules) : ResourcePack()
 	Window::soundPopup[2] = getSound("GEO.CAT", ResourcePack::WINDOW_POPUP[2]);
 
 	loadBattlescapeResources(); // TODO load this at battlescape start, unload at battlescape end?
-	
+
 
 	// we create extra rows on the soldier stat screens by shrinking them all down one pixel.
 	// this is done after loading them, but BEFORE loading the extraSprites, in case a modder wants to replace them.
@@ -491,7 +491,7 @@ XcomResourcePack::XcomResourcePack(Ruleset *rules) : ResourcePack()
 			{
 				Log(LOG_DEBUG) << "Adding/Replacing items in surface set: " << sheetName;
 			}
-			
+
 			if (subdivision)
 			{
 				int frames = (spritePack->getWidth() / spritePack->getSubX())*(spritePack->getHeight() / spritePack->getSubY());
@@ -616,7 +616,7 @@ XcomResourcePack::XcomResourcePack(Ruleset *rules) : ResourcePack()
 		surface1->setPalette(surface2->getPalette());
 		surface2->blit(surface1);
 	}
-	
+
 	std::vector< std::pair<std::string, ExtraSounds *> >extraSounds = rules->getExtraSounds();
 	for (std::vector< std::pair<std::string, ExtraSounds *> >::const_iterator i = extraSounds.begin(); i != extraSounds.end(); ++i)
 	{
@@ -712,7 +712,7 @@ void XcomResourcePack::loadBattlescapeResources()
 	s2 << "UFOGRAPH/" << "SMOKE.TAB";
 	_sets["SMOKE.PCK"] = new SurfaceSet(32, 40);
 	_sets["SMOKE.PCK"]->loadPck(CrossPlatform::getDataFile(s.str()), CrossPlatform::getDataFile(s2.str()));
-	
+
 	s.str("");
 	s2.str("");
 	s << "UFOGRAPH/" << "HIT.PCK";
@@ -790,7 +790,7 @@ void XcomResourcePack::loadBattlescapeResources()
 		_surfaces[scrs[i]] = new Surface(320, 200);
 		_surfaces[scrs[i]]->loadScr(CrossPlatform::getDataFile(s.str()));
 	}
-	
+
 
 	std::string lbms[] = {"D0.LBM",
 						  "D1.LBM",
@@ -846,7 +846,7 @@ void XcomResourcePack::loadBattlescapeResources()
 		}
 	}
 
-	
+
 	std::string ufograph = CrossPlatform::getDataFolder("UFOGRAPH/");
 	std::vector<std::string> bdys = CrossPlatform::getFolderContents(ufograph, "BDY");
 	for (std::vector<std::string>::iterator i = bdys.begin(); i != bdys.end(); ++i)
@@ -1094,7 +1094,7 @@ void XcomResourcePack::createTransparencyLUT(Palette *pal)
 				desiredColor.r = std::min(255, (int)(pal->getColors(currentColor)->r) + (tint->r * opacity));
 				desiredColor.g = std::min(255, (int)(pal->getColors(currentColor)->g) + (tint->g * opacity));
 				desiredColor.b = std::min(255, (int)(pal->getColors(currentColor)->b) + (tint->b * opacity));
- 
+
 				Uint8 closest = 0;
 				int lowestDifference = INT_MAX;
 				// now compare each color in the palette to find the closest match to our desired one
@@ -1103,7 +1103,7 @@ void XcomResourcePack::createTransparencyLUT(Palette *pal)
 					int currentDifference = Sqr(desiredColor.r - pal->getColors(comparator)->r) +
 											Sqr(desiredColor.g-pal->getColors(comparator)->g) +
 											Sqr(desiredColor.b-pal->getColors(comparator)->b);
- 
+
 					if (currentDifference < lowestDifference)
 					{
 						closest = comparator;

--- a/src/Ruleset/Armor.cpp
+++ b/src/Ruleset/Armor.cpp
@@ -17,6 +17,7 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "Armor.h"
+#include "../Savegame/Soldier.h"
 
 namespace OpenXcom
 {
@@ -30,10 +31,13 @@ Armor::Armor(const std::string &type) :
 	_type(type), _frontArmor(0), _sideArmor(0), _rearArmor(0), _underArmor(0),
 	_drawingRoutine(0), _movementType(MT_WALK), _size(1), _weight(0),
 	_deathFrames(3), _constantAnimation(false), _canHoldWeapon(false),
-	_forcedTorso(TORSO_USE_GENDER)
+	_forcedTorso(TORSO_USE_GENDER), _faceColorGroup(0), _hairColorGroup(0)
 {
 	for (int i=0; i < DAMAGE_TYPES; i++)
 		_damageModifier[i] = 1.0f;
+
+	_faceColor.resize((LOOK_AFRICAN + 1) * 2);
+	_hairColor.resize((LOOK_AFRICAN + 1) * 2);
 }
 
 /**
@@ -105,6 +109,19 @@ void Armor::load(const YAML::Node &node)
 	else
 	{
 		_canHoldWeapon = false;
+	}
+
+	_faceColorGroup = node["spriteFaceGroup"].as<int>(_faceColorGroup);
+	_hairColorGroup = node["spriteHairGroup"].as<int>(_hairColorGroup);
+	if (const YAML::Node& colors = node["spriteFaceColor"])
+	{
+		for (size_t i = 0; i < colors.size() && i < _faceColor.size(); ++i)
+			_faceColor[i] = colors[i].as<int>();
+	}
+	if (const YAML::Node& colors = node["spriteHairColor"])
+	{
+		for (size_t i = 0; i < colors.size() && i < _hairColor.size(); ++i)
+			_hairColor[i] = colors[i].as<int>();
 	}
 }
 
@@ -313,4 +330,39 @@ ForcedTorso Armor::getForcedTorso() const
 	return _forcedTorso;
 }
 
+/**
+ * Gets hair base color group for replacement, if -1 then don't replace colors.
+ * @return Color group or -1.
+ */
+int Armor::getFaceColorGroup() const
+{
+	return _faceColorGroup;
+}
+
+/**
+ * Gets hair base color group for replacement, if -1 then don't replace colors.
+ * @return Color group or -1.
+ */
+int Armor::getHairColorGroup() const
+{
+	return _hairColorGroup;
+}
+
+/**
+ * Gets new face colors for replacement.
+ * @return Vector with new values based on gender and race.
+ */
+const std::vector<int>& Armor::getFaceColor() const
+{
+	return _faceColor;
+}
+
+/**
+ * Gets new hair colors for replacement.
+ * @return Vector with new values based on gender and race.
+ */
+const std::vector<int>& Armor::getHairColor() const
+{
+	return _hairColor;
+}
 }

--- a/src/Ruleset/Armor.cpp
+++ b/src/Ruleset/Armor.cpp
@@ -26,7 +26,11 @@ namespace OpenXcom
  * type of armor.
  * @param type String defining the type.
  */
-Armor::Armor(const std::string &type) : _type(type), _frontArmor(0), _sideArmor(0), _rearArmor(0), _underArmor(0), _drawingRoutine(0), _movementType(MT_WALK), _size(1), _weight(0), _deathFrames(3), _constantAnimation(false), _canHoldWeapon(false), _forcedTorso(TORSO_USE_GENDER)
+Armor::Armor(const std::string &type) :
+	_type(type), _frontArmor(0), _sideArmor(0), _rearArmor(0), _underArmor(0),
+	_drawingRoutine(0), _movementType(MT_WALK), _size(1), _weight(0),
+	_deathFrames(3), _constantAnimation(false), _canHoldWeapon(false),
+	_forcedTorso(TORSO_USE_GENDER)
 {
 	for (int i=0; i < DAMAGE_TYPES; i++)
 		_damageModifier[i] = 1.0f;
@@ -74,7 +78,7 @@ void Armor::load(const YAML::Node &node)
 	_stats.merge(node["stats"].as<UnitStats>(_stats));
 	if (const YAML::Node &dmg = node["damageModifier"])
 	{
-		for (size_t i = 0; i < dmg.size() && i < DAMAGE_TYPES; ++i)
+		for (size_t i = 0; i < dmg.size() && i < (size_t)DAMAGE_TYPES; ++i)
 		{
 			_damageModifier[i] = dmg[i].as<float>();
 		}
@@ -242,7 +246,7 @@ int Armor::getSize() const
  * @param dt The damageType.
  * @return The damage modifier 0->1.
  */
-float Armor::getDamageModifier(ItemDamageType dt)
+float Armor::getDamageModifier(ItemDamageType dt) const
 {
 	return _damageModifier[(int)dt];
 }
@@ -250,7 +254,7 @@ float Armor::getDamageModifier(ItemDamageType dt)
 /** Gets the loftempSet.
  * @return The loftempsSet.
  */
-std::vector<int> Armor::getLoftempsSet() const
+const std::vector<int>& Armor::getLoftempsSet() const
 {
 	return _loftempsSet;
 }
@@ -259,7 +263,7 @@ std::vector<int> Armor::getLoftempsSet() const
   * Gets pointer to the armor's stats.
   * @return stats Pointer to the armor's stats.
   */
-UnitStats *Armor::getStats()
+const UnitStats *Armor::getStats() const
 {
 	return &_stats;
 }
@@ -268,7 +272,7 @@ UnitStats *Armor::getStats()
  * Gets the armor's weight.
  * @return the weight of the armor.
  */
-int Armor::getWeight()
+int Armor::getWeight() const
 {
 	return _weight;
 }
@@ -277,7 +281,7 @@ int Armor::getWeight()
  * Gets number of death frames.
  * @return number of death frames.
  */
-int Armor::getDeathFrames()
+int Armor::getDeathFrames() const
 {
 	return _deathFrames;
 }
@@ -286,7 +290,7 @@ int Armor::getDeathFrames()
  * Gets if armor uses constant animation.
  * @return if it uses constant animation
  */
-bool Armor::getConstantAnimation()
+bool Armor::getConstantAnimation() const
 {
 	return _constantAnimation;
 }
@@ -295,7 +299,7 @@ bool Armor::getConstantAnimation()
  * Gets if armor can hold weapon.
  * @return if it can hold weapon
  */
-bool Armor::getCanHoldWeapon()
+bool Armor::getCanHoldWeapon() const
 {
 	return _canHoldWeapon;
 }
@@ -304,7 +308,7 @@ bool Armor::getCanHoldWeapon()
  * Checks if this armor ignores gender (power suit/flying suit).
  * @return which torso to force on the sprite.
  */
-ForcedTorso Armor::getForcedTorso()
+ForcedTorso Armor::getForcedTorso() const
 {
 	return _forcedTorso;
 }

--- a/src/Ruleset/Armor.h
+++ b/src/Ruleset/Armor.h
@@ -27,7 +27,7 @@
 
 namespace OpenXcom
 {
-	
+
 enum ForcedTorso{ TORSO_USE_GENDER, TORSO_ALWAYS_MALE, TORSO_ALWAYS_FEMALE };
 /**
  * Represents a specific type of armor.
@@ -36,7 +36,7 @@ enum ForcedTorso{ TORSO_USE_GENDER, TORSO_ALWAYS_MALE, TORSO_ALWAYS_FEMALE };
  */
 class Armor
 {
-public:	
+public:
 	static const int DAMAGE_TYPES = 10;
 private:
 	std::string _type, _spriteSheet, _spriteInv, _corpseGeo, _storeItem, _specWeapon;
@@ -87,21 +87,21 @@ public:
 	/// Gets whether this is a normal or big unit.
 	int getSize() const;
 	/// Gets damage modifier.
-	float getDamageModifier(ItemDamageType dt);
+	float getDamageModifier(ItemDamageType dt) const;
 	/// Gets loftempSet
-	std::vector<int> getLoftempsSet() const;
+	const std::vector<int>& getLoftempsSet() const;
 	/// Gets the armor's stats.
-	UnitStats *getStats();
+	const UnitStats *getStats() const;
 	/// Gets the armor's weight.
-	int getWeight();
+	int getWeight() const;
 	/// Gets number of death frames.
-	int getDeathFrames();
+	int getDeathFrames() const;
 	/// Gets if armor uses constant animation.
-	bool getConstantAnimation();
+	bool getConstantAnimation() const;
 	/// Gets if armor can hold weapon.
-	bool getCanHoldWeapon();
+	bool getCanHoldWeapon() const;
 	/// Checks if this armor ignores gender (power suit/flying suit).
-	ForcedTorso getForcedTorso();
+	ForcedTorso getForcedTorso() const;
 };
 
 }

--- a/src/Ruleset/Armor.h
+++ b/src/Ruleset/Armor.h
@@ -51,6 +51,8 @@ private:
 	bool _constantAnimation;
 	bool _canHoldWeapon;
 	ForcedTorso _forcedTorso;
+	int _faceColorGroup, _hairColorGroup;
+	std::vector<int> _faceColor, _hairColor;
 public:
 	/// Creates a blank armor ruleset.
 	Armor(const std::string &type);
@@ -102,6 +104,14 @@ public:
 	bool getCanHoldWeapon() const;
 	/// Checks if this armor ignores gender (power suit/flying suit).
 	ForcedTorso getForcedTorso() const;
+	/// Get face base color
+	int getFaceColorGroup() const;
+	/// Get hair base color
+	int getHairColorGroup() const;
+	/// Get face base color
+	const std::vector<int>& getFaceColor() const;
+	/// Get hair base color
+	const std::vector<int>& getHairColor() const;
 };
 
 }

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -224,6 +224,8 @@ BattleUnit::BattleUnit(Unit *unit, UnitFaction faction, int id, Armor *armor, in
 	_activeHand = "STR_RIGHT_HAND";
 
 	lastCover = Position(-1, -1, -1);
+
+	setRecolor(std::rand() % 8);
 }
 
 

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -121,6 +121,9 @@ private:
 	bool _breathing;
 	bool _hidingForTurn, _floorAbove, _respawn;
 	MovementType _movementType;
+	std::pair<Uint8, Uint8> _recolor[2];
+
+	void setRecolor(int selectLook);
 public:
 	static const int MAX_SOLDIER_ID = 1000000;
 	/// Creates a BattleUnit from solder.
@@ -183,6 +186,8 @@ public:
 	void setCache(Surface *cache, int part = 0);
 	/// If this unit is cached on the battlescape.
 	Surface *getCache(bool *invalid, int part = 0) const;
+	/// Gets unit sprite recolors values.
+	std::pair<Uint8, Uint8> getRecolor(int i) const;
 	/// Kneel down.
 	void kneel(bool kneeled);
 	/// Is kneeled?

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -428,7 +428,7 @@ void SavedGame::load(const std::string &filename, Ruleset *rule)
 		b->load(*i, this, false);
 		_bases.push_back(b);
 	}
-	
+
 	const YAML::Node &research = doc["poppedResearch"];
 	for (YAML::const_iterator it = research.begin(); it != research.end(); ++it)
 	{
@@ -996,7 +996,7 @@ void SavedGame::getAvailableResearchProjects (std::vector<RuleResearch *> & proj
 			continue;
 		}
 		std::vector<const RuleResearch *>::const_iterator itDiscovered = std::find(discovered.begin(), discovered.end(), research);
-		
+
 		bool liveAlien = ruleset->getUnit(research->getName()) != 0;
 
 		if (itDiscovered != discovered.end())
@@ -1022,7 +1022,7 @@ void SavedGame::getAvailableResearchProjects (std::vector<RuleResearch *> & proj
 			{
 				std::vector<std::string>::const_iterator leaderCheck = std::find(research->getUnlocked().begin(), research->getUnlocked().end(), "STR_LEADER_PLUS");
 				std::vector<std::string>::const_iterator cmnderCheck = std::find(research->getUnlocked().begin(), research->getUnlocked().end(), "STR_COMMANDER_PLUS");
-				
+
 				bool leader ( leaderCheck != research->getUnlocked().end());
 				bool cmnder ( cmnderCheck != research->getUnlocked().end());
 
@@ -1120,12 +1120,12 @@ bool SavedGame::isResearchAvailable (RuleResearch * r, const std::vector<const R
 		return true;
 	}
 	else if (liveAlien)
-	{		
+	{
 		if (!r->getGetOneFree().empty())
 		{
 			std::vector<std::string>::const_iterator leaderCheck = std::find(r->getUnlocked().begin(), r->getUnlocked().end(), "STR_LEADER_PLUS");
 			std::vector<std::string>::const_iterator cmnderCheck = std::find(r->getUnlocked().begin(), r->getUnlocked().end(), "STR_COMMANDER_PLUS");
-				
+
 			bool leader ( leaderCheck != r->getUnlocked().end());
 			bool cmnder ( cmnderCheck != r->getUnlocked().end());
 
@@ -1573,7 +1573,7 @@ std::vector<int64_t> &SavedGame::getExpenditures()
 	return _expenditures;
 }
 /**
- * return if the player has been 
+ * return if the player has been
  * warned about poor performance.
  * @return true or false.
  */
@@ -1752,7 +1752,7 @@ void SavedGame::setLastSelectedArmor(const std::string &value)
 
 /**
  * Gets the the last selected armour
- * @return last used armor type string 
+ * @return last used armor type string
  */
 std::string SavedGame::getLastSelectedArmor()
 {
@@ -1778,5 +1778,5 @@ Craft *SavedGame::findCraftByUniqueId(const CraftId& craftId) const
 	return NULL;
 }
 
-    
+
 }


### PR DESCRIPTION
Support for TFTD aquanauts recoloring.
One drawback it don't have default recoloring for all armors like current version.
Evey one who want use different colors for nationality in his sprite should add line like for `STR_NONE_UC`.

Additional I added option for aliens and civilians too. All code doing it is in last commit, can be skipped.
Only important change its do is move place where seed is loaded form save. This was done to preventing clobbering current seed by using `RNG` in `BattleUnit` constructor.

BTW for completion, do you want add option for recoloring corpses in battlescape and inventory?