### PR TITLE
Only load difficulty from IGLOB.DAT if present

### DIFF
--- a/src/Savegame/SaveConverter.cpp
+++ b/src/Savegame/SaveConverter.cpp
@@ -325,13 +325,13 @@ void SaveConverter::loadDatIGlob()
 	int second = load<int>(data + 0x14);
 	_save->setTime(GameTime(weekday, day, month, _year, hour, minute, second));
 
-	int difficulty = load<int>(data + 0x3C);
-	// if the save was affected by the difficulty bug, this will have a garbage value
-	// tests show this value to be negative, and as a result, rather hilariously,
-	// the game will be reset to beginner.
-	// TODO: when we add the difficulty coefficient, account for TFTD's values here.
-	difficulty = std::min(4, std::max(0, difficulty));
-	_save->setDifficulty((GameDifficulty)difficulty);
+	// The save file might be missing the difficulty due to this bug:
+	// http://www.ufopaedia.org/index.php?title=Known_Bugs#Difficulty_Bug
+	if (buffer.size() > 0x3C)
+	{
+		int difficulty = load<int>(data + 0x3C);
+		_save->setDifficulty((GameDifficulty)difficulty);
+	}
 
 	// Fix up the months
 	int monthsPassed = month + (_year - _rule->getStartingTime().getYear()) * 12;


### PR DESCRIPTION
A bug in the DOS versions of UFO causes the difficulty to be missing
from IGLOB.DAT. Prior to this change, whatever happened to be in memory
past the end of the data vector was loaded as the difficulty. This could
result in aliens having extremely high or negative stats and surprising
end-of-month results.