### PR TITLE
Initialization order must match declaration order

### DIFF
--- a/src/Mod/AlienDeployment.cpp
+++ b/src/Mod/AlienDeployment.cpp
@@ -113,8 +113,8 @@ namespace OpenXcom
  * type of deployment data.
  * @param type String defining the type.
  */
-AlienDeployment::AlienDeployment(const std::string &type) : _type(type), _width(0), _length(0), _height(0), _civilians(0), _shade(-1), _finalDestination(false), _markerIcon(-1), _durationMin(0), _durationMax(0),
-	_alert("STR_ALIENS_TERRORISE"), _alertBackground("BACK03.SCR"), _markerName("STR_TERROR_SITE"), _minDepth(0), _maxDepth(0), _minSiteDepth(0), _maxSiteDepth(0), _objectiveType(-1), _objectivesRequired(0), _objectiveCompleteScore(0), _objectiveFailedScore(0), _despawnPenalty(0), _points(0)
+AlienDeployment::AlienDeployment(const std::string &type) : _type(type), _width(0), _length(0), _height(0), _civilians(0), _shade(-1), _finalDestination(false), _alert("STR_ALIENS_TERRORISE"), _alertBackground("BACK03.SCR"), _markerName("STR_TERROR_SITE"), _markerIcon(-1), _durationMin(0), _durationMax(0),
+	_minDepth(0), _maxDepth(0), _minSiteDepth(0), _maxSiteDepth(0), _objectiveType(-1), _objectivesRequired(0), _objectiveCompleteScore(0), _objectiveFailedScore(0), _despawnPenalty(0), _points(0)
 {
 }
 


### PR DESCRIPTION
compilation still has trouble
```
src/Mod/AlienDeployment.h:75:33: error: ‘OpenXcom::AlienDeployment::_durationMax’ will be initialized after [-Werror=reorder]
  int _markerIcon, _durationMin, _durationMax, _minDepth, _maxDepth, _minSiteDepth, _maxSiteDepth;
                                 ^
src/Mod/AlienDeployment.h:72:14: error:   ‘std::string OpenXcom::AlienDeployment::_alert’ [-Werror=reorder]
  std::string _alert, _alertBackground;
              ^
src/Mod/AlienDeployment.cpp:116:1: error:   when initialized here [-Werror=reorder]
 AlienDeployment::AlienDeployment(const std::string &type) : _type(type), _width(0), _length(0), _height(0), _civilians(0), _shade(-1), _finalDestination(false), _markerIcon(-1), _durationMin(0), _durationMax(0),
 ^
```