### PR TITLE
dual-license Weapons/Terror.png

### DIFF
--- a/bin/standard/xcom1/Resources/Weapons/license.txt
+++ b/bin/standard/xcom1/Resources/Weapons/license.txt
@@ -1,7 +1,12 @@
 Artwork (c) Niklas Jansson (http://androidarts.com/)
 
 This artwork is licensed under a
-Creative Commons Attribution-ShareAlike 4.0 International License.
+Creative Commons Attribution-ShareAlike 4.0 International License;
+or alternatively under version 3 of the GNU General Public License.
 
-You should have received a copy of the license along with this
+
+You should have received a copy of the CC SA license along with this
 work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
+
+A copy of the GNU GPL-3 license is present in this
+project's repository at /LICENSE.txt.


### PR DESCRIPTION
Can you please ensure that the whole work is GPL-3 licensed ?
It makes packaging & copyright review easier.

src/Engine/RNG.cpp is Public Domain + GPL-3, that's fine too.

For the rest I would say this project is very well maintained :smile: 

---------------------------------------------------------

Date: Tue, 4 Aug 2015 19:31:51 +0200
Message-ID: `<CA+L7Mz3oZAN=a_yV6yZkW1Mf1pvWfxoRdkYZLgRUBJ-NOCNMTw@mail.gmail.com>`
Subject: Re: OpenXCom
From: Niklas Jansson `edited`
To: Alexandre Detiste `<`alexandre.detiste@gmail.com`>`

Do with them as you like.
` - n`

On Sun, Aug 2, 2015 at 2:34 PM, Alexandre Detiste <
alexandre.detiste@gmail.com> wrote:

> Hi
>
> I'm working on packaging OpenXCom for Debian Linux.
>
>
> I stumbled on this:
>
>
> https://github.com/SupSuper/OpenXcom/blob/master/bin/standard/xcom1/Resources/Weapons/license.txt
>
> > Artwork (c) Niklas Jansson (http://androidarts.com/)
> >
> > This artwork is licensed under a
> > Creative Commons Attribution-ShareAlike 4.0 International License.
> >
> > You should have received a copy of the license along with this
> > work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
>
> Does it apply to Terror.png in the same folder ? To other files too ? Not
> any file at all ?
>
> If applicable, would you be OK to relicense your works under the GPL-3
> License,
> like the rest of OpenXCom.
>
> That would spare me a lot of head-ache for this tiny picture.
>
>
> https://github.com/SupSuper/OpenXcom/blob/master/bin/standard/xcom1/Resources/Weapons/Terror.png
>
>
> Cheers,
>
> Alexandre Detiste