### PR TITLE
Makefile.am: fix parallel build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -712,6 +712,7 @@ dist-hook:
 	fi
 
 install-data-local:
+	mkdir -p $(DESTDIR)$(pkgdatadir)
 	cp -r $(top_srcdir)/bin/* $(DESTDIR)$(pkgdatadir)/ ; \
 	find $(DESTDIR)$(pkgdatadir) | xargs chmod a=rX,u+w
 


### PR DESCRIPTION
Hi,

I'm working on packaging this for Debian (and the commercial data with `game-data-packager`)

I have the `install-data-local` rule fail because $(DESTDIR)$(pkgdatadir) doesn't exist.

It's maybe linked to the parallel build.

I guess a little `mkdir -p $(DESTDIR)$(pkgdatadir)` wouldn't hurt; even
if it's not needed for other environments.

Alexandre Detiste

PS:

Is this license really applicable ?
https://github.com/SupSuper/OpenXcom/blob/master/bin/standard/xcom1/Resources/Weapons/license.txt


Here is my current debian/rules:

```
#!/usr/bin/make -f
#export DH_VERBOSE=1

%:
        dh $@ --parallel --with autotools-dev,autoreconf
#--buildsystem=qmake

override_dh_auto_configure:
        ./configure --prefix=/usr --bindir=/usr/games --disable-werror --without-docs

override_dh_auto_install:
        mkdir -p debian/openxcom/usr/share/openxcom/
        dh_auto_install

        # SVG icon not square nor centered
        # only one of two PNG icon got automaticaly installed
        install -D -m 0644 res/linux/icons/openxcom_48x48.png debian/openxcom/usr/share/icons/hicolor/48x48/apps/openxcom.png
        install -D -m 0644 res/linux/icons/openxcom_128x128.png debian/openxcom/usr/share/icons/hicolor/128x128/apps/openxcom.png
        rm -vf debian/openxcom/usr/share/pixmaps/openxcom.png
        rm -vf debian/openxcom/usr/share/pixmaps/openxcom.svg
        rmdir --ignore-fail-on-non-empty debian/openxcom/usr/share/pixmaps

        # copy of GPL 3
        rm -vf debian/openxcom/usr/share/doc/openxcom/LICENSE.txt*
        # same as changelog.txt.gz
        rm -vf debian/openxcom/usr/share/doc/openxcom/CHANGELOG.txt*
```