### PR TITLE
Handle spaces in filenames by avoiding xargs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -712,7 +712,7 @@ dist-hook:
 install-data-local:
 	mkdir -p $(DESTDIR)$(pkgdatadir)
 	cp -r $(top_srcdir)/bin/* $(DESTDIR)$(pkgdatadir)/ ; \
-	find $(DESTDIR)$(pkgdatadir) | xargs chmod a=rX,u+w
+	find $(DESTDIR)$(pkgdatadir) -exec chmod a=rX,u+w {} \;
 
 # NOTE: this might wipe user unpacked xcom if it is in the dir, as there
 #       is no way of distinguishing between our content and their.


### PR DESCRIPTION
faeeba46eef7b8819cfda404f2916b0e2971210a introduced filenames with spaces. `make install` chokes on those files because xargs thinks a file named "foo bar" is two files (foo and bar).