### PR TITLE
Let medikits honor relative TU usage.

### DIFF
--- a/src/Battlescape/MedikitState.cpp
+++ b/src/Battlescape/MedikitState.cpp
@@ -128,6 +128,7 @@ MedikitState::MedikitState (BattleUnit *targetUnit, BattleAction *action) : _tar
 		_game->getScreen()->resetDisplay(false);
 	}
 
+	_tu = action->TU;
 	_unit = action->actor;
 	_item = action->weapon;
 	_bg = new Surface(320, 200);
@@ -220,7 +221,7 @@ void MedikitState::onHealClick(Action *)
 	{
 		return;
 	}
-	if (_unit->spendTimeUnits (rule->getTUUse()))
+	if (_unit->spendTimeUnits(_tu))
 	{
 		_targetUnit->heal(_medikitView->getSelectedPart(), rule->getWoundRecovery(), rule->getHealthRecovery());
 		_item->setHealQuantity(--heal);
@@ -254,7 +255,7 @@ void MedikitState::onStimulantClick(Action *)
 	{
 		return;
 	}
-	if (_unit->spendTimeUnits (rule->getTUUse()))
+	if (_unit->spendTimeUnits (_tu))
 	{
 		_targetUnit->stimulant(rule->getEnergyRecovery(), rule->getStunRecovery());
 		_item->setStimulantQuantity(--stimulant);
@@ -287,7 +288,7 @@ void MedikitState::onPainKillerClick(Action *)
 	{
 		return;
 	}
-	if (_unit->spendTimeUnits (rule->getTUUse()))
+	if (_unit->spendTimeUnits (_tu))
 	{
 		_targetUnit->painKillers();
 		_item->setPainKillerQuantity(--pk);

--- a/src/Battlescape/MedikitState.h
+++ b/src/Battlescape/MedikitState.h
@@ -41,6 +41,7 @@ class MedikitState : public State
 	BattleUnit *_targetUnit, *_unit;
 	BattleItem *_item;
 	BattleAction *_action;
+	int _tu;
 	/// Handler for the end button.
 	void onEndClick(Action *action);
 	/// Handler for the heal button.


### PR DESCRIPTION
Action menu already did the hard work (and shows it to user), so why not
make use of it.
Fixes bug where medikits do not behave as advertised when mods did not
set ``flatRate: true``.