### PR TITLE
Relax item level requirements

### DIFF
--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -947,11 +947,13 @@ void BattlescapeGenerator::deployAliens(AlienDeployment *deployment)
 				}
 				else
 				{
+					if ((*d).itemSets.size() == 0)
+					{
+						throw Exception("Unit generator encountered an error: item set not defined");
+					}
 					if (itemLevel >= (*d).itemSets.size())
 					{
-						std::stringstream ss;
-						ss << "Unit generator encountered an error: not enough item sets defined, expected: " << itemLevel + 1 << " found: " << (*d).itemSets.size();
-						throw Exception(ss.str());
+						itemLevel = (*d).itemSets.size() - 1;
 					}
 					for (std::vector<std::string>::iterator it = (*d).itemSets.at(itemLevel).items.begin(); it != (*d).itemSets.at(itemLevel).items.end(); ++it)
 					{


### PR DESCRIPTION
Now if ilvl > max level then it use last level available.
Its fix problems when you try run two mods with different item levels.