### PR TITLE
Adlib fix

### DIFF
--- a/src/Resource/XcomResourcePack.cpp
+++ b/src/Resource/XcomResourcePack.cpp
@@ -307,8 +307,8 @@ XcomResourcePack::XcomResourcePack(Ruleset *rules) : ResourcePack()
 
 	// Load surface sets
 	std::string sets[] = {"BASEBITS.PCK",
-						  "INTICON.PCK",
-						  "TEXTURE.DAT"};
+			      "INTICON.PCK",
+			      "TEXTURE.DAT"};
 
 	for (size_t i = 0; i < sizeof(sets)/sizeof(sets[0]); ++i)
 	{
@@ -1080,12 +1080,12 @@ bool XcomResourcePack::isImageFile(std::string extension)
 Music *XcomResourcePack::loadMusic(MusicFormat fmt, const std::string &file, int track, float volume, CatFile *adlibcat, CatFile *aintrocat, GMCatFile *gmcat)
 {
 	/* MUSIC_AUTO, MUSIC_FLAC, MUSIC_OGG, MUSIC_MP3, MUSIC_MOD, MUSIC_WAV, MUSIC_ADLIB, MUSIC_MIDI */
-	static const std::string exts[] = {"", "flac", "ogg", "mp3", "mod", "wav", "", "mid"};
+	static const std::string exts[] = {"", ".flac", ".ogg", ".mp3", ".mod", ".wav", "", ".mid"};
 	Music *music = 0;
 	std::set<std::string> soundContents = FileMap::getVFolderContents("SOUND");
 	try
 	{
-		std::string fname = file + "." + exts[fmt];
+		std::string fname = file + exts[fmt];
 		std::transform(fname.begin(), fname.end(), fname.begin(), tolower);
 
 		// Try Adlib music


### PR DESCRIPTION
fix looking up of adlib sound files

when looking for files in the virtual directory, it is a string compare.  the extra '.' at the end of the extension-less files causes the string compare to fail.