### PR TITLE
Fix gcc warnings (unused variable + un/signed comparisons)

### DIFF
--- a/src/Battlescape/UnitDieBState.cpp
+++ b/src/Battlescape/UnitDieBState.cpp
@@ -205,7 +205,6 @@ void UnitDieBState::think()
 		if (!_unit->getSpawnUnit().empty())
 		{
 			// converts the dead zombie to a chryssalid
-			BattleUnit *newUnit = _parent->convertUnit(_unit, _unit->getSpawnUnit());
 		}
 		else
 		{

--- a/src/Engine/FlcPlayer.cpp
+++ b/src/Engine/FlcPlayer.cpp
@@ -468,7 +468,7 @@ void FlcPlayer::playAudioFrame(Uint16 sampleRate)
 	}
 
 	float volume = Game::volumeExponent(Options::musicVolume);
-	for (int i = 0; i < _audioFrameSize; i++)
+	for (unsigned int i = 0; i < _audioFrameSize; i++)
 	{
 		loadingBuff->samples[loadingBuff->sampleCount + i] = (float)((_chunkData[i]) -128) * 240 * volume;
 	}

--- a/src/Ruleset/RuleAlienMission.h
+++ b/src/Ruleset/RuleAlienMission.h
@@ -91,7 +91,7 @@ public:
 	/// Gets the UFO type for special spawns.
 	const std::string &getSpawnUfo() const { return _spawnUfo; }
 	/// Gets the zone for spawning an alien site or base.
-	int getSpawnZone() const { return _spawnZone; }
+	unsigned int getSpawnZone() const { return _spawnZone; }
 	/// Gets the chances of this mission based on the game time.
 	int getWeight(const size_t monthsPassed) const;
 private:


### PR DESCRIPTION
This pull request fixes the following errors:
```
src/Battlescape/UnitDieBState.cpp: In member function 'virtual void OpenXcom::UnitDieBState::think()':
src/Battlescape/UnitDieBState.cpp:208:16: error: unused variable 'newUnit' [-Werror=unused-variable]
    BattleUnit *newUnit = _parent->convertUnit(_unit, _unit->getSpawnUnit());
                ^
```
```
src/Engine/FlcPlayer.cpp: In member function 'void OpenXcom::FlcPlayer::playAudioFrame(Uint16)':
src/Engine/FlcPlayer.cpp:471:20: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
  for (int i = 0; i < _audioFrameSize; i++)
                    ^
```
and
```
src/Geoscape/GeoscapeState.cpp: In member function 'void OpenXcom::GeoscapeState::setupLandMission()':
src/Geoscape/GeoscapeState.cpp:2186:40: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   if (region->getMissionZones().size() > missionRules.getSpawnZone() &&
                                        ^
```