### PR TITLE
Feature: When unit has fatal wounds, his health bar will be flashing.

### DIFF
--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -1378,7 +1378,7 @@ void BattlescapeState::blinkVisibleUnitButtons()
  */
 void BattlescapeState::blinkHealthBar()
 {
-	static Uint8 color = _barHealth->getColor(), maxcolor = (color & 0xF0) + 8;
+	static Uint8 color = _barHealth->getColor(), maxcolor = color + 3, step = 0;
 
 	BattleUnit *bu = _save->getSelectedUnit();
 	if (bu == 0 || !_barHealth->getVisible()) return;
@@ -1387,9 +1387,10 @@ void BattlescapeState::blinkHealthBar()
 	{
 		if (bu->getFatalWound(i) > 0)
 		{
-			_barHealth->setColor(color++);
+			_barHealth->setColor(color);
+			color += step ^= 1;		// +1, +0, +1, +0, ...
 			if (color > maxcolor)
-				color = maxcolor & 0xF0;
+				color = maxcolor - 3;
 			break;
 		}
 	}

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -1246,6 +1246,7 @@ bool BattlescapeState::playableUnitSelected()
  */
 void BattlescapeState::updateSoldierInfo()
 {
+	static Uint8 barHealthColor = _barHealth->getColor();
 	BattleUnit *battleUnit = _save->getSelectedUnit();
 
 	for (int i = 0; i < VISIBLE_MAX; ++i)
@@ -1301,6 +1302,7 @@ void BattlescapeState::updateSoldierInfo()
 	_barHealth->setMax(battleUnit->getBaseStats()->health);
 	_barHealth->setValue(battleUnit->getHealth());
 	_barHealth->setValue2(battleUnit->getStunlevel());
+	_barHealth->setColor(barHealthColor);
 	_numMorale->setValue(battleUnit->getMorale());
 	_barMorale->setMax(100);
 	_barMorale->setValue(battleUnit->getMorale());
@@ -1372,6 +1374,28 @@ void BattlescapeState::blinkVisibleUnitButtons()
 }
 
 /**
+ * Shifts the colors of the health bar when unit has fatal wounds.
+ */
+void BattlescapeState::blinkHealthBar()
+{
+	static Uint8 color = _barHealth->getColor(), maxcolor = (color & 0xF0) + 8;
+
+	BattleUnit *bu = _save->getSelectedUnit();
+	if (bu == 0 || !_barHealth->getVisible()) return;
+
+	for (int i = 0; i < 6; i++)
+	{
+		if (bu->getFatalWound(i) > 0)
+		{
+			_barHealth->setColor(color++);
+			if (color > maxcolor)
+				color = maxcolor & 0xF0;
+			break;
+		}
+	}
+}
+
+/**
  * Popups a context sensitive list of actions the user can choose from.
  * Some actions result in a change of gamestate.
  * @param item Item the user clicked on (righthand/lefthand)
@@ -1401,6 +1425,7 @@ void BattlescapeState::animate()
 	_map->animate(!_battleGame->isBusy());
 
 	blinkVisibleUnitButtons();
+	blinkHealthBar();
 }
 
 /**

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -1380,17 +1380,17 @@ void BattlescapeState::blinkHealthBar()
 {
 	static Uint8 color = _barHealth->getColor(), maxcolor = color + 3, step = 0;
 
+	step ^= 1;	// 1, 0, 1, 0, ...
 	BattleUnit *bu = _save->getSelectedUnit();
-	if (bu == 0 || !_barHealth->getVisible()) return;
+	if (step == 0 || bu == 0 || !_barHealth->getVisible()) return;
+
+	if (++color > maxcolor) color = maxcolor - 3;
 
 	for (int i = 0; i < 6; i++)
 	{
 		if (bu->getFatalWound(i) > 0)
 		{
 			_barHealth->setColor(color);
-			color += step ^= 1;		// +1, +0, +1, +0, ...
-			if (color > maxcolor)
-				color = maxcolor - 3;
 			break;
 		}
 	}

--- a/src/Battlescape/BattlescapeState.h
+++ b/src/Battlescape/BattlescapeState.h
@@ -85,6 +85,8 @@ private:
 	void handleItemClick(BattleItem *item);
 	/// Shifts the red colors of the visible unit buttons backgrounds.
 	void blinkVisibleUnitButtons();
+	/// Shifts the colors of the health bar when unit has fatal wounds.
+	void blinkHealthBar();
 public:
 	/// Selects the next soldier.
 	void selectNextPlayerUnit(bool checkReselect = false, bool setReselect = false, bool checkInventory = false);


### PR DESCRIPTION
Sometimes good soldiers dies because of fatal wounds.
Sometimes good soldiers dies because of fatal wounds because player not know that this soldier has fatal wounds. Because good soldiers cannot speak.

This feature improves the game experience.
When unit has fatal wounds, his health bar will be flashing.
![screen020](https://cloud.githubusercontent.com/assets/3616568/6765312/92d19884-cfeb-11e4-8fd3-2dc276f3c79e.png)
![screen021](https://cloud.githubusercontent.com/assets/3616568/6765313/97eed606-cfeb-11e4-9f29-66b1f4c7fb4b.png)
