### PR TITLE
Fix melee attack

### DIFF
--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -620,7 +620,6 @@ void BattlescapeGame::handleNonTargetAction()
 		if (!_currentAction.result.empty())
 		{
 			_parentState->warning(_currentAction.result);
-			_currentAction.result = "";
 		}
 		if (_currentAction.type == BA_PRIME && _currentAction.value > -1)
 		{
@@ -652,6 +651,7 @@ void BattlescapeGame::handleNonTargetAction()
 				}
 			}
 		}
+		_currentAction.result = "";
 		_currentAction.type = BA_NONE;
 		_parentState->updateSoldierInfo();
 	}


### PR DESCRIPTION
line `_currentAction.result = "";` will cause `if (_currentAction.result.empty())` to pass. We get error but still can melee attack?