### PR TITLE
fix address errors

### DIFF
--- a/src/Engine/OpenGL.cpp
+++ b/src/Engine/OpenGL.cpp
@@ -295,10 +295,10 @@ Uint32 (APIENTRYP wglSwapIntervalEXT)(int interval);
 
 
 
-    shader_support = &glCreateProgram && &glUseProgram && &glCreateShader
-    && &glDeleteShader && &glShaderSource && &glCompileShader && &glAttachShader
-    && &glDetachShader && &glLinkProgram && &glGetUniformLocation
-    && &glUniform1i && &glUniform2fv && &glUniform4fv;
+    shader_support = glCreateProgram && glUseProgram && glCreateShader
+    && glDeleteShader && glShaderSource && glCompileShader && glAttachShader
+    && glDetachShader && glLinkProgram && glGetUniformLocation
+    && glUniform1i && glUniform2fv && glUniform4fv;
 	
     if (shader_support) glprogram = glCreateProgram();
 


### PR DESCRIPTION
This reverts the OpenGL part of commit 038bb833378b38ca4751280ae5cf23d2db33e03e.  I don't know clang warnings that tried to fix, but the current code can't be right.  Every variable has a non-null address because it is a variable.  There is no such thing as a homeless variable.  So, `shader_support` always evaluates to true.  g++ righteously complains about this and (with -Werror) refuses to compile the code:

    src/Engine/OpenGL.cpp:298:43: error: the address of ‘OpenXcom::glCreateProgram’ will always evaluate as ‘true’ [-Werror=address]
         shader_support = &glCreateProgram && &glUseProgram && &glCreateShader