### PR TITLE
Ranks compared with saved race instead rank.

### DIFF
--- a/src/Savegame/SaveConverter.cpp
+++ b/src/Savegame/SaveConverter.cpp
@@ -146,7 +146,7 @@ SaveConverter::SaveConverter(int save, Ruleset *rule) : _rule(rule)
 					_idAlienRaces.push_back(race);
 				}
 				std::string rank = i->substr(n);
-				if (std::find(_idAlienRanks.begin(), _idAlienRanks.end(), race) == _idAlienRanks.end())
+				if (std::find(_idAlienRanks.begin(), _idAlienRanks.end(), rank) == _idAlienRanks.end())
 				{
 					_idAlienRanks.push_back(rank);
 				}


### PR DESCRIPTION
Instead unique ranks converter pushes all ranks from all aliens.
For first 6 ranks that OK, but terrorists would becomes commanders instead, after this game crashes in Base Info screen as non existed alien do not have weight.
See http://openxcom.org/forum/index.php?topic=3677.msg46125 for actual issue.