### PR TITLE
Add melee availability to statstring conditions

### DIFF
--- a/bin/standard/XcomUtil_Statstrings/XcomUtil_Statstrings.rul
+++ b/bin/standard/XcomUtil_Statstrings/XcomUtil_Statstrings.rul
@@ -1,6 +1,7 @@
 # Based on XcomUtil by Scott Jones and BladeFireLight
 # See http://ufopaedia.org/index.php?title=Statstrings
 # These are the default statStrings from XcomUtil.
+# Melee has been added as a value that can be reported by statstrings.  Use "melee:" as the criteria.
   statStrings:
   - string: "x"
     psiStrength: [~, 30]

--- a/src/Ruleset/StatString.cpp
+++ b/src/Ruleset/StatString.cpp
@@ -43,7 +43,7 @@ StatString::~StatString()
  */
 void StatString::load(const YAML::Node &node)
 {
-    std::string conditionNames[] = {"psiStrength", "psiSkill", "bravery", "strength", "firing", "reactions", "stamina", "tu", "health", "throwing"};
+    std::string conditionNames[] = {"psiStrength", "psiSkill", "bravery", "strength", "firing", "reactions", "stamina", "tu", "health", "throwing", "melee"};
 	_stringToBeAddedIfAllConditionsAreMet = node["string"].as<std::string>(_stringToBeAddedIfAllConditionsAreMet);
     for (size_t i = 0; i < sizeof(conditionNames)/sizeof(conditionNames[0]); i++)
 	{
@@ -160,6 +160,7 @@ std::map<std::string, int> StatString::getCurrentStats(UnitStats &currentStats)
 	currentStatsMap["tu"] = currentStats.tu;
 	currentStatsMap["health"] = currentStats.health;
 	currentStatsMap["throwing"] = currentStats.throwing;
+	currentStatsMap["melee"] = currentStats.melee;
 	return currentStatsMap;
 }
 


### PR DESCRIPTION
This modifies two files and makes the Melee attribute available to XcomUtil's Custom StatStrings.
Tested by Meridian, Arthanor, & IvanDogovich