### PR TITLE
Lots of fixes to get things compiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ configure
 Makefile
 Makefile.in
 depcomp
+compile
 .deps/
 *.tar.gz
 *.tar.xz

--- a/Makefile.am
+++ b/Makefile.am
@@ -146,10 +146,10 @@ openxcom_SOURCES = \
 	src/Battlescape/CannotReequipState.h \
 	src/Battlescape/CivilianBAIState.cpp \
 	src/Battlescape/CivilianBAIState.h \
-	src/Battlescape/CommendationsLateState.cpp \
-	src/Battlescape/CommendationsLateState.h \
-	src/Battlescape/CommendationsState.cpp \
-	src/Battlescape/CommendationsState.h \
+	src/Battlescape/CommendationLateState.cpp \
+	src/Battlescape/CommendationLateState.h \
+	src/Battlescape/CommendationState.cpp \
+	src/Battlescape/CommendationState.h \
 	src/Battlescape/DebriefingState.cpp \
 	src/Battlescape/DebriefingState.h \
 	src/Battlescape/Explosion.cpp \

--- a/src/Basescape/SoldierDiaryMissionState.cpp
+++ b/src/Basescape/SoldierDiaryMissionState.cpp
@@ -76,7 +76,7 @@ SoldierDiaryMissionState::SoldierDiaryMissionState(Soldier *soldier, int rowEntr
 
 	// Set up objects
 	std::vector<MissionStatistics*> *missionStatistics = _game->getSavedGame()->getMissionStatistics();
-    int missionId = _soldier->getDiary()->getMissionIdList().at(_rowEntry);
+	unsigned int missionId = _soldier->getDiary()->getMissionIdList().at(_rowEntry);
 	if (missionId > missionStatistics->size())
 	{
 		missionId = 0;
@@ -117,7 +117,7 @@ SoldierDiaryMissionState::SoldierDiaryMissionState(Soldier *soldier, int rowEntr
 
 	for (std::vector<BattleUnitKills*>::iterator i = _soldier->getDiary()->getKills().begin() ; i != _soldier->getDiary()->getKills().end() ; ++i)
 	{
-		if ((*i)->mission != missionId) continue;
+		if ((unsigned int)(*i)->mission != missionId) continue;
 
 		switch ((*i)->status)
 		{

--- a/src/Basescape/SoldierDiaryOverviewState.cpp
+++ b/src/Basescape/SoldierDiaryOverviewState.cpp
@@ -177,7 +177,7 @@ void SoldierDiaryOverviewState::init()
 	
 	std::vector<MissionStatistics*> *missionStatistics = _game->getSavedGame()->getMissionStatistics();
 
-	int row = 0;
+	unsigned int row = 0;
 	for (std::vector<MissionStatistics*>::iterator j = missionStatistics->begin() ; j != missionStatistics->end() ; ++j)
 	{
 		int missionId = (*j)->id;
@@ -246,7 +246,6 @@ void SoldierDiaryOverviewState::btnKillsClick(Action *)
  */
 void SoldierDiaryOverviewState::btnMissionsClick(Action *)
 {
-	int _display = 1;
 	_game->pushState(new SoldierDiaryPerformanceState(_base, _soldierId, this, DIARY_MISSIONS));
 }
 

--- a/src/Basescape/SoldierDiaryPerformanceState.cpp
+++ b/src/Basescape/SoldierDiaryPerformanceState.cpp
@@ -413,7 +413,7 @@ void SoldierDiaryPerformanceState::drawSprites()
 	{
 		RuleCommendations* commendation = _game->getMod()->getCommendation()[(*i)->getType()];
 		// Skip commendations that are not visible in the textlist
-		if ( vectorIterator < scrollDepth || vectorIterator - scrollDepth >= _commendations.size())
+		if ( vectorIterator < scrollDepth || vectorIterator - scrollDepth >= (int)_commendations.size())
 		{
 			vectorIterator++;
 			continue;
@@ -535,7 +535,7 @@ void SoldierDiaryPerformanceState::think()
 {
 	State::think();
 
-	if (_lastScrollPos != _lstCommendations->getScroll())
+	if ((unsigned int)_lastScrollPos != _lstCommendations->getScroll())
 	{
 		drawSprites();
 		_lastScrollPos = _lstCommendations->getScroll();

--- a/src/Basescape/SoldierDiaryPerformanceState.h
+++ b/src/Basescape/SoldierDiaryPerformanceState.h
@@ -62,8 +62,8 @@ private:
 	std::vector<Surface*> _commendations, _commendationDecorations;
 	SurfaceSet *_commendationSprite, *_commendationDecoration;
 
-	int _lastScrollPos;
 	SoldierDiaryDisplay _display;
+	int _lastScrollPos;
 	TextButton *_group;
 
 public:

--- a/src/Basescape/TransferItemsState.cpp
+++ b/src/Basescape/TransferItemsState.cpp
@@ -143,7 +143,7 @@ TransferItemsState::TransferItemsState(Base *baseFrom, Base *baseTo) : _baseFrom
 	{
 		if ((*i)->getCraft() == 0)
 		{
-			TransferRow row = { TRANSFER_SOLDIER, (*i), (*i)->getName(true), 5 * _distance, 1, 0, 0 };
+			TransferRow row = { TRANSFER_SOLDIER, (*i), (*i)->getName(true), (int)(5 * _distance), 1, 0, 0 };
 			_items.push_back(row);
 			std::string cat = getCategory(_items.size() - 1);
 			if (std::find(_cats.begin(), _cats.end(), cat) == _cats.end())
@@ -156,7 +156,7 @@ TransferItemsState::TransferItemsState(Base *baseFrom, Base *baseTo) : _baseFrom
 	{
 		if ((*i)->getStatus() != "STR_OUT" || (Options::canTransferCraftsWhileAirborne && (*i)->getFuel() >= (*i)->getFuelLimit(_baseTo)))
 		{
-			TransferRow row = { TRANSFER_CRAFT, (*i), (*i)->getName(_game->getLanguage()), 25 * _distance, 1, 0, 0 };
+			TransferRow row = { TRANSFER_CRAFT, (*i), (*i)->getName(_game->getLanguage()), (int)(25 * _distance), 1, 0, 0 };
 			_items.push_back(row);
 			std::string cat = getCategory(_items.size() - 1);
 			if (std::find(_cats.begin(), _cats.end(), cat) == _cats.end())
@@ -167,7 +167,7 @@ TransferItemsState::TransferItemsState(Base *baseFrom, Base *baseTo) : _baseFrom
 	}
 	if (_baseFrom->getAvailableScientists() > 0)
 	{
-		TransferRow row = { TRANSFER_SCIENTIST, 0, tr("STR_SCIENTIST"), 5 * _distance, _baseFrom->getAvailableScientists(), _baseTo->getAvailableScientists(), 0 };
+		TransferRow row = { TRANSFER_SCIENTIST, 0, tr("STR_SCIENTIST"), (int)(5 * _distance), _baseFrom->getAvailableScientists(), _baseTo->getAvailableScientists(), 0 };
 		_items.push_back(row);
 		std::string cat = getCategory(_items.size() - 1);
 		if (std::find(_cats.begin(), _cats.end(), cat) == _cats.end())
@@ -177,7 +177,7 @@ TransferItemsState::TransferItemsState(Base *baseFrom, Base *baseTo) : _baseFrom
 	}
 	if (_baseFrom->getAvailableEngineers() > 0)
 	{
-		TransferRow row = { TRANSFER_ENGINEER, 0, tr("STR_ENGINEER"), 5 * _distance, _baseFrom->getAvailableEngineers(), _baseTo->getAvailableEngineers(), 0 };
+		TransferRow row = { TRANSFER_ENGINEER, 0, tr("STR_ENGINEER"), (int)(5 * _distance), _baseFrom->getAvailableEngineers(), _baseTo->getAvailableEngineers(), 0 };
 		_items.push_back(row);
 		std::string cat = getCategory(_items.size() - 1);
 		if (std::find(_cats.begin(), _cats.end(), cat) == _cats.end())
@@ -192,7 +192,7 @@ TransferItemsState::TransferItemsState(Base *baseFrom, Base *baseTo) : _baseFrom
 		if (qty > 0)
 		{
 			RuleItem *rule = _game->getMod()->getItem(*i);
-			TransferRow row = { TRANSFER_ITEM, rule, tr(*i), 1 * _distance, qty, _baseTo->getStorageItems()->getItem(*i), 0 };
+			TransferRow row = { TRANSFER_ITEM, rule, tr(*i), (int)(1 * _distance), qty, _baseTo->getStorageItems()->getItem(*i), 0 };
 			_items.push_back(row);
 			std::string cat = getCategory(_items.size() - 1);
 			if (std::find(_cats.begin(), _cats.end(), cat) == _cats.end())

--- a/src/Geoscape/Globe.cpp
+++ b/src/Geoscape/Globe.cpp
@@ -408,6 +408,7 @@ Polygon* Globe::getPolygonFromLonLat(double lon, double lat) const
 	{
 		double x, y, z, x2, y2;
 		double clat, clon;
+		z = 0;
 		for (int j = 0; j < (*i)->getPoints(); ++j)
 		{
 			z = coslat * cos((*i)->getLatitude(j)) * cos((*i)->getLongitude(j) - lon) + sinlat * sin((*i)->getLatitude(j));
@@ -1077,7 +1078,6 @@ void Globe::drawRadars()
 	if (!Options::globeRadarLines)
 		return;
 
-	double x, y;
 	double tr, range;
 	double lat, lon;
 	std::vector<double> ranges;

--- a/src/Mod/RuleCommendations.cpp
+++ b/src/Mod/RuleCommendations.cpp
@@ -25,7 +25,7 @@ namespace OpenXcom
 /**
  * Creates a blank set of commendation data.
  */
-RuleCommendations::RuleCommendations() : _description(""), _criteria(), _sprite(), _killCriteria()
+RuleCommendations::RuleCommendations() : _criteria(), _killCriteria(), _description(""), _sprite()
 {
 }
 

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -54,9 +54,9 @@ BattleUnit::BattleUnit(Soldier *soldier, int depth) :
 	_verticalDirection(0), _status(STATUS_STANDING), _walkPhase(0), _fallPhase(0), _kneeled(false), _floating(false),
 	_dontReselect(false), _fire(0), _currentAIState(0), _visible(false), _cacheInvalid(true),
 	_expBravery(0), _expReactions(0), _expFiring(0), _expThrowing(0), _expPsiSkill(0), _expPsiStrength(0), _expMelee(0),
-	_motionPoints(0), _kills(0), _hitByFire(false), _moraleRestored(0), _coverReserve(0), _charging(0),
-	_turnsSinceSpotted(255), _geoscapeSoldier(soldier), _unitRules(0), _rankInt(-1), _turretType(-1), _hidingForTurn(false), _respawn(false),
-    _statistics(), _murdererId(0), _fatalShotSide(SIDE_FRONT), _fatalShotBodyPart(BODYPART_HEAD)
+	_motionPoints(0), _kills(0), _hitByFire(false), _moraleRestored(0), _coverReserve(0), _charging(0), _turnsSinceSpotted(255),
+	_statistics(), _murdererId(0), _fatalShotSide(SIDE_FRONT), _fatalShotBodyPart(BODYPART_HEAD),
+	_geoscapeSoldier(soldier), _unitRules(0), _rankInt(-1), _turretType(-1), _hidingForTurn(false), _respawn(false)
 {
 	_name = soldier->getName(true);
 	_id = soldier->getId();
@@ -163,9 +163,9 @@ BattleUnit::BattleUnit(Unit *unit, UnitFaction faction, int id, Armor *armor, in
 	_visible(false), _cacheInvalid(true), _expBravery(0), _expReactions(0), _expFiring(0),
 	_expThrowing(0), _expPsiSkill(0), _expPsiStrength(0), _expMelee(0), _motionPoints(0), _kills(0), _hitByFire(false),
 	_moraleRestored(0), _coverReserve(0), _charging(0), _turnsSinceSpotted(255),
+	_statistics(), _murdererId(0), _fatalShotSide(SIDE_FRONT), _fatalShotBodyPart(BODYPART_HEAD),
 	_armor(armor), _geoscapeSoldier(0),  _unitRules(unit), _rankInt(-1),
-	_turretType(-1), _hidingForTurn(false), _respawn(false), _statistics(), _murdererId(0),
-    _fatalShotSide(SIDE_FRONT), _fatalShotBodyPart(BODYPART_HEAD)
+	_turretType(-1), _hidingForTurn(false), _respawn(false)
 {
 	_type = unit->getType();
 	_rank = unit->getRank();

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -100,11 +100,11 @@ private:
 	int _turnsSinceSpotted;
 	std::string _spawnUnit;
 	std::string _activeHand;
-    BattleUnitStatistics* _statistics;
+	BattleUnitStatistics* _statistics;
 	int _murdererId;	// used to credit the murderer with the kills that this unit got by blowing up on death
-    UnitSide _fatalShotSide;
-    UnitBodyPart _fatalShotBodyPart;
-    std::string _murdererWeapon, _murdererWeaponAmmo;
+	UnitSide _fatalShotSide;
+	UnitBodyPart _fatalShotBodyPart;
+	std::string _murdererWeapon, _murdererWeaponAmmo;
 
 	// static data
 	std::string _type;

--- a/src/Savegame/SoldierDiary.cpp
+++ b/src/Savegame/SoldierDiary.cpp
@@ -381,15 +381,15 @@ bool SoldierDiary::manageCommendations(Mod *mod)
 		for (std::map<std::string, std::vector<int> >::const_iterator j = (*i).second->getCriteria()->begin(); j != (*i).second->getCriteria()->end(); ++j)
 		{
 			// Skip this medal if we have reached its max award level.
-			if (nextCommendationLevel["noNoun"] >= (*j).second.size())
+			if ((unsigned int)nextCommendationLevel["noNoun"] >= (*j).second.size())
 			{
 				awardCommendationBool = false;
 				break;
 			}
             // These criteria have no nouns, so only the nextCommendationLevel["noNoun"] will ever be used.
 			else if( nextCommendationLevel.count("noNoun") == 1 &&
-					((*j).first == "totalKills" && _killList.size() < (*j).second.at(nextCommendationLevel["noNoun"])) ||
-					((*j).first == "totalMissions" && _missionIdList.size() < (*j).second.at(nextCommendationLevel["noNoun"])) ||
+				      ( ((*j).first == "totalKills" && _killList.size() < (unsigned int)(*j).second.at(nextCommendationLevel["noNoun"])) ||
+					((*j).first == "totalMissions" && _missionIdList.size() < (unsigned int)(*j).second.at(nextCommendationLevel["noNoun"])) ||
 					((*j).first == "totalWins" && _winTotal < (*j).second.at(nextCommendationLevel["noNoun"])) ||
 					((*j).first == "totalScore" && _scoreTotal < (*j).second.at(nextCommendationLevel["noNoun"])) ||
 					((*j).first == "totalStuns" && _stunTotal < (*j).second.at(nextCommendationLevel["noNoun"])) ||
@@ -430,7 +430,7 @@ bool SoldierDiary::manageCommendations(Mod *mod)
 					((*j).first == "totalMartyrKills" && _martyrKillsTotal < (*j).second.at(nextCommendationLevel["noNoun"])) ||
 					((*j).first == "totalPostMortemKills" && _postMortemKills < (*j).second.at(nextCommendationLevel["noNoun"])) ||
                     ((*j).first == "globeTrotter" && (int)_globeTrotter < (*j).second.at(nextCommendationLevel["noNoun"])) ||
-					((*j).first == "totalSlaveKills" && _slaveKillsTotal < (*j).second.at(nextCommendationLevel["noNoun"])) )
+					((*j).first == "totalSlaveKills" && _slaveKillsTotal < (*j).second.at(nextCommendationLevel["noNoun"])) ) )
 					
 			{
 				awardCommendationBool = false;
@@ -454,12 +454,12 @@ bool SoldierDiary::manageCommendations(Mod *mod)
 				for(std::map<std::string, int>::const_iterator k = tempTotal.begin(); k != tempTotal.end(); ++k)
 				{
 					int criteria = -1;
-                    std::string noun = (*k).first;
+	                                std::string noun = (*k).first;
 					// If there is no matching noun, get the first award criteria.
-                    if (nextCommendationLevel.count(noun) == 0)
+	                                if (nextCommendationLevel.count(noun) == 0)
 						criteria = (*j).second.front(); 
 					// Otherwise, get the criteria that reflects the soldier's commendation level.
-                    else if (nextCommendationLevel[noun] != (*j).second.size())
+	                                else if ((unsigned int)nextCommendationLevel[noun] != (*j).second.size())
 						criteria = (*j).second.at(nextCommendationLevel[noun]); 
 
                     // If a criteria was set AND the stat's count exceeds the criteria.
@@ -595,7 +595,6 @@ bool SoldierDiary::manageCommendations(Mod *mod)
                 }
             }
         }
-		bool awardedModularCommendation = false;
 		if (awardCommendationBool)
 		{
             // If we do not have modular medals, but are awarded a different medal,
@@ -604,10 +603,6 @@ bool SoldierDiary::manageCommendations(Mod *mod)
             {
                 modularCommendations.push_back("noNoun");
             }
-			else
-			{
-				awardedModularCommendation = true;
-			}
             for (std::vector<std::string>::const_iterator j = modularCommendations.begin(); j != modularCommendations.end(); ++j)
             {
 				bool newCommendation = true;


### PR DESCRIPTION
Makefile typos
uninitialized variable (Globe.cpp)
added parentheses to fix operator order (&& comes before || by default)
constructor initializer reordering
unused variables
signed/unsigned comparisons
"narrowing conversion... from ‘double’ to ‘int’ inside { } is ill-formed in C++11" (TransferItemsState.cpp, old issue)
and retabbification