### PR TITLE
allow UFO and TFTD in the user folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ at:
 
 Do not use modded versions (e.g. with XcomUtil) as they may cause bugs and
 crashes.  Copy the UFO subfolders to the UFO subdirectory in OpenXcom's data
-folder and/or the TFTD subfolders to the TFTD subdirectory in OpenXcom's data
-folder (see below for data folder locations).
+or user folder and/or the TFTD subfolders to the TFTD subdirectory in OpenXcom's
+data or user folder (see below for folder locations).
 
 ## Mods
 

--- a/bin/TFTD/README.txt
+++ b/bin/TFTD/README.txt
@@ -1,5 +1,9 @@
 Copy all the X-COM: Terror From the Deep subfolders to this directory!
 
+If you can't write to this directory, you can also create a TFTD folder in your
+user folder (where your OpenXcom savegames are) and copy your TFTD subfolders
+there.
+
 After the copy, this directory should contain at least the following items:
   FLOP_INT
   GEODATA

--- a/bin/UFO/README.txt
+++ b/bin/UFO/README.txt
@@ -1,5 +1,9 @@
 Copy all the UFO: Enemy Unknown / X-COM: UFO Defense subfolders to this directory!
 
+If you can't write to this directory, you can also create a UFO folder in your
+user folder (where your OpenXcom savegames are) and copy your UFO subfolders
+there.
+
 After the copy, this directory should contain at least the following items:
   GEODATA
   GEOGRAPH


### PR DESCRIPTION
- allows all external resource dirs to be loaded from the user folder
- make UFO and TFTD game detection routines more friendly so we can
still detect that the games are installed even on case sensitive files
where all files have been lcased (which was a popular way to get the game
running in OpenXcom 1.0 on Linux)