### PR TITLE
Fix rendering of wrapped elements in TextLists

### DIFF
--- a/src/Interface/Text.cpp
+++ b/src/Interface/Text.cpp
@@ -293,6 +293,11 @@ Uint8 Text::getSecondaryColor() const
 	return _color2;
 }
 
+int Text::getNumLines() const
+{
+	return _wrap ? _lineHeight.size() : 1;
+}
+
 /**
  * Returns the rendered text's height. Useful to check if wordwrap applies.
  * @param line Line to get the height, or -1 to get whole text height.

--- a/src/Interface/Text.h
+++ b/src/Interface/Text.h
@@ -98,6 +98,8 @@ public:
 	void setSecondaryColor(Uint8 color);
 	/// Gets the text's secondary color.
 	Uint8 getSecondaryColor() const;
+	/// Gets the number of lines in the (wrapped, if wrapping is enabled) text
+	int getNumLines() const;
 	/// Gets the rendered text's width.
 	int getTextWidth(int line = -1) const;
 	/// Gets the rendered text's height.


### PR DESCRIPTION
There were two bugs here that I found and fixed while exploring the UI:
1) if the longest wrapped line in a row was not in the first column, the
rendered text would collide with the next rendered row
2) if a wrapped text element spanned more than two rows, it would be
scrolled incorrectly

The first I fixed by ensuring all elements in a row are set to the
height of the tallest element so draw() will pick up the correct Y delta
when incrementing the offset for the next row.

The second I fixed by replacing the "check row - 1" logic in draw()
(which could only handle wrapped text of two lines maximum) with a loop
that can handle wrapped text of arbitrary length.