### PR TITLE
Improved recolor

### DIFF
--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -345,7 +345,7 @@ void BattlescapeGenerator::run()
 			_terrain = _game->getRuleset()->getTerrain(ruleDeploy->getTerrains().at(pick));
 		}
 		else
-		{			
+		{
 			Target *target = _ufo;
 			if (_mission) target = _mission;
 			_terrain = _game->getRuleset()->getTerrain(_worldTexture->getRandomTerrain(target));

--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -704,7 +704,6 @@ BattleUnit *BattlescapeGenerator::addXCOMUnit(BattleUnit *unit)
 			unit->setDirection(RNG::generate(0,7));
 			_save->getUnits()->push_back(unit);
 			_save->getTileEngine()->calculateFOV(unit);
-			unit->deriveRank();
 			unit->setSpecialWeapon(_save, _game->getRuleset());
 			return unit;
 		}
@@ -716,7 +715,6 @@ BattleUnit *BattlescapeGenerator::addXCOMUnit(BattleUnit *unit)
 				unit->setDirection(RNG::generate(0,7));
 				_save->getUnits()->push_back(unit);
 				_save->getTileEngine()->calculateFOV(unit);
-				unit->deriveRank();
 				unit->setSpecialWeapon(_save, _game->getRuleset());
 				return unit;
 			}
@@ -742,7 +740,6 @@ BattleUnit *BattlescapeGenerator::addXCOMUnit(BattleUnit *unit)
 				{
 					_save->getUnits()->push_back(unit);
 					unit->setDirection(dir);
-					unit->deriveRank();
 					unit->setSpecialWeapon(_save, _game->getRuleset());
 					return unit;
 				}
@@ -758,7 +755,6 @@ BattleUnit *BattlescapeGenerator::addXCOMUnit(BattleUnit *unit)
 				if (_save->setUnitPosition(unit, _save->getTiles()[i]->getPosition()))
 				{
 					_save->getUnits()->push_back(unit);
-					unit->deriveRank();
 					unit->setSpecialWeapon(_save, _game->getRuleset());
 					return unit;
 				}

--- a/src/Battlescape/UnitSprite.h
+++ b/src/Battlescape/UnitSprite.h
@@ -40,7 +40,8 @@ private:
 	SurfaceSet *_unitSurface, *_itemSurfaceA, *_itemSurfaceB;
 	int _part, _animationFrame, _drawingRoutine;
 	bool _helmet;
-	std::pair<Uint8, Uint8> _colorA, _colorB;
+	const std::pair<Uint8, Uint8> *_color;
+	int _colorSize;
 
 	/// Drawing routine for XCom soldiers in overalls, sectoids (routine 0),
 	/// mutons (routine 10),

--- a/src/Ruleset/Armor.cpp
+++ b/src/Ruleset/Armor.cpp
@@ -31,13 +31,11 @@ Armor::Armor(const std::string &type) :
 	_type(type), _frontArmor(0), _sideArmor(0), _rearArmor(0), _underArmor(0),
 	_drawingRoutine(0), _movementType(MT_WALK), _size(1), _weight(0),
 	_deathFrames(3), _constantAnimation(false), _canHoldWeapon(false),
-	_forcedTorso(TORSO_USE_GENDER), _faceColorGroup(0), _hairColorGroup(0)
+	_forcedTorso(TORSO_USE_GENDER),
+	_faceColorGroup(0), _hairColorGroup(0), _utileColorGroup(0), _rankColorGroup(0)
 {
 	for (int i=0; i < DAMAGE_TYPES; i++)
 		_damageModifier[i] = 1.0f;
-
-	_faceColor.resize((LOOK_AFRICAN + 1) * 2);
-	_hairColor.resize((LOOK_AFRICAN + 1) * 2);
 }
 
 /**
@@ -113,16 +111,12 @@ void Armor::load(const YAML::Node &node)
 
 	_faceColorGroup = node["spriteFaceGroup"].as<int>(_faceColorGroup);
 	_hairColorGroup = node["spriteHairGroup"].as<int>(_hairColorGroup);
-	if (const YAML::Node& colors = node["spriteFaceColor"])
-	{
-		for (size_t i = 0; i < colors.size() && i < _faceColor.size(); ++i)
-			_faceColor[i] = colors[i].as<int>();
-	}
-	if (const YAML::Node& colors = node["spriteHairColor"])
-	{
-		for (size_t i = 0; i < colors.size() && i < _hairColor.size(); ++i)
-			_hairColor[i] = colors[i].as<int>();
-	}
+	_rankColorGroup = node["spriteRankGroup"].as<int>(_rankColorGroup);
+	_utileColorGroup = node["spriteUtileGroup"].as<int>(_utileColorGroup);
+	_faceColor = node["spriteFaceColor"].as<std::vector<int> >(_faceColor);
+	_hairColor = node["spriteHairColor"].as<std::vector<int> >(_hairColor);
+	_rankColor = node["spriteRankColor"].as<std::vector<int> >(_rankColor);
+	_utileColor = node["spriteUtileColor"].as<std::vector<int> >(_utileColor);
 }
 
 /**
@@ -331,8 +325,8 @@ ForcedTorso Armor::getForcedTorso() const
 }
 
 /**
- * Gets hair base color group for replacement, if -1 then don't replace colors.
- * @return Color group or -1.
+ * Gets hair base color group for replacement, if 0 then don't replace colors.
+ * @return Color group or 0.
  */
 int Armor::getFaceColorGroup() const
 {
@@ -340,8 +334,8 @@ int Armor::getFaceColorGroup() const
 }
 
 /**
- * Gets hair base color group for replacement, if -1 then don't replace colors.
- * @return Color group or -1.
+ * Gets hair base color group for replacement, if 0 then don't replace colors.
+ * @return Color group or 0.
  */
 int Armor::getHairColorGroup() const
 {
@@ -349,20 +343,85 @@ int Armor::getHairColorGroup() const
 }
 
 /**
- * Gets new face colors for replacement.
- * @return Vector with new values based on gender and race.
+ * Gets utile base color group for replacement, if 0 then don't replace colors.
+ * @return Color group or 0.
  */
-const std::vector<int>& Armor::getFaceColor() const
+int Armor::getUtileColorGroup() const
 {
-	return _faceColor;
+	return _utileColorGroup;
 }
 
 /**
- * Gets new hair colors for replacement.
- * @return Vector with new values based on gender and race.
+ * Gets rank base color group for replacement, if 0 then don't replace colors.
+ * @return Color group or 0.
  */
-const std::vector<int>& Armor::getHairColor() const
+int Armor::getRankColorGroup() const
 {
-	return _hairColor;
+	return _rankColorGroup;
 }
+
+/**
+ * Gets new face colors for replacement, if 0 then don't replace colors.
+ * @return Color index or 0.
+ */
+int Armor::getFaceColor(int i) const
+{
+	if ((size_t)i < _faceColor.size())
+	{
+		return _faceColor[i];
+	}
+	else
+	{
+		return 0;
+	}
+}
+
+/**
+ * Gets new hair colors for replacement, if 0 then don't replace colors.
+ * @return Color index or 0.
+ */
+int Armor::getHairColor(int i) const
+{
+	if ((size_t)i < _hairColor.size())
+	{
+		return _hairColor[i];
+	}
+	else
+	{
+		return 0;
+	}
+}
+
+/**
+ * Gets new utile colors for replacement, if 0 then don't replace colors.
+ * @return Color index or 0.
+ */
+int Armor::getUtileColor(int i) const
+{
+	if ((size_t)i < _utileColor.size())
+	{
+		return _utileColor[i];
+	}
+	else
+	{
+		return 0;
+	}
+}
+
+/**
+ * Gets new rank colors for replacement, if 0 then don't replace colors.
+ * @return Color index or 0.
+ */
+int Armor::getRankColor(int i) const
+{
+	if ((size_t)i < _rankColor.size())
+	{
+		return _rankColor[i];
+	}
+	else
+	{
+		return 0;
+	}
+}
+
 }

--- a/src/Ruleset/Armor.h
+++ b/src/Ruleset/Armor.h
@@ -51,8 +51,8 @@ private:
 	bool _constantAnimation;
 	bool _canHoldWeapon;
 	ForcedTorso _forcedTorso;
-	int _faceColorGroup, _hairColorGroup;
-	std::vector<int> _faceColor, _hairColor;
+	int _faceColorGroup, _hairColorGroup, _utileColorGroup, _rankColorGroup;
+	std::vector<int> _faceColor, _hairColor, _utileColor, _rankColor;
 public:
 	/// Creates a blank armor ruleset.
 	Armor(const std::string &type);
@@ -108,10 +108,18 @@ public:
 	int getFaceColorGroup() const;
 	/// Get hair base color
 	int getHairColorGroup() const;
+	/// Get utile base color
+	int getUtileColorGroup() const;
+	/// Get rank base color
+	int getRankColorGroup() const;
 	/// Get face base color
-	const std::vector<int>& getFaceColor() const;
+	int getFaceColor(int i) const;
 	/// Get hair base color
-	const std::vector<int>& getHairColor() const;
+	int getHairColor(int i) const;
+	/// Get utile base color
+	int getUtileColor(int i) const;
+	/// Get rank base color
+	int getRankColor(int i) const;
 };
 
 }

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -127,7 +127,10 @@ BattleUnit::BattleUnit(Soldier *soldier, int depth) :
 
 	lastCover = Position(-1, -1, -1);
 
-	setRecolor(soldier->getGender() + 2 * (soldier->getLook()));
+	deriveRank();
+
+	int look = soldier->getGender() + 2 * soldier->getLook();
+	setRecolor(look, look, _rankInt);
 }
 
 /**
@@ -225,7 +228,35 @@ BattleUnit::BattleUnit(Unit *unit, UnitFaction faction, int id, Armor *armor, in
 
 	lastCover = Position(-1, -1, -1);
 
-	setRecolor(std::rand() % 8);
+	int generalRank = 0;
+	if (faction == FACTION_HOSTILE)
+	{
+		const int max = 7;
+		const char* rankList[max] =
+		{
+			"STR_LIVE_SOLDIER",
+			"STR_LIVE_ENGINEER",
+			"STR_LIVE_MEDIC",
+			"STR_LIVE_NAVIGATOR",
+			"STR_LIVE_LEADER",
+			"STR_LIVE_COMMANDER",
+			"STR_LIVE_TERRORIST",
+		};
+		for (int i = 0; i < max; ++i)
+		{
+			if (_rank.compare(rankList[i]) == 0)
+			{
+				generalRank = i;
+				break;
+			}
+		}
+	}
+	else if (faction == FACTION_NEUTRAL)
+	{
+		generalRank = std::rand() % 8;
+	}
+
+	setRecolor(std::rand() % 8, std::rand() % 8, generalRank);
 }
 
 
@@ -287,10 +318,10 @@ void BattleUnit::load(const YAML::Node &node)
 
 	if (const YAML::Node& p = node["recolor"])
 	{
-		for (size_t i = 0; i < 2; ++i)
+		_recolor.clear();
+		for (size_t i = 0; i < p.size(); ++i)
 		{
-			_recolor[i].first = p[i][0].as<Uint8>();
-			_recolor[i].second = p[i][1].as<Uint8>();
+			_recolor.push_back(std::make_pair(p[i][0].as<int>(), p[i][1].as<int>()));
 		}
 	}
 }
@@ -352,37 +383,40 @@ YAML::Node BattleUnit::save() const
 	node["respawn"] = _respawn;
 	node["activeHand"] = _activeHand;
 
-	for (size_t i = 0; i < 2; ++i)
+	for (size_t i = 0; i < _recolor.size(); ++i)
 	{
 		YAML::Node p;
-		p.push_back(_recolor[i].first);
-		p.push_back(_recolor[i].second);
+		p.push_back((int)_recolor[i].first);
+		p.push_back((int)_recolor[i].second);
 		node["recolor"].push_back(p);
 	}
 
 	return node;
 }
 
-void BattleUnit::setRecolor(int selectLook)
+/**
+ * Prepare vector values for recolor.
+ * @param basicLook select index for hair and face color.
+ * @param utileLook select index for utile color.
+ * @param rankLook select index for rank color.
+ */
+void BattleUnit::setRecolor(int basicLook, int utileLook, int rankLook)
 {
-	int BaseColor = 0;
-
-	int faceColor = _armor->getFaceColor()[selectLook];
-	int faceColorGroup = _armor->getFaceColorGroup();
-	if (faceColorGroup > 0 && faceColor >= 0)
+	const int colorsMax = 4;
+	std::pair<int, int> colors[colorsMax] =
 	{
-		_recolor[BaseColor].first = faceColorGroup << 4;
-		_recolor[BaseColor].second = faceColor;
-		++BaseColor;
-	}
+		std::make_pair(_armor->getFaceColorGroup(), _armor->getFaceColor(basicLook)),
+		std::make_pair(_armor->getHairColorGroup(), _armor->getHairColor(basicLook)),
+		std::make_pair(_armor->getUtileColorGroup(), _armor->getUtileColor(utileLook)),
+		std::make_pair(_armor->getRankColorGroup(), _armor->getRankColor(rankLook)),
+	};
 
-	int hairColor = _armor->getHairColor()[selectLook];
-	int hairColorGroup = _armor->getHairColorGroup();
-	if (hairColorGroup > 0 && hairColor >= 0)
+	for (int i = 0; i < colorsMax; ++i)
 	{
-		_recolor[BaseColor].first = hairColorGroup << 4;
-		_recolor[BaseColor].second = hairColor;
-		++BaseColor;
+		if (colors[i].first > 0 && colors[i].second > 0)
+		{
+			_recolor.push_back(std::make_pair(colors[i].first << 4, colors[i].second));
+		}
 	}
 }
 
@@ -851,16 +885,9 @@ Surface *BattleUnit::getCache(bool *invalid, int part) const
  * @param i what value choose.
  * @return Pairs of value, where first is color group to replace and second is new color group with shade.
  */
-std::pair<Uint8, Uint8> BattleUnit::getRecolor(int i) const
+const std::vector<std::pair<Uint8, Uint8> > &BattleUnit::getRecolor() const
 {
-	if (i >= 0 && i < 2)
-	{
-		return _recolor[i];
-	}
-	else
-	{
-		return std::pair<Uint8, Uint8>(0, 0);
-	}
+	return _recolor;
 }
 
 /**

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -121,9 +121,10 @@ private:
 	bool _breathing;
 	bool _hidingForTurn, _floorAbove, _respawn;
 	MovementType _movementType;
-	std::pair<Uint8, Uint8> _recolor[2];
+	std::vector<std::pair<Uint8, Uint8> > _recolor;
 
-	void setRecolor(int selectLook);
+	/// Helper function initing recolor vector.
+	void setRecolor(int basicLook, int utileLook, int rankLook);
 public:
 	static const int MAX_SOLDIER_ID = 1000000;
 	/// Creates a BattleUnit from solder.
@@ -187,7 +188,7 @@ public:
 	/// If this unit is cached on the battlescape.
 	Surface *getCache(bool *invalid, int part = 0) const;
 	/// Gets unit sprite recolors values.
-	std::pair<Uint8, Uint8> getRecolor(int i) const;
+	const std::vector<std::pair<Uint8, Uint8> > &getRecolor() const;
 	/// Kneel down.
 	void kneel(bool kneeled);
 	/// Is kneeled?

--- a/src/Savegame/SavedBattleGame.cpp
+++ b/src/Savegame/SavedBattleGame.cpp
@@ -188,6 +188,7 @@ void SavedBattleGame::load(const YAML::Node &node, Ruleset *rule, SavedGame* sav
 	for (YAML::const_iterator i = node["units"].begin(); i != node["units"].end(); ++i)
 	{
 		UnitFaction faction = (UnitFaction)(*i)["faction"].as<int>();
+		UnitFaction originalFaction = (UnitFaction)(*i)["originalFaction"].as<int>(faction);
 		int id = (*i)["soldierId"].as<int>();
 		BattleUnit *unit;
 		if (id < BattleUnit::MAX_SOLDIER_ID) // Unit is linked to a geoscape soldier
@@ -200,7 +201,7 @@ void SavedBattleGame::load(const YAML::Node &node, Ruleset *rule, SavedGame* sav
 			std::string type = (*i)["genUnitType"].as<std::string>();
 			std::string armor = (*i)["genUnitArmor"].as<std::string>();
 			// create a new Unit.
-			unit = new BattleUnit(rule->getUnit(type), faction, id, rule->getArmor(armor), savedGame->getDifficulty(), _depth);
+			unit = new BattleUnit(rule->getUnit(type), originalFaction, id, rule->getArmor(armor), savedGame->getDifficulty(), _depth);
 		}
 		unit->load(*i);
 		unit->setSpecialWeapon(this, rule);
@@ -209,13 +210,6 @@ void SavedBattleGame::load(const YAML::Node &node, Ruleset *rule, SavedGame* sav
 		{
 			if ((unit->getId() == selectedUnit) || (_selectedUnit == 0 && !unit->isOut()))
 				_selectedUnit = unit;
-			
-			// silly hack to fix mind controlled aliens
-			// TODO: save stats instead? maybe some kind of weapon will affect them at some point.
-			if (unit->getOriginalFaction() == FACTION_HOSTILE)
-			{
-				unit->adjustStats(savedGame->getDifficulty());
-			}
 		}
 		if (unit->getStatus() != STATUS_DEAD)
 		{

--- a/src/Savegame/SavedBattleGame.cpp
+++ b/src/Savegame/SavedBattleGame.cpp
@@ -58,7 +58,7 @@ SavedBattleGame::SavedBattleGame() : _battleState(0), _mapsize_x(0), _mapsize_y(
 	for (int i = 0; i < 121; ++i)
 	{
 		_tileSearch[i].x = ((i%11) - 5);
-		_tileSearch[i].y = ((i/11) - 5); 
+		_tileSearch[i].y = ((i/11) - 5);
 	}
 }
 
@@ -136,7 +136,7 @@ void SavedBattleGame::load(const YAML::Node &node, Ruleset *rule, SavedGame* sav
 			getTile(pos)->load((*i));
 		}
 	}
-	else 
+	else
 	{
 		// load key to how the tile data was saved
 		Tile::SerializationKey serKey;
@@ -151,7 +151,7 @@ void SavedBattleGame::load(const YAML::Node &node, Ruleset *rule, SavedGame* sav
 		serKey._mapDataSetID = node["tileSetIDSize"].as<Uint8>(serKey._mapDataSetID);
 		serKey.boolFields = node["tileBoolFieldsSize"].as<Uint8>(1); // boolean flags used to be stored in an unmentioned byte (Uint8) :|
 
-		// load binary tile data! 
+		// load binary tile data!
 		YAML::Binary binTiles = node["binTiles"].as<YAML::Binary>();
 
 		Uint8 *r = (Uint8*)binTiles.data();
@@ -949,7 +949,7 @@ void SavedBattleGame::resetUnitTiles()
 		}
 	}
 }
- 
+
 /**
  * Gives access to the "storage space" vector, for distribution of items in base defense missions.
  * @return Vector of storage positions.
@@ -1112,9 +1112,9 @@ Node *SavedBattleGame::getSpawnNode(int nodeRank, BattleUnit *unit)
 	for (std::vector<Node*>::iterator i = getNodes()->begin(); i != getNodes()->end(); ++i)
 	{
 		if ((*i)->getRank() == nodeRank								// ranks must match
-			&& (!((*i)->getType() & Node::TYPE_SMALL) 
+			&& (!((*i)->getType() & Node::TYPE_SMALL)
 				|| unit->getArmor()->getSize() == 1)				// the small unit bit is not set or the unit is small
-			&& (!((*i)->getType() & Node::TYPE_FLYING) 
+			&& (!((*i)->getType() & Node::TYPE_FLYING)
 				|| unit->getMovementType() == MT_FLY)				// the flying unit bit is not set or the unit can fly
 			&& (*i)->getPriority() > 0								// priority 0 is no spawnplace
 			&& setUnitPosition(unit, (*i)->getPosition(), true))	// check if not already occupied
@@ -1175,7 +1175,7 @@ Node *SavedBattleGame::getPatrolNode(bool scout, BattleUnit *unit, Node *fromNod
 			&& (!scout || n != fromNode)																// scouts push forward
 			&& n->getPosition().x > 0 && n->getPosition().y > 0)
 		{
-			if (!preferred 
+			if (!preferred
 				|| (preferred->getRank() == Node::nodeRank[unit->getRankInt()][0] && preferred->getFlags() < n->getFlags())
 				|| preferred->getFlags() < n->getFlags())
 			{
@@ -1441,7 +1441,7 @@ bool SavedBattleGame::setUnitPosition(BattleUnit *bu, const Position &position, 
 		{
 			Tile *t = getTile(position + Position(x,y,0));
 			Tile *tb = getTile(position + Position(x,y,-1));
-			if (t == 0 || 
+			if (t == 0 ||
 				(t->getUnit() != 0 && t->getUnit() != bu) ||
 				t->getTUCost(MapData::O_OBJECT, bu->getMovementType()) == 255 ||
 				(t->hasNoFloor(tb) && bu->getMovementType() != MT_FLY) ||


### PR DESCRIPTION
I made some fix to ION armor on load because it's messy. Its mix colors form different color groups that is problematic for my recoloring and even worse for normal shading. Some colors used are form 9 group that don't have proper shades.

New recolor values used by aquanauts:

      spriteFaceGroup: 14
      spriteFaceColor: [160, 160, 64, 160, 160, 64, 160, 160] #M0 F0 M1 F1 M2 F2 M3 F3
      spriteHairGroup: 4
      spriteHairColor: [16, 16, 204, 160, 64, 200, 160, 64] #M0 F0 M1 F1 M2 F2 M3 F3


Added support for third color and color based on rank for mod proposes.
To made it work I made proper fix for faction of MC units. battle unit constructor is always call with proper fraction.
I find too bug in yaml that break saves. I used `Uint8` for saving values but sometimes its output value that it can load back (e.g. whitespace `" "` can't be load back).
I switch to `int` to prevent this bug. One drawback is that old battlescape saves can't be load.
Is possible to prevent it and maintain compatibility but it would require some special code only for this.
But for now I choose simples solution (this can be fixed by users if they relay want by removing nodes with it form save).