### PR TITLE
Fix bug with armor hp buff

### DIFF
--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -2019,7 +2019,7 @@ bool BattleUnit::postMissionProcedures(SavedGame *geoscape)
 
 	UnitStats *stats = s->getCurrentStats();
 	const UnitStats caps = s->getRules()->getStatCaps();
-	int healthLoss = stats->health - _health;
+	int healthLoss = _stats.health - _health;
 
 	s->setWoundRecovery(RNG::generate((healthLoss*0.5),(healthLoss*1.5)));
 


### PR DESCRIPTION
Current health is based on `_stats.health` if we compare it with `stats->health` we will get negative numbers and `setWoundRecovery` will be set negative. This break defense mission because of `getWounldRecowery() == 0`.