### PR TITLE
don't spam the logs when probing for armor sprites

### DIFF
--- a/src/Battlescape/InventoryState.cpp
+++ b/src/Battlescape/InventoryState.cpp
@@ -341,7 +341,10 @@ void InventoryState::init()
 		if (s->getLook() == LOOK_AFRICAN)
 			look += "3";
 		look += ".SPK";
-		if (!CrossPlatform::fileExists(FileMap::getFilePath("UFOGRAPH/" + look)) && !_game->getResourcePack()->getSurface(look))
+		const std::set<std::string> &ufographContents = FileMap::getVFolderContents("UFOGRAPH");
+		std::string lcaseLook = look;
+		std::transform(lcaseLook.begin(), lcaseLook.end(), lcaseLook.begin(), tolower);
+		if (ufographContents.find("lcaseLook") == ufographContents.end() && !_game->getResourcePack()->getSurface(look))
 		{
 			look = s->getArmor()->getSpriteInventory() + ".SPK";
 		}


### PR DESCRIPTION
custom armors will fail the UFOGRAPH probe, which will cause
FileMap::mapFile to spit out a useless error message.  use the vfolder
lookup method to avoid the error message