### PR TITLE
Make each game Master (xcom1, xcom2) have own autosave slots.

### DIFF
--- a/src/Menu/LoadGameState.cpp
+++ b/src/Menu/LoadGameState.cpp
@@ -55,16 +55,17 @@ LoadGameState::LoadGameState(OptionsOrigin origin, const std::string &filename, 
  */
 LoadGameState::LoadGameState(OptionsOrigin origin, SaveType type, SDL_Color *palette) : _firstRun(0), _origin(origin)
 {
+	std::string curMaster = Options::getActiveMaster();
 	switch (type)
 	{
 	case SAVE_QUICK:
-		_filename = SavedGame::QUICKSAVE;
+		_filename = curMaster + SavedGame::QUICKSAVE;
 		break;
 	case SAVE_AUTO_GEOSCAPE:
-		_filename = SavedGame::AUTOSAVE_GEOSCAPE;
+		_filename = curMaster + SavedGame::AUTOSAVE_GEOSCAPE;
 		break;
 	case SAVE_AUTO_BATTLESCAPE:
-		_filename = SavedGame::AUTOSAVE_BATTLESCAPE;
+		_filename = curMaster + SavedGame::AUTOSAVE_BATTLESCAPE;
 		break;
 	default:
 		// can't auto-load ironman games

--- a/src/Menu/SaveGameState.cpp
+++ b/src/Menu/SaveGameState.cpp
@@ -54,16 +54,17 @@ SaveGameState::SaveGameState(OptionsOrigin origin, const std::string &filename, 
  */
 SaveGameState::SaveGameState(OptionsOrigin origin, SaveType type, SDL_Color *palette) : _firstRun(0), _origin(origin), _type(type)
 {
+	std::string curMaster = Options::getActiveMaster();
 	switch (type)
 	{
 	case SAVE_QUICK:
-		_filename = SavedGame::QUICKSAVE;
+		_filename = curMaster + SavedGame::QUICKSAVE;
 		break;
 	case SAVE_AUTO_GEOSCAPE:
-		_filename = SavedGame::AUTOSAVE_GEOSCAPE;
+		_filename = curMaster + SavedGame::AUTOSAVE_GEOSCAPE;
 		break;
 	case SAVE_AUTO_BATTLESCAPE:
-		_filename = SavedGame::AUTOSAVE_BATTLESCAPE;
+		_filename = curMaster + SavedGame::AUTOSAVE_BATTLESCAPE;
 		break;
 	case SAVE_IRONMAN:
 	case SAVE_IRONMAN_END:

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -255,17 +255,18 @@ SaveInfo SavedGame::getSaveInfo(const std::string &file, Language *lang)
 
 	save.fileName = file;
 
-	if (save.fileName == QUICKSAVE)
+	std::string curMaster = Options::getActiveMaster();
+	if (save.fileName == curMaster + QUICKSAVE)
 	{
 		save.displayName = lang->getString("STR_QUICK_SAVE_SLOT");
 		save.reserved = true;
 	}
-	else if (save.fileName == AUTOSAVE_GEOSCAPE)
+	else if (save.fileName == curMaster + AUTOSAVE_GEOSCAPE)
 	{
 		save.displayName = lang->getString("STR_AUTO_SAVE_GEOSCAPE_SLOT");
 		save.reserved = true;
 	}
-	else if (save.fileName == AUTOSAVE_BATTLESCAPE)
+	else if (save.fileName == curMaster + AUTOSAVE_BATTLESCAPE)
 	{
 		save.displayName = lang->getString("STR_AUTO_SAVE_BATTLESCAPE_SLOT");
 		save.reserved = true;


### PR DESCRIPTION
After switching to TFTD I noticed that openxcom overwrited my old UFO quicksave, autobattlesave and autogeosave :(.
This commit split autosaves for each master game. After that savedir will be little messy, but old autosaves will be still intact and available for loading.