### PR TITLE
Fixed crash caused by serializing doubles imprecisely

### DIFF
--- a/src/Savegame/MovingTarget.cpp
+++ b/src/Savegame/MovingTarget.cpp
@@ -73,9 +73,9 @@ YAML::Node MovingTarget::save() const
 	{
 		node["dest"] = _dest->saveId();
 	}
-	node["speedLon"] = _speedLon;
-	node["speedLat"] = _speedLat;
-	node["speedRadian"] = _speedRadian;
+	node["speedLon"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _speedLon).str();
+	node["speedLat"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _speedLat).str();
+	node["speedRadian"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _speedRadian).str();
 	node["speed"] = _speed;
 	return node;
 }

--- a/src/Savegame/MovingTarget.cpp
+++ b/src/Savegame/MovingTarget.cpp
@@ -20,6 +20,7 @@
 #include "MovingTarget.h"
 #include <cmath>
 #include "../fmath.h"
+#include "SerializationHelper.h"
 
 namespace OpenXcom
 {
@@ -73,9 +74,9 @@ YAML::Node MovingTarget::save() const
 	{
 		node["dest"] = _dest->saveId();
 	}
-	node["speedLon"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _speedLon).str();
-	node["speedLat"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _speedLat).str();
-	node["speedRadian"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _speedRadian).str();
+	node["speedLon"] = serializeDouble(_speedLon);
+	node["speedLat"] = serializeDouble(_speedLat);
+	node["speedRadian"] = serializeDouble(_speedRadian);
 	node["speed"] = _speed;
 	return node;
 }

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -31,6 +31,7 @@
 #include "../Engine/Options.h"
 #include "../Engine/CrossPlatform.h"
 #include "SavedBattleGame.h"
+#include "SerializationHelper.h"
 #include "GameTime.h"
 #include "Country.h"
 #include "Base.h"
@@ -499,8 +500,8 @@ void SavedGame::save(const std::string &filename) const
 	node["incomes"] = _incomes;
 	node["expenditures"] = _expenditures;
 	node["warned"] = _warned;
-	node["globeLon"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _globeLon).str();
-	node["globeLat"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _globeLat).str();
+	node["globeLon"] = serializeDouble(_globeLon);
+	node["globeLat"] = serializeDouble(_globeLat);
 	node["globeZoom"] = _globeZoom;
 	node["ids"] = _ids;
 	for (std::vector<Country*>::const_iterator i = _countries.begin(); i != _countries.end(); ++i)

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -499,8 +499,8 @@ void SavedGame::save(const std::string &filename) const
 	node["incomes"] = _incomes;
 	node["expenditures"] = _expenditures;
 	node["warned"] = _warned;
-	node["globeLon"] = _globeLon;
-	node["globeLat"] = _globeLat;
+	node["globeLon"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _globeLon).str();
+	node["globeLat"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _globeLat).str();
 	node["globeZoom"] = _globeZoom;
 	node["ids"] = _ids;
 	for (std::vector<Country*>::const_iterator i = _countries.begin(); i != _countries.end(); ++i)

--- a/src/Savegame/SerializationHelper.cpp
+++ b/src/Savegame/SerializationHelper.cpp
@@ -18,6 +18,7 @@
  */
 #include "SerializationHelper.h"
 #include <assert.h>
+#include <sstream>
 
 namespace OpenXcom
 {
@@ -71,6 +72,14 @@ void serializeInt(Uint8 **buffer, Uint8 sizeKey, int value)
 	}
 
 	*buffer += sizeKey;
+}
+
+std::string serializeDouble(double value)
+{
+	std::ostringstream stream;
+	stream.precision(std::numeric_limits<double>::digits10 + 2);
+	stream << value;
+	return stream.str();
 }
 
 }

--- a/src/Savegame/SerializationHelper.h
+++ b/src/Savegame/SerializationHelper.h
@@ -21,12 +21,14 @@
 #define OPENXCOM_SERHELP_H
 
 #include <SDL_types.h>
+#include <string>
 
 namespace OpenXcom
 {
 
 int unserializeInt(Uint8 **buffer, Uint8 sizeKey);
 void serializeInt(Uint8 **buffer, Uint8 sizeKey, int value);
+std::string serializeDouble(double value);
 
 }
 

--- a/src/Savegame/Target.cpp
+++ b/src/Savegame/Target.cpp
@@ -64,8 +64,8 @@ void Target::load(const YAML::Node &node)
 YAML::Node Target::save() const
 {
 	YAML::Node node;
-	node["lon"] = _lon;
-	node["lat"] = _lat;
+	node["lon"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _lon).str();
+	node["lat"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _lat).str();
 	return node;
 }
 
@@ -76,8 +76,8 @@ YAML::Node Target::save() const
 YAML::Node Target::saveId() const
 {
 	YAML::Node node;
-	node["lon"] = _lon;
-	node["lat"] = _lat;
+	node["lon"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _lon).str();
+	node["lat"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _lat).str();
 	return node;
 }
 

--- a/src/Savegame/Target.cpp
+++ b/src/Savegame/Target.cpp
@@ -21,6 +21,7 @@
 #include <cmath>
 #include "../Engine/Language.h"
 #include "Craft.h"
+#include "SerializationHelper.h"
 
 namespace OpenXcom
 {
@@ -64,8 +65,8 @@ void Target::load(const YAML::Node &node)
 YAML::Node Target::save() const
 {
 	YAML::Node node;
-	node["lon"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _lon).str();
-	node["lat"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _lat).str();
+	node["lon"] = serializeDouble(_lon);
+	node["lat"] = serializeDouble(_lat);
 	return node;
 }
 
@@ -76,8 +77,8 @@ YAML::Node Target::save() const
 YAML::Node Target::saveId() const
 {
 	YAML::Node node;
-	node["lon"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _lon).str();
-	node["lat"] = static_cast<std::ostringstream&>(std::ostringstream() << std::hexfloat << _lat).str();
+	node["lon"] = serializeDouble(_lon);
+	node["lat"] = serializeDouble(_lat);
 	return node;
 }
 


### PR DESCRIPTION
http://openxcom.org/bugs/openxcom/issues/892 is the crash
https://code.google.com/p/yaml-cpp/issues/detail?id=197 -- this is an issue in yaml-cpp

My code works around the imprecision in yaml-cpp by pre-serializing doubles to hexfloat format. Old savegames remain compatible.