### PR TITLE
Make the "exit medikit screen" button moddable.

### DIFF
--- a/bin/standard/xcom1/interfaces.rul
+++ b/bin/standard/xcom1/interfaces.rul
@@ -1287,3 +1287,6 @@ interfaces:
         color: 32
       - id: numWounds
         color: 32
+      - id: buttonEnd
+        pos: [220, 140]
+        size: [20, 20]

--- a/bin/standard/xcom2/interfaces.rul
+++ b/bin/standard/xcom2/interfaces.rul
@@ -1441,6 +1441,9 @@ interfaces: #done
       - id: numWounds
         pos: [145, 116]
         color: 32
+      - id: buttonEnd
+        pos: [292, 46]
+        size: [28, 86]
       # required
       - id: body
         pos: [90, 55]

--- a/src/Battlescape/MedikitState.cpp
+++ b/src/Battlescape/MedikitState.cpp
@@ -151,7 +151,7 @@ MedikitState::MedikitState (BattleUnit *targetUnit, BattleAction *action) : _tar
 	_healTxt = new MedikitTxt (124);
 	add(_bg);
 	add(_medikitView, "body", "medikit", _bg);
-	add(_endButton);
+	add(_endButton, "buttonEnd", "medikit", _bg);
 	add(new MedikitTitle (37, tr("STR_PAIN_KILLER")), "textPK", "medikit", _bg);
 	add(new MedikitTitle (73, tr("STR_STIMULANT")), "textStim", "medikit", _bg);
 	add(new MedikitTitle (109, tr("STR_HEAL")), "textHeal", "medikit", _bg);


### PR DESCRIPTION
Since the medikit sprite is different from xcom1, the
users-without-keyboard-and-right-click (aka mobile users) are having
trouble getting away from this screen, since the exit button is now not in
an obvious position. This patch makes the right handle an exit button for
TFTD.