### PR TITLE
Fix wrong resolution in main menu if intro is not present.

### DIFF
--- a/src/Menu/MainMenuState.cpp
+++ b/src/Menu/MainMenuState.cpp
@@ -30,12 +30,16 @@
 #include "NewBattleState.h"
 #include "ListLoadState.h"
 #include "OptionsVideoState.h"
+#include "../Engine/Screen.h"
+#include "../Engine/Options.h"
 
 namespace OpenXcom
 {
 
 void GoToMainMenuState::init()
 {
+	Screen::updateScale(Options::geoscapeScale, Options::geoscapeScale, Options::baseXGeoscape, Options::baseYGeoscape, true);
+	_game->getScreen()->resetDisplay(false);
 	_game->setState(new MainMenuState);
 }
 

--- a/src/Menu/StartState.cpp
+++ b/src/Menu/StartState.cpp
@@ -167,16 +167,13 @@ void StartState::think()
 	case LOADING_SUCCESSFUL:
 		CrossPlatform::flashWindow();
 		Log(LOG_INFO) << "OpenXcom started successfully!";
+		_game->setState(new GoToMainMenuState);
 		if (!Options::reload && Options::playIntro)
 		{
-			_game->setState(new GoToMainMenuState);
 			_game->pushState(new CutsceneState("intro"));
 		}
 		else
 		{
-			Screen::updateScale(Options::geoscapeScale, Options::geoscapeScale, Options::baseXGeoscape, Options::baseYGeoscape, true);
-			_game->getScreen()->resetDisplay(false);
-			_game->setState(new MainMenuState);
 			Options::reload = false;
 		}
 		_game->getCursor()->setVisible(true);


### PR DESCRIPTION
If a player has no ANIMS/FLOP_INT folders but doesn't disable playing the
intro, the resolution/scale won't be changed for the main menu. This patch moves
the code for resolution change to the GoToMainMenuState utility state.