### PR TITLE
Removing non-existed deathSound reference to BATTLE.CAT

### DIFF
--- a/bin/standard/xcom1/units.rul
+++ b/bin/standard/xcom1/units.rul
@@ -853,4 +853,4 @@ units:
     energyRecovery: 20
     spawnUnit: STR_CHRYSSALID_TERRORIST
     livingWeapon: true
-    deathSound: -2
+    # Zombies are silent on death, no deathSound

--- a/bin/standard/xcom2/units.rul
+++ b/bin/standard/xcom2/units.rul
@@ -581,7 +581,7 @@ units: #done
     standHeight: 18
     kneelHeight: 18
     value: 18
-    deathSound: -2
+    # Zombies are silent on death, no deathSound
     intelligence: 3
     aggression: 2
     spawnUnit: STR_TENTACULAT_TERRORIST


### PR DESCRIPTION
After adding support for moddable deathsound (61c2601c628d99083669be613876b50b74e67a8e) by new logic, if you don't need death scream, you shouldn't define deathSound otherwise OpenXcom will crash with segfault.