### PR TITLE
Append mission zones instead of overwriting

### DIFF
--- a/src/Ruleset/RuleRegion.cpp
+++ b/src/Ruleset/RuleRegion.cpp
@@ -63,7 +63,8 @@ void RuleRegion::load(const YAML::Node &node)
 		_latMin.push_back(areas[i][2] * M_PI / 180.0);
 		_latMax.push_back(areas[i][3] * M_PI / 180.0);
 	}
-	_missionZones = node["missionZones"].as< std::vector<MissionZone> >(_missionZones);
+	std::vector<MissionZone> misZones = node["missionZones"].as< std::vector<MissionZone> >(misZones);
+	_missionZones.insert(_missionZones.end(), misZones.begin(), misZones.end());
 	if (const YAML::Node &weights = node["missionWeights"])
 	{
 		_missionWeights.load(weights);


### PR DESCRIPTION
For modding purposes - append new mission zones instead of overwriting - so no need to copy/paste zones/cities from one mod to another...
Modders can use if needed the delete region option for overwrite effect.