### PR TITLE
Feature: Unhardcoded first turn when AI can use grenades, launchers etc (alternative version)

### DIFF
--- a/bin/data/Ruleset/Xcom1Ruleset/items.rul
+++ b/bin/data/Ruleset/Xcom1Ruleset/items.rul
@@ -832,6 +832,7 @@ items:
     invHeight: 3
     recoveryPoints: 5
     armor: 40
+    turnAICanUse: 3
   - type: STR_BLASTER_BOMB
     requires:
       - STR_BLASTER_BOMB
@@ -899,6 +900,7 @@ items:
     damageType: 3
     battleType: 4
     recoveryPoints: 1
+    turnAICanUse: 3
     blastRadius: 5
   - type: STR_ELERIUM_115
     size: 0.1

--- a/bin/data/Ruleset/Xcom1Ruleset/items.rul
+++ b/bin/data/Ruleset/Xcom1Ruleset/items.rul
@@ -832,7 +832,7 @@ items:
     invHeight: 3
     recoveryPoints: 5
     armor: 40
-    turnAICanUse: 3
+    aiUseDelay: 3
   - type: STR_BLASTER_BOMB
     requires:
       - STR_BLASTER_BOMB
@@ -900,7 +900,7 @@ items:
     damageType: 3
     battleType: 4
     recoveryPoints: 1
-    turnAICanUse: 3
+    aiUseDelay: 3
     blastRadius: 5
   - type: STR_ELERIUM_115
     size: 0.1

--- a/src/Battlescape/AlienBAIState.cpp
+++ b/src/Battlescape/AlienBAIState.cpp
@@ -189,7 +189,7 @@ void AlienBAIState::think(BattleAction *action)
 	if (action->weapon)
 	{
 		RuleItem *rule = action->weapon->getRules();
-		if (rule->getTurnAICanUse() <= _save->getTurn()
+		if (_save->getTurn() >= rule->getAIUseDelay()
 			&& (!rule->isWaterOnly() || _save->getDepth() != 0))
 		{
 			if (rule->getBattleType() == BT_FIREARM)
@@ -218,7 +218,7 @@ void AlienBAIState::think(BattleAction *action)
 	}
 
 	BattleItem *grenade = _unit->getGrenadeFromBelt();
-	_grenade = grenade != 0 && grenade->getRules()->getTurnAICanUse() <= _save->getTurn();
+	_grenade = grenade != 0 && _save->getTurn() >= grenade->getRules()->getAIUseDelay();
 
 	if (_spottingEnemies && !_escapeTUs)
 	{

--- a/src/Battlescape/AlienBAIState.cpp
+++ b/src/Battlescape/AlienBAIState.cpp
@@ -51,7 +51,7 @@ namespace OpenXcom
  * @param node Pointer to the node the unit originates from.
  */
 AlienBAIState::AlienBAIState(SavedBattleGame *save, BattleUnit *unit, Node *node) : BattleAIState(save, unit), _aggroTarget(0), _knownEnemies(0), _visibleEnemies(0), _spottingEnemies(0),
-																				_escapeTUs(0), _ambushTUs(0), _reserveTUs(0), _rifle(false), _melee(false), _blaster(false),
+																				_escapeTUs(0), _ambushTUs(0), _reserveTUs(0), _rifle(false), _melee(false), _blaster(false), _grenade(false),
 																				_didPsi(false), _AIMode(AI_PATROL), _closestDist(100), _fromNode(node), _toNode(0)
 {
 	_traceAI = Options::traceAI;
@@ -189,7 +189,8 @@ void AlienBAIState::think(BattleAction *action)
 	if (action->weapon)
 	{
 		RuleItem *rule = action->weapon->getRules();
-		if (!rule->isWaterOnly() || _save->getDepth() != 0)
+		if (rule->getTurnAICanUse() <= _save->getTurn()
+			&& (!rule->isWaterOnly() || _save->getDepth() != 0))
 		{
 			if (rule->getBattleType() == BT_FIREARM)
 			{
@@ -215,6 +216,9 @@ void AlienBAIState::think(BattleAction *action)
 			action->weapon = 0;
 		}
 	}
+
+	BattleItem *grenade = _unit->getGrenadeFromBelt();
+	_grenade = grenade != 0 && grenade->getRules()->getTurnAICanUse() <= _save->getTurn();
 
 	if (_spottingEnemies && !_escapeTUs)
 	{
@@ -721,8 +725,7 @@ void AlienBAIState::setupAttack()
 		{
 			selectMeleeOrRanged();
 		}
-
-		if (_unit->getGrenadeFromBelt())
+		if (_grenade)
 		{
 			grenadeAction();
 		}
@@ -1496,9 +1499,6 @@ bool AlienBAIState::findFirePoint()
  */
 bool AlienBAIState::explosiveEfficacy(Position targetPos, BattleUnit *attackingUnit, int radius, int diff, bool grenade) const
 {
-	// i hate the player and i want him dead, but i don't want to piss him off.
-	if (_save->getTurn() < 3)
-		return false;
 	if (diff == -1)
 	{
 		diff = (int)(_save->getBattleState()->getGame()->getSavedGame()->getDifficulty());
@@ -2054,10 +2054,6 @@ void AlienBAIState::selectMeleeOrRanged()
  */
 bool AlienBAIState::getNodeOfBestEfficacy(BattleAction *action)
 {
-	// i hate the player and i want him dead, but i don't want to piss him off.
-	if (_save->getTurn() < 3)
-		return false;
-
 	int bestScore = 2;
 	Position originVoxel = _save->getTileEngine()->getSightOriginVoxel(_unit);
 	Position targetVoxel;

--- a/src/Battlescape/AlienBAIState.h
+++ b/src/Battlescape/AlienBAIState.h
@@ -42,7 +42,7 @@ protected:
 	int _knownEnemies, _visibleEnemies, _spottingEnemies;
 	int _escapeTUs, _ambushTUs, _reserveTUs;
 	BattleAction *_escapeAction, *_ambushAction, *_attackAction, *_patrolAction, *_psiAction;
-	bool _rifle, _melee, _blaster;
+	bool _rifle, _melee, _blaster, _grenade;
 	bool _traceAI, _didPsi;
 	int _AIMode, _intelligence, _closestDist;
 	Node *_fromNode, *_toNode;

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -985,6 +985,13 @@ bool TileEngine::tryReaction(BattleUnit *unit, BattleUnit *target, int attackTyp
 	{
 		return false;
 	}
+
+	// check restrictions for aliens
+	if (unit->getFaction() == FACTION_HOSTILE && _save->getTurn() < action.weapon->getRules()->getAIUseDelay())
+	{
+		return false;
+	}
+
 	action.type = (BattleActionType)(attackType);
 	action.target = target->getPosition();
 	action.TU = unit->getActionTUs(action.type, action.weapon);

--- a/src/Ruleset/RuleItem.cpp
+++ b/src/Ruleset/RuleItem.cpp
@@ -30,7 +30,7 @@ namespace OpenXcom
  */
 RuleItem::RuleItem(const std::string &type) : _type(type), _name(type), _size(0.0), _costBuy(0), _costSell(0), _transferTime(24), _weight(3), _bigSprite(0), _floorSprite(-1), _handSprite(120), _bulletSprite(-1), _fireSound(-1), _hitSound(-1), _hitAnimation(0), _power(0), _damageType(DT_NONE),
 											_accuracyAuto(0), _accuracySnap(0), _accuracyAimed(0), _tuAuto(0), _tuSnap(0), _tuAimed(0), _clipSize(0), _accuracyMelee(0), _tuMelee(0), _battleType(BT_NONE), _twoHanded(false), _waypoint(false), _fixedWeapon(false), _invWidth(1), _invHeight(1),
-											_painKiller(0), _heal(0), _stimulant(0), _woundRecovery(0), _healthRecovery(0), _stunRecovery(0), _energyRecovery(0), _tuUse(0), _recoveryPoints(0), _armor(20), _turretType(-1), _turnAICanUse(0), _recover(true), _liveAlien(false), _blastRadius(-1), _attraction(0),
+											_painKiller(0), _heal(0), _stimulant(0), _woundRecovery(0), _healthRecovery(0), _stunRecovery(0), _energyRecovery(0), _tuUse(0), _recoveryPoints(0), _armor(20), _turretType(-1), _aiUseDelay(0), _recover(true), _liveAlien(false), _blastRadius(-1), _attraction(0),
 											_flatRate(false), _arcingShot(false), _listOrder(0), _maxRange(200), _aimRange(200), _snapRange(15), _autoRange(7), _minRange(0), _dropoff(2), _bulletSpeed(0), _explosionSpeed(0), _autoShots(3), _shotgunPellets(0),
 											_strengthApplied(false), _skillApplied(true), _LOSRequired(false), _underwaterOnly(false), _meleeSound(39), _meleePower(0), _meleeAnimation(0), _meleeHitSound(-1), _specialType(-1), _vaporColor(-1), _vaporDensity(0), _vaporProbability(15)
 {
@@ -158,7 +158,7 @@ void RuleItem::load(const YAML::Node &node, int modIndex, int listOrder)
 	_recoveryPoints = node["recoveryPoints"].as<int>(_recoveryPoints);
 	_armor = node["armor"].as<int>(_armor);
 	_turretType = node["turretType"].as<int>(_turretType);
-	_turnAICanUse = node["turnAICanUse"].as<int>(_turnAICanUse);
+	_aiUseDelay = node["aiUseDelay"].as<int>(_aiUseDelay);
 	_recover = node["recover"].as<bool>(_recover);
 	_liveAlien = node["liveAlien"].as<bool>(_liveAlien);
 	_blastRadius = node["blastRadius"].as<int>(_blastRadius);

--- a/src/Ruleset/RuleItem.cpp
+++ b/src/Ruleset/RuleItem.cpp
@@ -30,7 +30,7 @@ namespace OpenXcom
  */
 RuleItem::RuleItem(const std::string &type) : _type(type), _name(type), _size(0.0), _costBuy(0), _costSell(0), _transferTime(24), _weight(3), _bigSprite(0), _floorSprite(-1), _handSprite(120), _bulletSprite(-1), _fireSound(-1), _hitSound(-1), _hitAnimation(0), _power(0), _damageType(DT_NONE),
 											_accuracyAuto(0), _accuracySnap(0), _accuracyAimed(0), _tuAuto(0), _tuSnap(0), _tuAimed(0), _clipSize(0), _accuracyMelee(0), _tuMelee(0), _battleType(BT_NONE), _twoHanded(false), _waypoint(false), _fixedWeapon(false), _invWidth(1), _invHeight(1),
-											_painKiller(0), _heal(0), _stimulant(0), _woundRecovery(0), _healthRecovery(0), _stunRecovery(0), _energyRecovery(0), _tuUse(0), _recoveryPoints(0), _armor(20), _turretType(-1), _recover(true), _liveAlien(false), _blastRadius(-1), _attraction(0),
+											_painKiller(0), _heal(0), _stimulant(0), _woundRecovery(0), _healthRecovery(0), _stunRecovery(0), _energyRecovery(0), _tuUse(0), _recoveryPoints(0), _armor(20), _turretType(-1), _turnAICanUse(0), _recover(true), _liveAlien(false), _blastRadius(-1), _attraction(0),
 											_flatRate(false), _arcingShot(false), _listOrder(0), _maxRange(200), _aimRange(200), _snapRange(15), _autoRange(7), _minRange(0), _dropoff(2), _bulletSpeed(0), _explosionSpeed(0), _autoShots(3), _shotgunPellets(0),
 											_strengthApplied(false), _skillApplied(true), _LOSRequired(false), _underwaterOnly(false), _meleeSound(39), _meleePower(0), _meleeAnimation(0), _meleeHitSound(-1), _specialType(-1), _vaporColor(-1), _vaporDensity(0), _vaporProbability(15)
 {
@@ -158,6 +158,7 @@ void RuleItem::load(const YAML::Node &node, int modIndex, int listOrder)
 	_recoveryPoints = node["recoveryPoints"].as<int>(_recoveryPoints);
 	_armor = node["armor"].as<int>(_armor);
 	_turretType = node["turretType"].as<int>(_turretType);
+	_turnAICanUse = node["turnAICanUse"].as<int>(_turnAICanUse);
 	_recover = node["recover"].as<bool>(_recover);
 	_liveAlien = node["liveAlien"].as<bool>(_liveAlien);
 	_blastRadius = node["blastRadius"].as<int>(_blastRadius);

--- a/src/Ruleset/RuleItem.h
+++ b/src/Ruleset/RuleItem.h
@@ -61,6 +61,7 @@ private:
 	int _recoveryPoints;
 	int _armor;
 	int _turretType;
+	int _turnAICanUse;
 	bool _recover, _liveAlien;
 	int _blastRadius, _attraction;
 	bool _flatRate, _arcingShot;
@@ -169,6 +170,8 @@ public:
 	bool isRecoverable() const;
 	/// Gets the item's turret type.
 	int getTurretType() const;
+	/// Gets first turn when AI can use item.
+	int getTurnAICanUse() const {return _turnAICanUse;}
 	/// Checks if this a live alien.
 	bool isAlien() const;
 	/// Should we charge a flat rate?

--- a/src/Ruleset/RuleItem.h
+++ b/src/Ruleset/RuleItem.h
@@ -61,7 +61,7 @@ private:
 	int _recoveryPoints;
 	int _armor;
 	int _turretType;
-	int _turnAICanUse;
+	int _aiUseDelay;
 	bool _recover, _liveAlien;
 	int _blastRadius, _attraction;
 	bool _flatRate, _arcingShot;
@@ -171,7 +171,7 @@ public:
 	/// Gets the item's turret type.
 	int getTurretType() const;
 	/// Gets first turn when AI can use item.
-	int getTurnAICanUse() const {return _turnAICanUse;}
+	int getAIUseDelay() const {return _aiUseDelay;}
 	/// Checks if this a live alien.
 	bool isAlien() const;
 	/// Should we charge a flat rate?


### PR DESCRIPTION
The same as https://github.com/SupSuper/OpenXcom/pull/993 but more general.
Topic: http://openxcom.org/forum/index.php/topic,3219.30.html
This version adds rule for each item: first turn when AI can use this item. 