### PR TITLE
Fixes Compiling with pre-compiled dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,16 +39,10 @@ if ( IS_DIRECTORY ${DEPS_DIR} )
    set ( SDLMIXER_LIBRARY SDL_mixer )
    set ( SDLIMAGE_LIBRARY SDL_image )
    set ( YAMLCPP_LIBRARY yaml-cpp )
+   set ( YAMLCPP_LIBRARY_DEBUG yaml-cppd )
 else ( )
   find_package ( SDL2 COMPONENTS mixer gfx image)
   find_package ( Yaml_cpp 0.5.0)
-  find_package ( OpenGL )
-
-  if ( NOT OPENGL_FOUND )
-	  message ( FATAL_ERROR "Can't find OpenGL; how does that even happen?" )
-  else ()
-	  include_directories ( ${OPENGL_INCLUDE_DIR} )
-  endif ()
 
   if ( NOT SDL_FOUND )
     message ( FATAL_ERROR "Can't find SDL which is required" )
@@ -85,6 +79,12 @@ else ( )
     message ( "found yaml-cpp(${YAMLCPP_LIBRARY_DIRS}:${YAMLCPP_INCLUDE_DIR})" )
   endif ( NOT YAMLCPP_FOUND )
 endif()
+
+# Find OpenGL
+find_package ( OpenGL )
+if ( NOT OPENGL_FOUND )
+  message ( FATAL_ERROR "Can't find OpenGL; how does that even happen?" )
+endif ()
 
 # Read version number
 set ( file "${CMAKE_SOURCE_DIR}/src/version.h" )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -762,7 +762,7 @@ if ( WIN32 )
   endif ()
   set ( system_libs ${basic_windows_libs} SDLmain ${static_flags} )
 endif ()
-target_link_libraries ( openxcom ${system_libs} ${SDLIMAGE_LIBRARY} ${SDLMIXER_LIBRARY} ${SDLGFX_LIBRARY} ${SDL_LIBRARY} ${YAMLCPP_LIBRARY} ${OPENGL_gl_LIBRARY} )
+target_link_libraries ( openxcom ${system_libs} ${SDLIMAGE_LIBRARY} ${SDLMIXER_LIBRARY} ${SDLGFX_LIBRARY} ${SDL_LIBRARY} ${OPENGL_gl_LIBRARY} debug ${YAMLCPP_LIBRARY_DEBUG} optimized ${YAMLCPP_LIBRARY} )
 
 set ( bin_data_dirs TFTD UFO common standard )
 foreach ( binpath ${bin_data_dirs} )


### PR DESCRIPTION
1) Find OpenGL package without relying on whether the pre-compiled dependencies (deps folder) are used. Removed the include directories variable for OpenGL, since they seem not to be referenced elsewhere.
2) YAML Debug library is now correctly linked for the debug configuration (produced compiler errors)