### PR TITLE
Refactor Base::getItems into Base::getStorageItems

### DIFF
--- a/src/Basescape/CraftArmorState.cpp
+++ b/src/Basescape/CraftArmorState.cpp
@@ -168,15 +168,15 @@ void CraftArmorState::lstSoldiersClick(Action *action)
 			Armor *a = _game->getMod()->getArmor(save->getLastSelectedArmor());
 			if (save->getMonthsPassed() != -1)
 			{
-				if (_base->getItems()->getItem(a->getStoreItem()) > 0 || a->getStoreItem() == "STR_NONE")
+				if (_base->getStorageItems()->getItem(a->getStoreItem()) > 0 || a->getStoreItem() == "STR_NONE")
 				{
 					if (s->getArmor()->getStoreItem() != "STR_NONE")
 					{
-						_base->getItems()->addItem(s->getArmor()->getStoreItem());
+						_base->getStorageItems()->addItem(s->getArmor()->getStoreItem());
 					}
 					if (a->getStoreItem() != "STR_NONE")
 					{
-						_base->getItems()->removeItem(a->getStoreItem());
+						_base->getStorageItems()->removeItem(a->getStoreItem());
 					}
 
 					s->setArmor(a);

--- a/src/Basescape/CraftEquipmentState.cpp
+++ b/src/Basescape/CraftEquipmentState.cpp
@@ -153,13 +153,13 @@ CraftEquipmentState::CraftEquipmentState(Base *base, size_t craft) : _sel(0), _c
 		}
 		if (rule->getBigSprite() > -1 && rule->getBattleType() != BT_NONE && rule->getBattleType() != BT_CORPSE &&
 			_game->getSavedGame()->isResearched(rule->getRequirements()) &&
-			(_base->getItems()->getItem(*i) > 0 || cQty > 0))
+			(_base->getStorageItems()->getItem(*i) > 0 || cQty > 0))
 		{
 			_items.push_back(*i);
 			std::wostringstream ss, ss2;
 			if (_game->getSavedGame()->getMonthsPassed() > -1)
 			{
-				ss << _base->getItems()->getItem(*i);
+				ss << _base->getStorageItems()->getItem(*i);
 			}
 			else
 			{
@@ -368,7 +368,7 @@ void CraftEquipmentState::updateQuantity()
 	std::wostringstream ss, ss2;
 	if (_game->getSavedGame()->getMonthsPassed() > -1)
 	{
-		ss << _base->getItems()->getItem(_items[_sel]);
+		ss << _base->getStorageItems()->getItem(_items[_sel]);
 	}
 	else
 	{
@@ -435,7 +435,7 @@ void CraftEquipmentState::moveLeftByValue(int change)
 			{
 				if ((*i)->getRules() == item)
 				{
-					_base->getItems()->addItem(ammo->getType(), (*i)->getAmmo());
+					_base->getStorageItems()->addItem(ammo->getType(), (*i)->getAmmo());
 					delete (*i);
 					i = c->getVehicles()->erase(i);
 				}
@@ -443,7 +443,7 @@ void CraftEquipmentState::moveLeftByValue(int change)
 			}
 			if (_game->getSavedGame()->getMonthsPassed() != -1)
 			{
-				_base->getItems()->addItem(_items[_sel], cQty);
+				_base->getStorageItems()->addItem(_items[_sel], cQty);
 			}
 			// And now reAdd the count we want to keep in the craft (and redistribute the ammo among them)
 			if (cQty > change) moveRightByValue(cQty - change);
@@ -452,7 +452,7 @@ void CraftEquipmentState::moveLeftByValue(int change)
 		{
 			if (_game->getSavedGame()->getMonthsPassed() != -1)
 			{
-				_base->getItems()->addItem(_items[_sel], change);
+				_base->getStorageItems()->addItem(_items[_sel], change);
 			}
 			for (std::vector<Vehicle*>::iterator i = c->getVehicles()->begin(); i != c->getVehicles()->end(); )
 			{
@@ -472,7 +472,7 @@ void CraftEquipmentState::moveLeftByValue(int change)
 		_totalItems -= change;
 		if (_game->getSavedGame()->getMonthsPassed() > -1)
 		{
-			_base->getItems()->addItem(_items[_sel], change);
+			_base->getStorageItems()->addItem(_items[_sel], change);
 		}
 	}
 	updateQuantity();
@@ -496,7 +496,7 @@ void CraftEquipmentState::moveRightByValue(int change)
 {
 	Craft *c = _base->getCrafts()->at(_craft);
 	RuleItem *item = _game->getMod()->getItem(_items[_sel]);
-	int bqty = _base->getItems()->getItem(_items[_sel]);
+	int bqty = _base->getStorageItems()->getItem(_items[_sel]);
 	if (_game->getSavedGame()->getMonthsPassed() == -1)
 	{
 		if (change == INT_MAX)
@@ -530,7 +530,7 @@ void CraftEquipmentState::moveRightByValue(int change)
 				{
 					ammoPerVehicle = item->getClipSize() / ammo->getClipSize();
 				}
-				int baseQty = _base->getItems()->getItem(ammo->getType()) / ammoPerVehicle;
+				int baseQty = _base->getStorageItems()->getItem(ammo->getType()) / ammoPerVehicle;
 				if (_game->getSavedGame()->getMonthsPassed() == -1)
 					baseQty = 1;
 				int canBeAdded = std::min(change, baseQty);
@@ -540,8 +540,8 @@ void CraftEquipmentState::moveRightByValue(int change)
 					{
 						if (_game->getSavedGame()->getMonthsPassed() != -1)
 						{
-							_base->getItems()->removeItem(ammo->getType(), ammoPerVehicle);
-							_base->getItems()->removeItem(_items[_sel]);
+							_base->getStorageItems()->removeItem(ammo->getType(), ammoPerVehicle);
+							_base->getStorageItems()->removeItem(_items[_sel]);
 						}
 						c->getVehicles()->push_back(new Vehicle(item, ammoPerVehicle, size));
 					}
@@ -560,7 +560,7 @@ void CraftEquipmentState::moveRightByValue(int change)
 					c->getVehicles()->push_back(new Vehicle(item, item->getClipSize(), size));
 					if (_game->getSavedGame()->getMonthsPassed() != -1)
 					{
-						_base->getItems()->removeItem(_items[_sel]);
+						_base->getStorageItems()->removeItem(_items[_sel]);
 					}
 				}
 		}
@@ -578,7 +578,7 @@ void CraftEquipmentState::moveRightByValue(int change)
 		_totalItems += change;
 		if (_game->getSavedGame()->getMonthsPassed() > -1)
 		{
-			_base->getItems()->removeItem(_items[_sel],change);
+			_base->getStorageItems()->removeItem(_items[_sel],change);
 		}
 	}
 	updateQuantity();

--- a/src/Basescape/CraftWeaponsState.cpp
+++ b/src/Basescape/CraftWeaponsState.cpp
@@ -100,14 +100,14 @@ CraftWeaponsState::CraftWeaponsState(Base *base, size_t craft, size_t weapon) : 
 	for (std::vector<std::string>::const_iterator i = weapons.begin(); i != weapons.end(); ++i)
 	{
 		RuleCraftWeapon *w = _game->getMod()->getCraftWeapon(*i);
-		if (_base->getItems()->getItem(w->getLauncherItem()) > 0)
+		if (_base->getStorageItems()->getItem(w->getLauncherItem()) > 0)
 		{
 			_weapons.push_back(w);
 			std::wostringstream ss, ss2;
-			ss << _base->getItems()->getItem(w->getLauncherItem());
+			ss << _base->getStorageItems()->getItem(w->getLauncherItem());
 			if (!w->getClipItem().empty())
 			{
-				ss2 << _base->getItems()->getItem(w->getClipItem());
+				ss2 << _base->getStorageItems()->getItem(w->getClipItem());
 			}
 			else
 			{
@@ -146,8 +146,8 @@ void CraftWeaponsState::lstWeaponsClick(Action *)
 	// Remove current weapon
 	if (current != 0)
 	{
-		_base->getItems()->addItem(current->getRules()->getLauncherItem());
-		_base->getItems()->addItem(current->getRules()->getClipItem(), current->getClipsLoaded(_game->getMod()));
+		_base->getStorageItems()->addItem(current->getRules()->getLauncherItem());
+		_base->getStorageItems()->addItem(current->getRules()->getClipItem(), current->getClipsLoaded(_game->getMod()));
 		delete current;
 		_base->getCrafts()->at(_craft)->getWeapons()->at(_weapon) = 0;
 	}
@@ -157,7 +157,7 @@ void CraftWeaponsState::lstWeaponsClick(Action *)
 	{
 		CraftWeapon *sel = new CraftWeapon(_weapons[_lstWeapons->getSelectedRow()], 0);
 		sel->setRearming(true);
-		_base->getItems()->removeItem(sel->getRules()->getLauncherItem());
+		_base->getStorageItems()->removeItem(sel->getRules()->getLauncherItem());
 		_base->getCrafts()->at(_craft)->getWeapons()->at(_weapon) = sel;
 		if (_base->getCrafts()->at(_craft)->getStatus() == "STR_READY")
 		{

--- a/src/Basescape/ManageAlienContainmentState.cpp
+++ b/src/Basescape/ManageAlienContainmentState.cpp
@@ -150,7 +150,7 @@ ManageAlienContainmentState::ManageAlienContainmentState(Base *base, OptionsOrig
 	const std::vector<std::string> &items = _game->getMod()->getItemsList();
 	for (std::vector<std::string>::const_iterator i = items.begin(); i != items.end(); ++i)
 	{
-		int qty = _base->getItems()->getItem(*i);
+		int qty = _base->getStorageItems()->getItem(*i);
 		if (qty > 0 && _game->getMod()->getItem(*i)->isAlien())
 		{
 			_qtys.push_back(0);
@@ -216,7 +216,7 @@ void ManageAlienContainmentState::btnOkClick(Action *)
 		if (_qtys[i] > 0)
 		{
 			// remove the aliens
-			_base->getItems()->removeItem(_aliens[i], _qtys[i]);
+			_base->getStorageItems()->removeItem(_aliens[i], _qtys[i]);
 
 			if (Options::canSellLiveAliens)
 			{
@@ -225,7 +225,7 @@ void ManageAlienContainmentState::btnOkClick(Action *)
 			else
 			{
 				// add the corpses
-				_base->getItems()->addItem(
+				_base->getStorageItems()->addItem(
 					_game->getMod()->getArmor(
 						_game->getMod()->getUnit(
 							_aliens[i]
@@ -367,7 +367,7 @@ void ManageAlienContainmentState::lstItemsMousePress(Action *action)
  */
 int ManageAlienContainmentState::getQuantity()
 {
-	return _base->getItems()->getItem(_aliens[_sel]);
+	return _base->getStorageItems()->getItem(_aliens[_sel]);
 }
 
 /**

--- a/src/Basescape/ManufactureStartState.cpp
+++ b/src/Basescape/ManufactureStartState.cpp
@@ -116,7 +116,7 @@ ManufactureStartState::ManufactureStartState(Base * base, RuleManufacture * item
 	_lstRequiredItems->setColumns(3, 140, 75, 55);
 	_lstRequiredItems->setBackground(_window);
 
-	ItemContainer * itemContainer (base->getItems());
+	ItemContainer * itemContainer (base->getStorageItems());
 	int row = 0;
 	for (std::map<std::string, int>::const_iterator iter = requiredItems.begin();
 		iter != requiredItems.end();

--- a/src/Basescape/PurchaseState.cpp
+++ b/src/Basescape/PurchaseState.cpp
@@ -173,7 +173,7 @@ PurchaseState::PurchaseState(Base *base) : _base(base), _sel(0), _itemOffset(0),
 			_items.push_back(*i);
 			_qtys.push_back(0);
 			std::wostringstream ss5;
-			ss5 << _base->getItems()->getItem(*i);
+			ss5 << _base->getStorageItems()->getItem(*i);
 			std::wstring item = tr(*i);
 			if (rule->getBattleType() == BT_AMMO || (rule->getBattleType() == BT_NONE && rule->getClipSize() > 0))
 			{

--- a/src/Basescape/ResearchInfoState.cpp
+++ b/src/Basescape/ResearchInfoState.cpp
@@ -124,7 +124,7 @@ void ResearchInfoState::buildUi()
 				(_game->getMod()->getUnit(_rule->getName()) ||
 				 Options::spendResearchedItems))
 		{
-			_base->getItems()->removeItem(_rule->getName(), 1);
+			_base->getStorageItems()->removeItem(_rule->getName(), 1);
 		}
 	}
 	setAssignedScientist();
@@ -187,7 +187,7 @@ void ResearchInfoState::btnCancelClick(Action *)
 			(_game->getMod()->getUnit(ruleResearch->getName()) ||
 			 Options::spendResearchedItems))
 	{
-		_base->getItems()->addItem(ruleResearch->getName(), 1);
+		_base->getStorageItems()->addItem(ruleResearch->getName(), 1);
 	}
 	_base->removeResearch(_project);
 	_game->popState();

--- a/src/Basescape/SackSoldierState.cpp
+++ b/src/Basescape/SackSoldierState.cpp
@@ -100,7 +100,7 @@ void SackSoldierState::btnOkClick(Action *)
 	Soldier *soldier = _base->getSoldiers()->at(_soldierId);
 	if (soldier->getArmor()->getStoreItem() != "STR_NONE")
 	{
-		_base->getItems()->addItem(soldier->getArmor()->getStoreItem());
+		_base->getStorageItems()->addItem(soldier->getArmor()->getStoreItem());
 	}
 	_base->getSoldiers()->erase(_base->getSoldiers()->begin() + _soldierId);
 	delete soldier;

--- a/src/Basescape/SellState.cpp
+++ b/src/Basescape/SellState.cpp
@@ -188,7 +188,7 @@ SellState::SellState(Base *base, OptionsOrigin origin) : _base(base), _sel(0), _
 	const std::vector<std::string> &items = _game->getMod()->getItemsList();
 	for (std::vector<std::string>::const_iterator i = items.begin(); i != items.end(); ++i)
 	{
-		int qty = _base->getItems()->getItem(*i);
+		int qty = _base->getStorageItems()->getItem(*i);
 		if (Options::storageLimitsEnforced && origin == OPT_BATTLESCAPE)
 		{
 			for (std::vector<Transfer*>::iterator j = _base->getTransfers()->begin(); j != _base->getTransfers()->end(); ++j)
@@ -280,7 +280,7 @@ void SellState::btnOkClick(Action *)
 					{
 						if ((*s)->getArmor()->getStoreItem() != "STR_NONE")
 						{
-							_base->getItems()->addItem((*s)->getArmor()->getStoreItem());
+							_base->getStorageItems()->addItem((*s)->getArmor()->getStoreItem());
 						}
 						_base->getSoldiers()->erase(s);
 						break;
@@ -298,24 +298,24 @@ void SellState::btnOkClick(Action *)
 				{
 					if ((*w) != 0)
 					{
-						_base->getItems()->addItem((*w)->getRules()->getLauncherItem());
-						_base->getItems()->addItem((*w)->getRules()->getClipItem(), (*w)->getClipsLoaded(_game->getMod()));
+						_base->getStorageItems()->addItem((*w)->getRules()->getLauncherItem());
+						_base->getStorageItems()->addItem((*w)->getRules()->getClipItem(), (*w)->getClipsLoaded(_game->getMod()));
 					}
 				}
 
 				// Remove items from craft
 				for (std::map<std::string, int>::iterator it = craft->getItems()->getContents()->begin(); it != craft->getItems()->getContents()->end(); ++it)
 				{
-					_base->getItems()->addItem(it->first, it->second);
+					_base->getStorageItems()->addItem(it->first, it->second);
 				}
 
 				// Remove vehicles from craft
 				for (std::vector<Vehicle*>::iterator v = craft->getVehicles()->begin(); v != craft->getVehicles()->end(); ++v)
 				{
-					_base->getItems()->addItem((*v)->getRules()->getType());
+					_base->getStorageItems()->addItem((*v)->getRules()->getType());
 					if (!(*v)->getRules()->getCompatibleAmmo()->empty())
 					{
-						_base->getItems()->addItem((*v)->getRules()->getCompatibleAmmo()->front(), (*v)->getAmmo());
+						_base->getStorageItems()->addItem((*v)->getRules()->getCompatibleAmmo()->front(), (*v)->getAmmo());
 					}
 				}
 
@@ -360,13 +360,13 @@ void SellState::btnOkClick(Action *)
 				break;
 
 			case SELL_ITEM:
-				if (_base->getItems()->getItem(_items[getItemIndex(i)]) < _qtys[i])
+				if (_base->getStorageItems()->getItem(_items[getItemIndex(i)]) < _qtys[i])
 				{
 					const std::string itemName = _items[getItemIndex(i)];
-					int toRemove = _qtys[i] - _base->getItems()->getItem(itemName);
+					int toRemove = _qtys[i] - _base->getStorageItems()->getItem(itemName);
 
 					// remove all of said items from base
-					_base->getItems()->removeItem(itemName, INT_MAX);
+					_base->getStorageItems()->removeItem(itemName, INT_MAX);
 
 					// if we still need to remove any, remove them from the crafts first, and keep a running tally
 					for (std::vector<Craft*>::iterator j = _base->getCrafts()->begin(); j != _base->getCrafts()->end() && toRemove; ++j)
@@ -408,7 +408,7 @@ void SellState::btnOkClick(Action *)
 				}
 				else
 				{
-					_base->getItems()->removeItem(_items[getItemIndex(i)], _qtys[i]);
+					_base->getStorageItems()->removeItem(_items[getItemIndex(i)], _qtys[i]);
 				}
 			}
 		}
@@ -571,7 +571,7 @@ int SellState::getQuantity()
 	case SELL_ENGINEER:
 		return _base->getAvailableEngineers();
 	case SELL_ITEM:
-		qty = _base->getItems()->getItem(_items[getItemIndex(_sel)]);
+		qty = _base->getStorageItems()->getItem(_items[getItemIndex(_sel)]);
 		if (Options::storageLimitsEnforced && _origin == OPT_BATTLESCAPE)
 		{
 			for (std::vector<Transfer*>::iterator j = _base->getTransfers()->begin(); j != _base->getTransfers()->end(); ++j)

--- a/src/Basescape/SoldierArmorState.cpp
+++ b/src/Basescape/SoldierArmorState.cpp
@@ -90,13 +90,13 @@ SoldierArmorState::SoldierArmorState(Base *base, size_t soldier) : _base(base), 
 	for (std::vector<std::string>::const_iterator i = armors.begin(); i != armors.end(); ++i)
 	{
 		Armor *a = _game->getMod()->getArmor(*i);
-		if (_base->getItems()->getItem(a->getStoreItem()) > 0)
+		if (_base->getStorageItems()->getItem(a->getStoreItem()) > 0)
 		{
 			_armors.push_back(a);
 			std::wostringstream ss;
 			if (_game->getSavedGame()->getMonthsPassed() > -1)
 			{
-				ss << _base->getItems()->getItem(a->getStoreItem());
+				ss << _base->getStorageItems()->getItem(a->getStoreItem());
 			}
 			else
 			{
@@ -141,11 +141,11 @@ void SoldierArmorState::lstArmorClick(Action *)
 	{
 		if (soldier->getArmor()->getStoreItem() != "STR_NONE")
 		{
-			_base->getItems()->addItem(soldier->getArmor()->getStoreItem());
+			_base->getStorageItems()->addItem(soldier->getArmor()->getStoreItem());
 		}
 		if (_armors[_lstArmor->getSelectedRow()]->getStoreItem() != "STR_NONE")
 		{
-			_base->getItems()->removeItem(_armors[_lstArmor->getSelectedRow()]->getStoreItem());
+			_base->getStorageItems()->removeItem(_armors[_lstArmor->getSelectedRow()]->getStoreItem());
 		}
 	}
 	soldier->setArmor(_armors[_lstArmor->getSelectedRow()]);

--- a/src/Basescape/StoresState.cpp
+++ b/src/Basescape/StoresState.cpp
@@ -89,7 +89,7 @@ StoresState::StoresState(Base *base) : _base(base)
 	const std::vector<std::string> &items = _game->getMod()->getItemsList();
 	for (std::vector<std::string>::const_iterator i = items.begin(); i != items.end(); ++i)
 	{
-		int qty = _base->getItems()->getItem(*i);
+		int qty = _base->getStorageItems()->getItem(*i);
 		if (qty > 0)
 		{
 			RuleItem *rule = _game->getMod()->getItem(*i);

--- a/src/Basescape/TransferItemsState.cpp
+++ b/src/Basescape/TransferItemsState.cpp
@@ -168,7 +168,7 @@ TransferItemsState::TransferItemsState(Base *baseFrom, Base *baseTo) : _baseFrom
 	const std::vector<std::string> &items = _game->getMod()->getItemsList();
 	for (std::vector<std::string>::const_iterator i = items.begin(); i != items.end(); ++i)
 	{
-		int qty = _baseFrom->getItems()->getItem(*i);
+		int qty = _baseFrom->getStorageItems()->getItem(*i);
 		if (qty > 0)
 		{
 			_baseQty.push_back(qty);
@@ -177,7 +177,7 @@ TransferItemsState::TransferItemsState(Base *baseFrom, Base *baseTo) : _baseFrom
 			RuleItem *rule = _game->getMod()->getItem(*i);
 			std::wostringstream ss, ss2;
 			ss << qty;
-			ss2 << _baseTo->getItems()->getItem(*i);
+			ss2 << _baseTo->getStorageItems()->getItem(*i);
 			std::wstring item = tr(*i);
 			if (rule->getBattleType() == BT_AMMO || (rule->getBattleType() == BT_NONE && rule->getClipSize() > 0))
 			{
@@ -345,7 +345,7 @@ void TransferItemsState::completeTransfer()
 			// Transfer items
 			else
 			{
-				_baseFrom->getItems()->removeItem(_items[ getItemIndex(i) ], _transferQty[i]);
+				_baseFrom->getStorageItems()->removeItem(_items[ getItemIndex(i) ], _transferQty[i]);
 				Transfer *t = new Transfer(time);
 				t->setItems(_items[getItemIndex(i)], _transferQty[i]);
 				_baseTo->getTransfers()->push_back(t);
@@ -511,7 +511,7 @@ int TransferItemsState::getQuantity() const
 	case TRANSFER_ENGINEER:
 		return _baseFrom->getAvailableEngineers();
 	case TRANSFER_ITEM:
-		return _baseFrom->getItems()->getItem(_items[getItemIndex(_sel)]);
+		return _baseFrom->getStorageItems()->getItem(_items[getItemIndex(_sel)]);
 	}
 	return 1;
 }

--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -647,7 +647,7 @@ void BattlescapeGenerator::deployXCOM()
 		if (_game->getSavedGame()->getMonthsPassed() != -1)
 		{
 			// add items that are in the base
-			for (std::map<std::string, int>::iterator i = _base->getItems()->getContents()->begin(); i != _base->getItems()->getContents()->end();)
+			for (std::map<std::string, int>::iterator i = _base->getStorageItems()->getContents()->begin(); i != _base->getStorageItems()->getContents()->end();)
 			{
 				// only put items in the battlescape that make sense (when the item got a sprite, it's probably ok)
 				RuleItem *rule = _game->getMod()->getItem(i->first);
@@ -659,7 +659,7 @@ void BattlescapeGenerator::deployXCOM()
 					}
 					std::map<std::string, int>::iterator tmp = i;
 					++i;
-					_base->getItems()->removeItem(tmp->first, tmp->second);
+					_base->getStorageItems()->removeItem(tmp->first, tmp->second);
 				}
 				else
 				{
@@ -2098,7 +2098,7 @@ void BattlescapeGenerator::generateMap(const std::vector<MapScript*> *script)
 	}
 
 	delete _dummy;
-	
+
 	// special hacks to fill in empty floors on level 0
 	for (int x = 0; x < _mapsize_x; ++x)
 	{

--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -542,7 +542,7 @@ void DebriefingState::prepareDebriefing()
 			}
 		}
 	}
-	
+
 	// mission site disappears (even when you abort)
 	for (std::vector<MissionSite*>::iterator i = save->getMissionSites()->begin(); i != save->getMissionSites()->end(); ++i)
 	{
@@ -605,7 +605,7 @@ void DebriefingState::prepareDebriefing()
 				// Take care to remove supply missions for this base.
 				std::for_each(save->getAlienMissions().begin(), save->getAlienMissions().end(),
 							ClearAlienBase(*i));
-				
+
 				for (std::vector<Target*>::iterator j = (*i)->getFollowers()->begin(); j != (*i)->getFollowers()->end(); ++j)
 				{
 					Craft* c = dynamic_cast<Craft*>(*j);
@@ -712,7 +712,7 @@ void DebriefingState::prepareDebriefing()
 					}
 					else
 					{ // non soldier player = tank
-						base->getItems()->addItem((*j)->getType());
+						base->getStorageItems()->addItem((*j)->getType());
 						RuleItem *tankRule = _game->getMod()->getItem((*j)->getType());
 						if ((*j)->getItem("STR_RIGHT_HAND"))
 						{
@@ -726,7 +726,7 @@ void DebriefingState::prepareDebriefing()
 									total /= ammoItem->getRules()->getClipSize();
 								}
 
-								base->getItems()->addItem(tankRule->getCompatibleAmmo()->front(), total);
+								base->getStorageItems()->addItem(tankRule->getCompatibleAmmo()->front(), total);
 							}
 						}
 						if ((*j)->getItem("STR_LEFT_HAND"))
@@ -742,7 +742,7 @@ void DebriefingState::prepareDebriefing()
 									total /= ammoItem->getRules()->getClipSize();
 								}
 
-								base->getItems()->addItem(secondaryRule->getCompatibleAmmo()->front(), total);
+								base->getStorageItems()->addItem(secondaryRule->getCompatibleAmmo()->front(), total);
 							}
 						}
 					}
@@ -835,7 +835,7 @@ void DebriefingState::prepareDebriefing()
 		}
 		else if (target == "STR_UFO")
 		{
-			_txtTitle->setText(tr("STR_UFO_IS_RECOVERED")); 
+			_txtTitle->setText(tr("STR_UFO_IS_RECOVERED"));
 		}
 		else if (target == "STR_ALIEN_BASE")
 		{
@@ -923,7 +923,7 @@ void DebriefingState::prepareDebriefing()
 	{
 		int total_clips = i->second / i->first->getClipSize();
 		if (total_clips > 0)
-			base->getItems()->addItem(i->first->getType(), total_clips);
+			base->getStorageItems()->addItem(i->first->getType(), total_clips);
 	}
 
 	// recover all our goodies
@@ -942,7 +942,7 @@ void DebriefingState::prepareDebriefing()
 			// recoverable battlescape tiles are now converted to items and put in base inventory
 			if ((*i)->recovery && (*i)->qty > 0)
 			{
-				base->getItems()->addItem((*i)->item, (*i)->qty);
+				base->getStorageItems()->addItem((*i)->item, (*i)->qty);
 			}
 		}
 
@@ -1026,15 +1026,15 @@ void DebriefingState::reequipCraft(Base *base, Craft *craft, bool vehicleItemsCa
 	std::map<std::string, int> craftItems = *craft->getItems()->getContents();
 	for (std::map<std::string, int>::iterator i = craftItems.begin(); i != craftItems.end(); ++i)
 	{
-		int qty = base->getItems()->getItem(i->first);
+		int qty = base->getStorageItems()->getItem(i->first);
 		if (qty >= i->second)
 		{
-			base->getItems()->removeItem(i->first, i->second);
+			base->getStorageItems()->removeItem(i->first, i->second);
 		}
 		else
 		{
 			int missing = i->second - qty;
-			base->getItems()->removeItem(i->first, qty);
+			base->getStorageItems()->removeItem(i->first, qty);
 			craft->getItems()->removeItem(i->first, missing);
 			ReequipStat stat = {i->first, missing, craft->getName(_game->getLanguage())};
 			_missingItems.push_back(stat);
@@ -1054,7 +1054,7 @@ void DebriefingState::reequipCraft(Base *base, Craft *craft, bool vehicleItemsCa
 	// Ok, now read those vehicles
 	for (std::map<std::string, int>::iterator i = craftVehicles.getContents()->begin(); i != craftVehicles.getContents()->end(); ++i)
 	{
-		int qty = base->getItems()->getItem(i->first);
+		int qty = base->getStorageItems()->getItem(i->first);
 		RuleItem *tankRule = _game->getMod()->getItem(i->first);
 		int size = 4;
 		if (_game->getMod()->getUnit(tankRule->getType()))
@@ -1073,7 +1073,7 @@ void DebriefingState::reequipCraft(Base *base, Craft *craft, bool vehicleItemsCa
 		{ // so this tank does NOT require ammo
 			for (int j = 0; j < canBeAdded; ++j)
 				craft->getVehicles()->push_back(new Vehicle(tankRule, tankRule->getClipSize(), size));
-			base->getItems()->removeItem(i->first, canBeAdded);
+			base->getStorageItems()->removeItem(i->first, canBeAdded);
 		}
 		else
 		{ // so this tank requires ammo
@@ -1083,7 +1083,7 @@ void DebriefingState::reequipCraft(Base *base, Craft *craft, bool vehicleItemsCa
 			{
 				ammoPerVehicle = tankRule->getClipSize() / ammo->getClipSize();
 			}
-			int baqty = base->getItems()->getItem(ammo->getType()); // Ammo Quantity for this vehicle-type on the base
+			int baqty = base->getStorageItems()->getItem(ammo->getType()); // Ammo Quantity for this vehicle-type on the base
 			if (baqty < i->second * ammoPerVehicle)
 			{ // missing ammo
 				int missing = (i->second * ammoPerVehicle) - baqty;
@@ -1096,9 +1096,9 @@ void DebriefingState::reequipCraft(Base *base, Craft *craft, bool vehicleItemsCa
 				for (int j = 0; j < canBeAdded; ++j)
 				{
 					craft->getVehicles()->push_back(new Vehicle(tankRule, ammoPerVehicle, size));
-					base->getItems()->removeItem(ammo->getType(), ammoPerVehicle);
+					base->getStorageItems()->removeItem(ammo->getType(), ammoPerVehicle);
 				}
-				base->getItems()->removeItem(i->first, canBeAdded);
+				base->getStorageItems()->removeItem(i->first, canBeAdded);
 			}
 		}
 	}
@@ -1127,7 +1127,7 @@ void DebriefingState::recoverItems(std::vector<BattleItem*> *from, Base *base)
 				if ((*it)->getRules()->getBattleType() == BT_CORPSE && (*it)->getUnit()->getStatus() == STATUS_DEAD)
 				{
 					addStat("STR_ALIEN_CORPSES_RECOVERED", 1, (*it)->getUnit()->getValue());
-					base->getItems()->addItem((*it)->getUnit()->getArmor()->getCorpseGeoscape(), 1);
+					base->getStorageItems()->addItem((*it)->getUnit()->getArmor()->getCorpseGeoscape(), 1);
 				}
 				else if ((*it)->getRules()->getBattleType() == BT_CORPSE)
 				{
@@ -1179,7 +1179,7 @@ void DebriefingState::recoverItems(std::vector<BattleItem*> *from, Base *base)
 						}
 						// Fall-through, to recover the weapon itself.
 					default:
-						base->getItems()->addItem((*it)->getRules()->getType(), 1);
+						base->getStorageItems()->addItem((*it)->getRules()->getType(), 1);
 				}
 			}
 		}
@@ -1212,7 +1212,7 @@ void DebriefingState::recoverAlien(BattleUnit *from, Base *base)
 		addStat("STR_ALIEN_CORPSES_RECOVERED", 1, from->getValue());
 
 		std::string corpseItem = from->getArmor()->getCorpseGeoscape();
-		base->getItems()->addItem(corpseItem, 1);
+		base->getStorageItems()->addItem(corpseItem, 1);
 	}
 	else
 	{
@@ -1228,7 +1228,7 @@ void DebriefingState::recoverAlien(BattleUnit *from, Base *base)
 			addStat("STR_LIVE_ALIENS_RECOVERED", 1, 10);
 		}
 
-		base->getItems()->addItem(type, 1);
+		base->getStorageItems()->addItem(type, 1);
 		_manageContainment = base->getAvailableContainment() - (base->getUsedContainment() * _limitsEnforced) < 0;
 	}
 }

--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -1237,9 +1237,9 @@ void GeoscapeState::time30Minutes()
 				}
 				else
 				{
-					if ((*i)->getItems()->getItem(item) > 0)
+					if ((*i)->getStorageItems()->getItem(item) > 0)
 					{
-						(*i)->getItems()->removeItem(item);
+						(*i)->getStorageItems()->removeItem(item);
 						(*j)->refuel();
 						(*j)->setLowFuel(false);
 					}
@@ -1534,7 +1534,7 @@ void GeoscapeState::time1Day()
 			// If "researched" the live alien, his body sent to the stores.
 			if (Options::spendResearchedItems && research->needItem() && _game->getMod()->getUnit(research->getName()))
 			{
-				(*i)->getItems()->addItem(
+				(*i)->getStorageItems()->addItem(
 					_game->getMod()->getArmor(
 						_game->getMod()->getUnit(
 							research->getName()
@@ -2214,7 +2214,7 @@ void GeoscapeState::determineAlienMissions()
 					ss << (*j)->getType() << ", ";
 				}
 			}
-			ss  << "are sharing the same label: " << command->getLabel(); 
+			ss  << "are sharing the same label: " << command->getLabel();
 			throw Exception(ss.str());
 		}
 		// level four condition check: does random chance favour this command's execution?

--- a/src/Geoscape/ItemsArrivingState.cpp
+++ b/src/Geoscape/ItemsArrivingState.cpp
@@ -137,7 +137,7 @@ ItemsArrivingState::ItemsArrivingState(GeoscapeState *state) : _state(state), _b
 								int used = std::min((*j)->getQuantity(), item->getClipSize() - (*v)->getAmmo());
 								(*v)->setAmmo((*v)->getAmmo() + used);
 								// Note that the items have already been delivered, so we remove them from the base, not the transfer
-								_base->getItems()->removeItem(item->getType(), used);
+								_base->getStorageItems()->removeItem(item->getType(), used);
 							}
 						}
 					}

--- a/src/Menu/NewBattleState.cpp
+++ b/src/Menu/NewBattleState.cpp
@@ -66,7 +66,7 @@ NewBattleState::NewBattleState() : _craft(0)
 	// Create objects
 	_window = new Window(this, 320, 200, 0, 0, POPUP_BOTH);
 	_txtTitle = new Text(320, 17, 0, 9);
-	
+
 	_txtMapOptions = new Text(148, 9, 8, 68);
 	_frameLeft = new Frame(148, 96, 8, 78);
 	_txtAlienOptions = new Text(148, 9, 164, 68);
@@ -78,7 +78,7 @@ NewBattleState::NewBattleState() : _craft(0)
 	_txtCraft = new Text(100, 9, 8, 50);
 	_cbxCraft = new ComboBox(this, 106, 16, 98, 46);
 	_btnEquip = new TextButton(106, 16, 206, 46);
-	
+
 	_txtDarkness = new Text(120, 9, 22, 83);
 	_slrDarkness = new Slider(120, 16, 22, 93);
 
@@ -87,7 +87,7 @@ NewBattleState::NewBattleState() : _craft(0)
 
 	_txtDepth = new Text(120, 9, 22, 143);
 	_slrDepth = new Slider(120, 16, 22, 153);
-	
+
 	_txtDifficulty = new Text(120, 9, 178, 83);
 	_cbxDifficulty = new ComboBox(this, 120, 16, 178, 93);
 
@@ -96,7 +96,7 @@ NewBattleState::NewBattleState() : _craft(0)
 
 	_txtAlienTech = new Text(120, 9, 178, 143);
 	_slrAlienTech = new Slider(120, 16, 178, 153);
-	
+
 	_btnOk = new TextButton(100, 16, 8, 176);
 	_btnCancel = new TextButton(100, 16, 110, 176);
 	_btnRandom = new TextButton(100, 16, 212, 176);
@@ -114,7 +114,7 @@ NewBattleState::NewBattleState() : _craft(0)
 	add(_txtMission, "text", "newBattleMenu");
 	add(_txtCraft, "text", "newBattleMenu");
 	add(_btnEquip, "button1", "newBattleMenu");
-	
+
 	add(_txtDarkness, "text", "newBattleMenu");
 	add(_slrDarkness, "button1", "newBattleMenu");
 	add(_txtDepth, "text", "newBattleMenu");
@@ -128,7 +128,7 @@ NewBattleState::NewBattleState() : _craft(0)
 	add(_btnOk, "button2", "newBattleMenu");
 	add(_btnCancel, "button2", "newBattleMenu");
 	add(_btnRandom, "button2", "newBattleMenu");
-	
+
 	add(_cbxTerrain, "button1", "newBattleMenu");
 	add(_cbxAlienRace, "button1", "newBattleMenu");
 	add(_cbxDifficulty, "button1", "newBattleMenu");
@@ -157,7 +157,7 @@ NewBattleState::NewBattleState() : _craft(0)
 	_txtCraft->setText(tr("STR_CRAFT"));
 
 	_txtDarkness->setText(tr("STR_MAP_DARKNESS"));
-	
+
 	_txtDepth->setText(tr("STR_MAP_DEPTH"));
 
 	_txtTerrain->setText(tr("STR_MAP_TERRAIN"));
@@ -165,7 +165,7 @@ NewBattleState::NewBattleState() : _craft(0)
 	_txtDifficulty->setText(tr("STR_ALIEN_DIFFICULTY"));
 
 	_txtAlienRace->setText(tr("STR_ALIEN_RACE"));
-	
+
 	_txtAlienTech->setText(tr("STR_ALIEN_TECH_LEVEL"));
 
 	_missionTypes = _game->getMod()->getDeploymentsList();
@@ -185,7 +185,7 @@ NewBattleState::NewBattleState() : _craft(0)
 	_cbxCraft->onChange((ActionHandler)&NewBattleState::cbxCraftChange);
 
 	_slrDarkness->setRange(0, 15);
-	
+
 	_slrDepth->setRange(1, 3);
 
 	_cbxTerrain->onChange((ActionHandler)&NewBattleState::cbxTerrainChange);
@@ -236,7 +236,7 @@ NewBattleState::NewBattleState() : _craft(0)
  */
 NewBattleState::~NewBattleState()
 {
-	
+
 }
 
 /**
@@ -295,14 +295,14 @@ void NewBattleState::load(const std::string &filename)
 				}
 
 				// Generate items
-				base->getItems()->getContents()->clear();
+				base->getStorageItems()->getContents()->clear();
 				const std::vector<std::string> &items = mod->getItemsList();
 				for (std::vector<std::string>::const_iterator i = items.begin(); i != items.end(); ++i)
 				{
 					RuleItem *rule = _game->getMod()->getItem(*i);
 					if (rule->getBattleType() != BT_CORPSE && rule->isRecoverable())
 					{
-						base->getItems()->addItem(*i, 1);
+						base->getStorageItems()->addItem(*i, 1);
 					}
 				}
 
@@ -389,7 +389,7 @@ void NewBattleState::initSave()
 	base->getSoldiers()->clear();
 	for (std::vector<Craft*>::iterator i = base->getCrafts()->begin(); i != base->getCrafts()->end(); ++i) delete (*i);
 	base->getCrafts()->clear();
-	base->getItems()->getContents()->clear();
+	base->getStorageItems()->getContents()->clear();
 
 	_craft = new Craft(mod->getCraft(_crafts[_cbxCraft->getSelected()]), base, 1);
 	base->getCrafts()->push_back(_craft);
@@ -433,7 +433,7 @@ void NewBattleState::initSave()
 		RuleItem *rule = _game->getMod()->getItem(*i);
 		if (rule->getBattleType() != BT_CORPSE && rule->isRecoverable())
 		{
-			base->getItems()->addItem(*i, 1);
+			base->getStorageItems()->addItem(*i, 1);
 			if (rule->getBattleType() != BT_NONE && !rule->isFixed() && rule->getBigSprite() > -1)
 			{
 				_craft->getItems()->addItem(*i, 1);

--- a/src/Savegame/Base.cpp
+++ b/src/Savegame/Base.cpp
@@ -335,10 +335,11 @@ std::vector<Transfer*> *Base::getTransfers()
 }
 
 /**
- * Returns the list of items in the base.
+ * Returns the list of items in the base storage rooms.
+ * Does NOT return items assigned to craft or in transfer.
  * @return Pointer to the item list.
  */
-ItemContainer *Base::getItems()
+ItemContainer *Base::getStorageItems()
 {
 	return _items;
 }
@@ -458,7 +459,7 @@ int Base::getAvailableSoldiers(bool checkCombatReadiness) const
 		{
 			total++;
 		}
-		else if (checkCombatReadiness && (((*i)->getCraft() != 0 && (*i)->getCraft()->getStatus() != "STR_OUT") || 
+		else if (checkCombatReadiness && (((*i)->getCraft() != 0 && (*i)->getCraft()->getStatus() != "STR_OUT") ||
 			((*i)->getCraft() == 0 && (*i)->getWoundRecovery() == 0)))
 		{
 			total++;
@@ -662,7 +663,7 @@ double Base::getIgnoredStores()
 				if (*w != 0 && (*w)->isRearming())
 				{
 					std::string clip = (*w)->getRules()->getClipItem();
-					int available = getItems()->getItem(clip);
+					int available = getStorageItems()->getItem(clip);
 					if (!clip.empty() && available > 0)
 					{
 						int clipSize = _mod->getItem(clip)->getClipSize();
@@ -1073,7 +1074,7 @@ bool Base::getHyperDetection() const
 		if ((*i)->getRules()->isHyperwave() && (*i)->getBuildTime() == 0)
 		{
 			return true;
-		}		
+		}
 	}
 	return false;
 }
@@ -1115,7 +1116,7 @@ int Base::getUsedPsiLabs() const
 }
 
 /**
- * Returns the total amount of used 
+ * Returns the total amount of used
  * Containment Space in the base.
  * @return Containment Lab space.
  */

--- a/src/Savegame/Base.h
+++ b/src/Savegame/Base.h
@@ -90,7 +90,7 @@ public:
 	/// Gets the base's transfers.
 	std::vector<Transfer*> *getTransfers();
 	/// Gets the base's items.
-	ItemContainer *getItems();
+	ItemContainer *getStorageItems();
 	/// Gets the base's scientists.
 	int getScientists() const;
 	/// Sets the base's scientists.

--- a/src/Savegame/Craft.cpp
+++ b/src/Savegame/Craft.cpp
@@ -812,7 +812,7 @@ std::string Craft::rearm(Mod *mod)
 		if (*i != 0 && (*i)->isRearming())
 		{
 			std::string clip = (*i)->getRules()->getClipItem();
-			int available = _base->getItems()->getItem(clip);
+			int available = _base->getStorageItems()->getItem(clip);
 			if (clip.empty())
 			{
 				(*i)->rearm(0, 0);
@@ -827,7 +827,7 @@ std::string Craft::rearm(Mod *mod)
 					(*i)->setRearming(false);
 				}
 
-				_base->getItems()->removeItem(clip, used);
+				_base->getStorageItems()->removeItem(clip, used);
 			}
 			else
 			{

--- a/src/Savegame/Production.cpp
+++ b/src/Savegame/Production.cpp
@@ -94,7 +94,7 @@ bool Production::haveEnoughMoneyForOneMoreUnit(SavedGame * g)
 bool Production::haveEnoughMaterialsForOneMoreUnit(Base * b)
 {
 	for (std::map<std::string,int>::const_iterator iter = _rules->getRequiredItems().begin(); iter != _rules->getRequiredItems().end(); ++iter)
-		if (b->getItems()->getItem(iter->first) < iter->second)
+		if (b->getStorageItems()->getItem(iter->first) < iter->second)
 			return false;
 	return true;
 }
@@ -166,7 +166,7 @@ productionProgress_e Production::step(Base * b, SavedGame * g, const Mod *m)
 					if (getSellItems())
 						g->setFunds(g->getFunds() + (m->getItem(i->first)->getSellCost() * i->second));
 					else
-						b->getItems()->addItem(i->first, i->second);
+						b->getStorageItems()->addItem(i->first, i->second);
 				}
 			}
 			count++;
@@ -206,7 +206,7 @@ void Production::startItem(Base * b, SavedGame * g)
 	g->setFunds(g->getFunds() - _rules->getManufactureCost());
 	for (std::map<std::string,int>::const_iterator iter = _rules->getRequiredItems().begin(); iter != _rules->getRequiredItems().end(); ++iter)
 	{
-		b->getItems()->removeItem(iter->first, iter->second);
+		b->getStorageItems()->removeItem(iter->first, iter->second);
 	}
 }
 

--- a/src/Savegame/SaveConverter.cpp
+++ b/src/Savegame/SaveConverter.cpp
@@ -294,7 +294,7 @@ void SaveConverter::graphVector(std::vector<T> &vector, int month, bool year)
 	{
 		std::vector<T> newVector;
 		int i = month;
-		do 
+		do
 		{
 			newVector.push_back(vector[i]);
 			i = (i + 1) % vector.size();
@@ -533,7 +533,7 @@ void SaveConverter::loadDatDiplom()
 		}
 		bool pact = satisfaction == 0;
 		bool newPact = load<Sint16>(cdata + 0x1E) != 0;
-		
+
 		if (pact)
 			country->setPact();
 		if (newPact)
@@ -774,7 +774,7 @@ void SaveConverter::loadDatBase()
 				int qty = load<Uint16>(bdata + 0x60 + j * 2);
 				if (qty != 0 && !_idItems[j].empty())
 				{
-					base->getItems()->addItem(_idItems[j], qty);
+					base->getStorageItems()->addItem(_idItems[j], qty);
 				}
 			}
 			base->setEngineers(engineers);
@@ -817,7 +817,7 @@ void SaveConverter::loadDatAStore()
 			if (base != 0xFF)
 			{
 				Base *b = dynamic_cast<Base*>(_targets[base]);
-				b->getItems()->addItem(liveAlien);
+				b->getStorageItems()->addItem(liveAlien);
 			}
 		}
 		_aliens.push_back(liveAlien);
@@ -1261,7 +1261,7 @@ void SaveConverter::loadDatXBases()
 			}
 		}
 	}
-	
+
 }
 
 }

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -1074,7 +1074,7 @@ void SavedGame::getAvailableResearchProjects (std::vector<RuleResearch *> & proj
 		{
 			continue;
 		}
-		if (research->needItem() && base->getItems()->getItem(research->getName()) == 0)
+		if (research->needItem() && base->getStorageItems()->getItem(research->getName()) == 0)
 		{
 			continue;
 		}

--- a/src/Savegame/Transfer.cpp
+++ b/src/Savegame/Transfer.cpp
@@ -299,7 +299,7 @@ void Transfer::advance(Base *base)
 		}
 		else if (_itemQty != 0)
 		{
-			base->getItems()->addItem(_itemId, _itemQty);
+			base->getStorageItems()->addItem(_itemId, _itemQty);
 		}
 		else if (_scientists != 0)
 		{


### PR DESCRIPTION
Old name implied that the function would return all items on base, while it returns only those items
currently in stores (it does not return items assigned to craft and and items in transfer).

