### PR TITLE
Fixed lag issue when research project is completed

### DIFF
--- a/src/Basescape/CraftEquipmentState.cpp
+++ b/src/Basescape/CraftEquipmentState.cpp
@@ -510,7 +510,7 @@ void CraftEquipmentState::moveRightByValue(int change)
 	if (item->isFixed())
 	{
 		int size = 4;
-		if (_game->getMod()->getUnit(item->getType()))
+		if (_game->getMod()->hasUnit(item->getType()))
 		{
 			size = _game->getMod()->getArmor(_game->getMod()->getUnit(item->getType())->getArmor())->getSize();
 			size *= size;

--- a/src/Basescape/ResearchInfoState.cpp
+++ b/src/Basescape/ResearchInfoState.cpp
@@ -120,7 +120,7 @@ void ResearchInfoState::buildUi()
 	{
 		_base->addResearch(_project);
 		if (_rule->needItem() &&
-				(_game->getMod()->getUnit(_rule->getName()) ||
+				(_game->getMod()->hasUnit(_rule->getName()) ||
 				 Options::spendResearchedItems))
 		{
 			_base->getStorageItems()->removeItem(_rule->getName(), 1);
@@ -183,7 +183,7 @@ void ResearchInfoState::btnCancelClick(Action *)
 {
 	const RuleResearch *ruleResearch = _rule ? _rule : _project->getRules();
 	if (ruleResearch->needItem() &&
-			(_game->getMod()->getUnit(ruleResearch->getName()) ||
+			(_game->getMod()->hasUnit(ruleResearch->getName()) ||
 			 Options::spendResearchedItems))
 	{
 		_base->getStorageItems()->addItem(ruleResearch->getName(), 1);

--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -1296,7 +1296,7 @@ void DebriefingState::reequipCraft(Base *base, Craft *craft, bool vehicleItemsCa
 		int qty = base->getStorageItems()->getItem(i->first);
 		RuleItem *tankRule = _game->getMod()->getItem(i->first);
 		int size = 4;
-		if (_game->getMod()->getUnit(tankRule->getType()))
+		if (_game->getMod()->hasUnit(tankRule->getType()))
 		{
 			size = _game->getMod()->getArmor(_game->getMod()->getUnit(tankRule->getType())->getArmor())->getSize();
 			size *= size;

--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -1544,7 +1544,7 @@ void GeoscapeState::time1Day()
 			RuleResearch * bonus = 0;
 			const RuleResearch * research = (*iter)->getRules();
 			// If "researched" the live alien, his body sent to the stores.
-			if (Options::spendResearchedItems && research->needItem() && _game->getMod()->getUnit(research->getName()))
+			if (Options::spendResearchedItems && research->needItem() && _game->getMod()->hasUnit(research->getName()))
 			{
 				(*i)->getStorageItems()->addItem(
 					_game->getMod()->getArmor(

--- a/src/Geoscape/NewPossibleResearchState.cpp
+++ b/src/Geoscape/NewPossibleResearchState.cpp
@@ -80,7 +80,7 @@ NewPossibleResearchState::NewPossibleResearchState(Base * base, const std::vecto
 	size_t tally(0);
 	for (std::vector<RuleResearch *>::const_iterator iter = possibilities.begin(); iter != possibilities.end(); ++iter)
 	{
-		bool liveAlien = (*iter)->needItem() && _game->getMod()->getUnit((*iter)->getName()) != 0;
+		bool liveAlien = (*iter)->needItem() && _game->getMod()->hasUnit((*iter)->getName());
 		if (!_game->getSavedGame()->wasResearchPopped(*iter) && (*iter)->getRequirements().empty() && !liveAlien)
 		{
 			_game->getSavedGame()->addPoppedResearch((*iter));

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -370,6 +370,27 @@ Mod::~Mod()
 }
 
 /**
+ * Checks if a specific rule element exists
+ * @param id String ID of the rule element.
+ * @param name Human-readable name of the rule type.
+ * @param map Map associated to the rule type.
+ * @return Boolean
+ */
+template <typename T>
+bool Mod::hasRule(const std::string &id, const std::map<std::string, T*> &map) const
+{
+	if (id.empty())
+	{
+		return false;
+	}
+	else
+	{
+		typename std::map<std::string, T*>::const_iterator i = map.find(id);
+		return (map.end() != i);
+	}
+}
+
+/**
  * Gets a specific rule element by ID.
  * @param id String ID of the rule element.
  * @param name Human-readable name of the rule type.
@@ -1581,6 +1602,16 @@ const std::vector<std::string> &Mod::getSoldiersList() const
 std::map<std::string, RuleCommendations *> Mod::getCommendation() const
 {
 	return _commendations;
+}
+
+/**
+ * Checks if a specific unit exists.
+ * @param name Unit name.
+ * @return bool
+ */
+bool Mod::hasUnit(const std::string &name) const
+{
+	return hasRule(name, _units);
 }
 
 /**

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -157,6 +157,9 @@ private:
 	/// Loads a ruleset element.
 	template <typename T>
 	T *loadRule(const YAML::Node &node, std::map<std::string, T*> *map, std::vector<std::string> *index = 0, const std::string &key = "type") const;
+	/// Checks if a ruleset element exists.
+	template <typename T>
+	bool hasRule(const std::string &id, const std::map<std::string, T*> &map) const;
 	/// Gets a ruleset element.
 	template <typename T>
 	T *getRule(const std::string &id, const std::string &name, const std::map<std::string, T*> &map) const;
@@ -295,6 +298,8 @@ public:
 	const std::vector<std::string> &getSoldiersList() const;
 	/// Gets commendation rules.
 	std::map<std::string, RuleCommendations *> getCommendation() const;
+	/// Checks if a unit exists.
+	bool hasUnit(const std::string &name) const;
 	/// Gets generated unit rules.
 	Unit *getUnit(const std::string &name) const;
 	/// Gets alien race rules.

--- a/src/Savegame/Base.cpp
+++ b/src/Savegame/Base.cpp
@@ -1198,7 +1198,7 @@ int Base::getUsedContainment() const
 	for (std::vector<ResearchProject*>::const_iterator i = _research.begin(); i != _research.end(); ++i)
 	{
 		const RuleResearch *projRules = (*i)->getRules();
-		if (projRules->needItem() && _mod->getUnit(projRules->getName()))
+		if (projRules->needItem() && _mod->hasUnit(projRules->getName()))
 		{
 			++total;
 		}
@@ -1372,7 +1372,7 @@ void Base::setupDefenses()
 		if (rule->isFixed())
 		{
 			int size = 4;
-			if (_mod->getUnit(itemId))
+			if (_mod->hasUnit(itemId))
 			{
 				size = _mod->getArmor(_mod->getUnit(itemId)->getArmor())->getSize();
 			}

--- a/src/Savegame/SavedBattleGame.cpp
+++ b/src/Savegame/SavedBattleGame.cpp
@@ -205,7 +205,7 @@ void SavedBattleGame::load(const YAML::Node &node, Mod *mod, SavedGame* savedGam
 			std::string type = (*i)["genUnitType"].as<std::string>();
 			std::string armor = (*i)["genUnitArmor"].as<std::string>();
 			// create a new Unit.
-			if(!mod->getUnit(type) || !mod->getArmor(armor)) continue;
+			if(!mod->hasUnit(type) || !mod->getArmor(armor)) continue;
 			unit = new BattleUnit(mod->getUnit(type), originalFaction, id, mod->getArmor(armor), mod->getStatAdjustment(savedGame->getDifficulty()), _depth);
 		}
 		unit->load(*i);

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -1062,8 +1062,6 @@ void SavedGame::getAvailableResearchProjects (std::vector<RuleResearch *> & proj
 		}
 		std::vector<const RuleResearch *>::const_iterator itDiscovered = std::find(discovered.begin(), discovered.end(), research);
 
-		bool liveAlien = mod->getUnit(research->getName()) != 0;
-
 		if (itDiscovered != discovered.end())
 		{
 			bool cull = true;
@@ -1079,18 +1077,11 @@ void SavedGame::getAvailableResearchProjects (std::vector<RuleResearch *> & proj
 					}
 				}
 			}
-			if (!liveAlien && cull)
-			{
-				continue;
-			}
-			else
+
+			if (mod->hasUnit(research->getName()))
 			{
 				std::vector<std::string>::const_iterator leaderCheck = std::find(research->getUnlocked().begin(), research->getUnlocked().end(), "STR_LEADER_PLUS");
-				std::vector<std::string>::const_iterator cmnderCheck = std::find(research->getUnlocked().begin(), research->getUnlocked().end(), "STR_COMMANDER_PLUS");
-
 				bool leader ( leaderCheck != research->getUnlocked().end());
-				bool cmnder ( cmnderCheck != research->getUnlocked().end());
-
 				if (leader)
 				{
 					std::vector<const RuleResearch*>::const_iterator found = std::find(discovered.begin(), discovered.end(), mod->getResearch("STR_LEADER_PLUS"));
@@ -1098,15 +1089,19 @@ void SavedGame::getAvailableResearchProjects (std::vector<RuleResearch *> & proj
 						cull = false;
 				}
 
+				std::vector<std::string>::const_iterator cmnderCheck = std::find(research->getUnlocked().begin(), research->getUnlocked().end(), "STR_COMMANDER_PLUS");
+				bool cmnder(cmnderCheck != research->getUnlocked().end());
 				if (cmnder)
 				{
 					std::vector<const RuleResearch*>::const_iterator found = std::find(discovered.begin(), discovered.end(), mod->getResearch("STR_COMMANDER_PLUS"));
 					if (found == discovered.end())
 						cull = false;
 				}
+			}
 
-				if (cull)
-					continue;
+			if (cull)
+			{
+				continue;
 			}
 		}
 

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -1174,12 +1174,11 @@ bool SavedGame::isResearchAvailable (RuleResearch * r, const std::vector<const R
 	}
 	std::vector<std::string> deps = r->getDependencies();
 	const std::vector<const RuleResearch *> & discovered(getDiscoveredResearch());
-	bool liveAlien = mod->getUnit(r->getName()) != 0;
 	if (_debug || std::find(unlocked.begin(), unlocked.end(), r) != unlocked.end())
 	{
 		return true;
 	}
-	else if (liveAlien)
+	else if (mod->hasUnit(r->getName()))
 	{
 		if (!r->getGetOneFree().empty())
 		{


### PR DESCRIPTION
Whenever the available research list is produced, the game halts. This
occurs when the new research list is opened as well as when a research
has been completed.

The issue comes from the fact that we check if the research project is
the same name as a unit. Since most research projects are not, an error
occurs as the unit could not be found. The generation of the error
causes the game to lag.

I've changed the code to check for live aliens only when needed as well
as checking if the unit exists instead of getting the unit and ensuring
an error was produced.