### PR TITLE
support pre-mission cutscenes

### DIFF
--- a/src/Battlescape/BriefingState.cpp
+++ b/src/Battlescape/BriefingState.cpp
@@ -40,6 +40,7 @@
 #include <sstream>
 #include "../Engine/Options.h"
 #include "../Engine/Screen.h"
+#include "../Menu/CutsceneState.h"
 
 namespace OpenXcom
 {
@@ -76,19 +77,21 @@ BriefingState::BriefingState(Craft *craft, Base *base)
 	if (!deployment) // none defined - should never happen, but better safe than sorry i guess.
 	{
 		setPalette("PAL_GEOSCAPE", 0);
-		_game->getResourcePack()->playMusic("GMDEFEND");
+		_musicId = "GMDEFEND";
 		_window->setBackground(_game->getResourcePack()->getSurface("BACK16.SCR"));
 	}
 	else
 	{
 		BriefingData data = deployment->getBriefingData();
 		setPalette("PAL_GEOSCAPE", data.palette);
-		_game->getResourcePack()->playMusic(data.music);
 		_window->setBackground(_game->getResourcePack()->getSurface(data.background));
 		_txtCraft->setY(56 + data.textOffset);
 		_txtBriefing->setY(72 + data.textOffset);
 		_txtTarget->setVisible(data.showTarget);
 		_txtCraft->setVisible(data.showCraft);
+
+		_cutsceneId = data.cutscene;
+		_musicId = data.music;
 	}
 
 	add(_window, "window", "briefing");
@@ -154,6 +157,23 @@ BriefingState::BriefingState(Craft *craft, Base *base)
 BriefingState::~BriefingState()
 {
 
+}
+
+void BriefingState::init()
+{
+	State::init();
+
+	if (!_cutsceneId.empty())
+	{
+		_game->pushState(new CutsceneState(_cutsceneId));
+
+		// don't play the cutscene again when we return to this state
+		_cutsceneId = "";
+	}
+	else
+	{
+		_game->getResourcePack()->playMusic(_musicId);
+	}
 }
 
 /**

--- a/src/Battlescape/BriefingState.h
+++ b/src/Battlescape/BriefingState.h
@@ -40,11 +40,14 @@ private:
 	TextButton *_btnOk;
 	Window *_window;
 	Text *_txtTitle, *_txtTarget, *_txtCraft, *_txtBriefing;
+	std::string _cutsceneId, _musicId;
 public:
 	/// Creates the Briefing state.
 	BriefingState(Craft *craft = 0, Base *base = 0);
 	/// Cleans up the Briefing state.
 	~BriefingState();
+	/// Initialization
+	void init();
 	/// Handler for clicking the Ok button.
 	void btnOkClick(Action *action);
 };

--- a/src/Ruleset/AlienDeployment.cpp
+++ b/src/Ruleset/AlienDeployment.cpp
@@ -80,6 +80,7 @@ namespace YAML
 			node["palette"] = rhs.palette;
 			node["textOffset"] = rhs.textOffset;
 			node["music"] = rhs.music;
+			node["cutscene"] = rhs.cutscene;
 			node["background"] = rhs.background;
 			node["showCraft"] = rhs.showCraft;
 			node["showTarget"] = rhs.showTarget;
@@ -92,6 +93,7 @@ namespace YAML
 			rhs.palette = node["palette"].as<int>(rhs.palette);
 			rhs.textOffset = node["textOffset"].as<int>(rhs.textOffset);
 			rhs.music = node["music"].as<std::string>(rhs.music);
+			rhs.cutscene = node["cutscene"].as<std::string>(rhs.cutscene);
 			rhs.background = node["background"].as<std::string>(rhs.background);
 			rhs.showCraft = node["showCraft"].as<bool>(rhs.showCraft);
 			rhs.showTarget = node["showTarget"].as<bool>(rhs.showTarget);

--- a/src/Ruleset/AlienDeployment.h
+++ b/src/Ruleset/AlienDeployment.h
@@ -44,7 +44,7 @@ struct DeploymentData
 struct BriefingData
 {
 	int palette, textOffset;
-	std::string music, background;
+	std::string music, background, cutscene;
 	bool showCraft, showTarget;
 	BriefingData() : palette(0), textOffset(0), music("GMDEFEND"), background("BACK16.SCR"), showCraft(true), showTarget(true) { /*Empty by Design*/ };
 };


### PR DESCRIPTION
This was a request from SupSuper to support the pre-T'leth cutscene.  Cutscenes can now be associated with briefing data and will be shown before the associated briefing screen.