### PR TITLE
Align price and quantity to right for better look.

### DIFF
--- a/src/Basescape/PurchaseState.cpp
+++ b/src/Basescape/PurchaseState.cpp
@@ -117,8 +117,11 @@ PurchaseState::PurchaseState(Base *base) : _base(base), _sel(0), _total(0), _pQt
 
 	_txtQuantity->setText(tr("STR_QUANTITY_UC"));
 
-	_lstItems->setArrowColumn(227, ARROW_VERTICAL);
-	_lstItems->setColumns(4, 150, 55, 50, 28);
+	_lstItems->setArrowColumn(235, ARROW_VERTICAL);
+	_lstItems->setColumns(4, 150, 55, 25, 53);
+	_lstItems->setAlign(ALIGN_RIGHT, 1);
+	_lstItems->setAlign(ALIGN_RIGHT, 2);
+	_lstItems->setAlign(ALIGN_RIGHT, 3);
 	_lstItems->setSelectable(true);
 	_lstItems->setBackground(_window);
 	_lstItems->setMargin(2);

--- a/src/Basescape/SellState.cpp
+++ b/src/Basescape/SellState.cpp
@@ -131,8 +131,11 @@ SellState::SellState(Base *base, OptionsOrigin origin) : _base(base), _sel(0), _
 
 	_txtValue->setText(tr("STR_VALUE"));
 
-	_lstItems->setArrowColumn(182, ARROW_VERTICAL);
-	_lstItems->setColumns(4, 156, 54, 24, 53);
+	_lstItems->setArrowColumn(185, ARROW_VERTICAL);
+	_lstItems->setColumns(4, 156, 24, 50, 53);
+	_lstItems->setAlign(ALIGN_RIGHT, 1);
+	_lstItems->setAlign(ALIGN_RIGHT, 2);
+	_lstItems->setAlign(ALIGN_RIGHT, 3);
 	_lstItems->setSelectable(true);
 	_lstItems->setBackground(_window);
 	_lstItems->setMargin(2);


### PR DESCRIPTION
Align to right 3 last columns in Purchase and Sell screens:
![screen003](https://cloud.githubusercontent.com/assets/81112/12020363/80b2ca7a-ad9d-11e5-83c1-582ebeb018c8.png)
![screen004](https://cloud.githubusercontent.com/assets/81112/12020369/851c649a-ad9d-11e5-8d17-0faa4ba1db9e.png)
