### PR TITLE
Describe worktree state in the version string.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ if ( "${OPENXCOM_VERSION_STRING}" STREQUAL "" )
       ERROR_VARIABLE git_describe_error
       RESULT_VARIABLE git_describe_result
       )
-    string ( REGEX MATCH "([a-z|0-9|.]*)-([0-9]*)-([a-z|0-9]*)([-|a-z]*)" git_commit "${git_describe_out}" )
+    string ( REGEX MATCH "([a-z|0-9|.]*)-([0-9]*)-g([a-z|0-9]*)([-|a-z]*)" git_commit "${git_describe_out}" )
     set ( git_tag ${CMAKE_MATCH_1} )
     set ( git_nb_commit ${CMAKE_MATCH_2} )
     set ( git_commit ${CMAKE_MATCH_3} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ if ( "${OPENXCOM_VERSION_STRING}" STREQUAL "" )
     set ( git_nb_commit ${CMAKE_MATCH_2} )
     set ( git_commit ${CMAKE_MATCH_3} )
     set ( git_dirty ${CMAKE_MATCH_4} )
-    set ( OPENXCOM_VERSION_STRING ".${git_commit}" )
+    set ( OPENXCOM_VERSION_STRING ".${git_commit}${git_dirty}" )
   endif()
 endif()
 

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -501,7 +501,12 @@ void SavedGame::save(const std::string &filename) const
 	YAML::Node brief;
 	brief["name"] = Language::wstrToUtf8(_name);
 	brief["version"] = OPENXCOM_VERSION_SHORT;
-	brief["build"] = OPENXCOM_VERSION_GIT;
+	std::string git_sha = OPENXCOM_VERSION_GIT;
+	if (git_sha[0] ==  '.')
+	{
+		git_sha.erase(0,1);
+	}
+	brief["build"] = git_sha;
 	brief["time"] = _time->save();
 	if (_battleGame != 0)
 	{


### PR DESCRIPTION
Adds "-dirty" when build was based on sources with uncommitted
alterations (hence unknown to bug-hunters).