### PR TITLE
Fix: fix "Space Used" in Alien containment

### DIFF
--- a/src/Basescape/ManageAlienContainmentState.cpp
+++ b/src/Basescape/ManageAlienContainmentState.cpp
@@ -207,10 +207,9 @@ void ManageAlienContainmentState::btnOkClick(Action *)
 	if (Options::storageLimitsEnforced && _base->storesOverfull())
 	{
 		_game->pushState(new SellState(_base, _origin));
-		if (_origin == OPT_BATTLESCAPE)
-			_game->pushState(new ErrorMessageState(tr("STR_STORAGE_EXCEEDED").arg(_base->getName()).c_str(), _palette, _game->getRuleset()->getInterface("manageContainment")->getElement("errorMessage")->color, "BACK01.SCR", _game->getRuleset()->getInterface("manageContainment")->getElement("errorPalette")->color));
-		else
-			_game->pushState(new ErrorMessageState(tr("STR_STORAGE_EXCEEDED").arg(_base->getName()).c_str(), _palette, _game->getRuleset()->getInterface("manageContainment")->getElement("errorMessage")->color, "BACK13.SCR", _game->getRuleset()->getInterface("manageContainment")->getElement("errorPalette")->color));
+
+		const char *backXX_scr = (_origin == OPT_BATTLESCAPE) ? "BACK01.SCR" : "BACK13.SCR";
+		_game->pushState(new ErrorMessageState(tr("STR_STORAGE_EXCEEDED").arg(_base->getName()).c_str(), _palette, _game->getRuleset()->getInterface("manageContainment")->getElement("errorMessage")->color, backXX_scr, _game->getRuleset()->getInterface("manageContainment")->getElement("errorPalette")->color));
  	}
 }
 

--- a/src/Basescape/ManageAlienContainmentState.cpp
+++ b/src/Basescape/ManageAlienContainmentState.cpp
@@ -50,18 +50,9 @@ namespace OpenXcom
  * @param base Pointer to the base to get info from.
  * @param origin Game section that originated this state.
  */
-ManageAlienContainmentState::ManageAlienContainmentState(Base *base, OptionsOrigin origin) : _base(base), _origin(origin), _sel(0), _aliensSold(0), _researchedAliens(0)
+ManageAlienContainmentState::ManageAlienContainmentState(Base *base, OptionsOrigin origin) : _base(base), _origin(origin), _sel(0), _aliensSold(0)
 {
 	_overCrowded = Options::storageLimitsEnforced && _base->getAvailableContainment() < _base->getUsedContainment();
-
-	for (std::vector<ResearchProject*>::const_iterator iter = _base->getResearch().begin(); iter != _base->getResearch().end(); ++iter)
-	{
-		const RuleResearch *research = (*iter)->getRules();
-		if (_game->getRuleset()->getUnit(research->getName()))
-		{
-			++_researchedAliens;
-		}
-	}
 
 	// Create objects
 	_window = new Window(this, 320, 200, 0, 0);
@@ -122,9 +113,9 @@ ManageAlienContainmentState::ManageAlienContainmentState(Base *base, OptionsOrig
 	_txtDeadAliens->setWordWrap(true);
 	_txtDeadAliens->setVerticalAlign(ALIGN_BOTTOM);
 
-	_txtAvailable->setText(tr("STR_SPACE_AVAILABLE").arg(_base->getAvailableContainment() - _base->getUsedContainment() - _researchedAliens));
+	_txtAvailable->setText(tr("STR_SPACE_AVAILABLE").arg(_base->getAvailableContainment() - _base->getUsedContainment()));
 
-	_txtUsed->setText(tr("STR_SPACE_USED").arg( _base->getUsedContainment() + _researchedAliens));
+	_txtUsed->setText(tr("STR_SPACE_USED").arg(_base->getUsedContainment()));
 
 	_lstAliens->setArrowColumn(184, ARROW_HORIZONTAL);
 	_lstAliens->setColumns(3, 150, 84, 46);
@@ -406,7 +397,7 @@ void ManageAlienContainmentState::updateStrings()
 	_lstAliens->setCellText(_sel, 1, ss.str());
 	_lstAliens->setCellText(_sel, 2, ss2.str());
 
-	int aliens = _base->getUsedContainment() - (_aliensSold - _researchedAliens);
+	int aliens = _base->getUsedContainment() - _aliensSold;
 	int spaces = _base->getAvailableContainment() - aliens;
 	bool enoughSpace = Options::storageLimitsEnforced ? spaces >= 0 : true;
 

--- a/src/Basescape/ManageAlienContainmentState.h
+++ b/src/Basescape/ManageAlienContainmentState.h
@@ -51,7 +51,7 @@ private:
 	std::vector<int> _qtys;
 	std::vector<std::string> _aliens;
 	size_t _sel;
-	int _aliensSold, _researchedAliens;
+	int _aliensSold;
 	bool _overCrowded;
 	/// Gets selected quantity.
 	int getQuantity();

--- a/src/Basescape/ManageAlienContainmentState.h
+++ b/src/Basescape/ManageAlienContainmentState.h
@@ -51,8 +51,7 @@ private:
 	std::vector<int> _qtys;
 	std::vector<std::string> _aliens;
 	size_t _sel;
-	int _aliensSold;
-	bool _overCrowded;
+	int _aliensSold, _spaceUsed, _spaceAvailable;
 	/// Gets selected quantity.
 	int getQuantity();
 public:


### PR DESCRIPTION
fix of http://openxcom.org/bugs/openxcom/issues/897

**Before fix**
1 Alien containment after loading. All OK
![screen008](https://cloud.githubusercontent.com/assets/3616568/7289511/deadc8ac-e979-11e4-88a4-bb0fb2ac9969.png)

2 One muton sent to interrogation. Option "Storage limits" is **off**.
"Space Used" and "Space Available" shows wrong values.
![screen009](https://cloud.githubusercontent.com/assets/3616568/7289530/23503c24-e97a-11e4-8513-bea3ca3f2049.png)

3 One muton sent to interrogation. Option "Storage limits" is **on**.
"Space Used" and "Space Available" shows wrong values.
![screen010](https://cloud.githubusercontent.com/assets/3616568/7289542/48ce164c-e97a-11e4-8400-b461033c8450.png)

**After fix**
4 One muton sent to interrogation. Option "Storage limits" is **off**.
"Space Used" and "Space Available" shows right values.
![screen011](https://cloud.githubusercontent.com/assets/3616568/7289560/8c9a9346-e97a-11e4-8a2a-92e4a63f8523.png)

5 One muton sent to interrogation. Option "Storage limits" is **on**.
"Space Used" and "Space Available" shows right values.
![screen012](https://cloud.githubusercontent.com/assets/3616568/7289575/c8e0737a-e97a-11e4-9806-5e116fce3b0f.png)

Researched aliens counted in Base::getUsedContainment() https://github.com/SupSuper/OpenXcom/blob/master/src/Savegame/Base.cpp#L1126

PR#1000 :-)