### PR TITLE
Bug in palette copy

### DIFF
--- a/src/Engine/Surface.cpp
+++ b/src/Engine/Surface.cpp
@@ -893,7 +893,7 @@ void Surface::resize(int width, int height)
 
 	// Copy old contents
 	SDL_SetColorKey(surface, SDL_SRCCOLORKEY, 0);
-	SDL_SetColors(surface, getPalette(), 0, 255);
+	SDL_SetColors(surface, getPalette(), 0, 256);
 	SDL_BlitSurface(_surface, 0, surface, 0);
 
 	// Delete old surface


### PR DESCRIPTION
We need copy 256 not 255 colors in palette.
This bug didn't surface because in 99.9% cases palettes are ignored.