### PR TITLE
Fixed lag issue related to mod rule not existing

### DIFF
--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -390,10 +390,6 @@ T *Mod::getRule(const std::string &id, const std::string &name, const std::map<s
 	}
 	else
 	{
-		if (id != Armor::NONE)
-		{
-			Log(LOG_WARNING) << name << " " << id << " not found";
-		}
 		return 0;
 	}
 }


### PR DESCRIPTION
Whenever the available research projects are calculated (e.g.: when a research is completed, when the new project button is clicked), we check all of the research projects' names as units. Since the majority of the research projects do not have corresponding units, an error log is generated for every research project.

Having no rule for the name is expected behavior and no error should be generated. This will incidentally fix the lag generated during the available research project calculations (and other places that test existence of a rule this way.)