### PR TITLE
Option for sharing node values in ruleset

### DIFF
--- a/src/Mod/AlienDeployment.cpp
+++ b/src/Mod/AlienDeployment.cpp
@@ -131,6 +131,10 @@ AlienDeployment::~AlienDeployment()
  */
 void AlienDeployment::load(const YAML::Node &node)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent);
+	}
 	_type = node["type"].as<std::string>(_type);
 	_data = node["data"].as< std::vector<DeploymentData> >(_data);
 	_width = node["width"].as<int>(_width);

--- a/src/Mod/AlienRace.cpp
+++ b/src/Mod/AlienRace.cpp
@@ -39,6 +39,10 @@ AlienRace::~AlienRace()
  */
 void AlienRace::load(const YAML::Node &node)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent);
+	}
 	_id = node["id"].as<std::string>(_id);
 	_members = node["members"].as< std::vector<std::string> >(_members);
 	_retaliation = node["retaliation"].as<bool>(_retaliation);

--- a/src/Mod/Armor.cpp
+++ b/src/Mod/Armor.cpp
@@ -53,6 +53,10 @@ Armor::~Armor()
  */
 void Armor::load(const YAML::Node &node)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent);
+	}
 	_type = node["type"].as<std::string>(_type);
 	_spriteSheet = node["spriteSheet"].as<std::string>(_spriteSheet);
 	_spriteInv = node["spriteInv"].as<std::string>(_spriteInv);

--- a/src/Mod/RuleAlienMission.cpp
+++ b/src/Mod/RuleAlienMission.cpp
@@ -74,6 +74,10 @@ RuleAlienMission::~RuleAlienMission()
  */
 void RuleAlienMission::load(const YAML::Node &node)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent);
+	}
 	_type = node["type"].as<std::string>(_type);
 	_points = node["points"].as<int>(_points);
 	_waves = node["waves"].as< std::vector<MissionWave> >(_waves);

--- a/src/Mod/RuleBaseFacility.cpp
+++ b/src/Mod/RuleBaseFacility.cpp
@@ -46,6 +46,10 @@ RuleBaseFacility::~RuleBaseFacility()
  */
 void RuleBaseFacility::load(const YAML::Node &node, Mod *mod, int listOrder)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent, mod, listOrder);
+	}
 	_type = node["type"].as<std::string>(_type);
 	_requires = node["requires"].as< std::vector<std::string> >(_requires);
 	if (node["spriteShape"])

--- a/src/Mod/RuleCountry.cpp
+++ b/src/Mod/RuleCountry.cpp
@@ -46,6 +46,10 @@ RuleCountry::~RuleCountry()
  */
 void RuleCountry::load(const YAML::Node &node)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent);
+	}
 	_type = node["type"].as<std::string>(_type);
 	_fundingBase = node["fundingBase"].as<int>(_fundingBase);
 	_fundingCap = node["fundingCap"].as<int>(_fundingCap);

--- a/src/Mod/RuleCraft.cpp
+++ b/src/Mod/RuleCraft.cpp
@@ -50,6 +50,10 @@ RuleCraft::~RuleCraft()
  */
 void RuleCraft::load(const YAML::Node &node, Mod *mod, int listOrder)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent, mod, listOrder);
+	}
 	_type = node["type"].as<std::string>(_type);
 	_requires = node["requires"].as< std::vector<std::string> >(_requires);
 	if (node["sprite"])

--- a/src/Mod/RuleCraftWeapon.cpp
+++ b/src/Mod/RuleCraftWeapon.cpp
@@ -44,6 +44,10 @@ RuleCraftWeapon::~RuleCraftWeapon()
  */
 void RuleCraftWeapon::load(const YAML::Node &node, Mod *mod)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent, mod);
+	}
 	_type = node["type"].as<std::string>(_type);
 	if (node["sprite"])
 	{

--- a/src/Mod/RuleInterface.cpp
+++ b/src/Mod/RuleInterface.cpp
@@ -42,6 +42,10 @@ RuleInterface::~RuleInterface()
  */
 void RuleInterface::load(const YAML::Node& node)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent);
+	}
 	_palette = node["palette"].as<std::string>(_palette);
 	_parent = node["parent"].as<std::string>(_parent);
 	_music = node["music"].as<std::string>(_music);

--- a/src/Mod/RuleInventory.cpp
+++ b/src/Mod/RuleInventory.cpp
@@ -68,6 +68,10 @@ RuleInventory::~RuleInventory()
  */
 void RuleInventory::load(const YAML::Node &node, int listOrder)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent, listOrder);
+	}
 	_id = node["id"].as<std::string>(_id);
 	_x = node["x"].as<int>(_x);
 	_y = node["y"].as<int>(_y);

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -52,6 +52,10 @@ RuleItem::~RuleItem()
  */
 void RuleItem::load(const YAML::Node &node, Mod *mod, int listOrder)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent, mod, listOrder);
+	}
 	_type = node["type"].as<std::string>(_type);
 	_name = node["name"].as<std::string>(_name);
 	_requires = node["requires"].as< std::vector<std::string> >(_requires);

--- a/src/Mod/RuleManufacture.cpp
+++ b/src/Mod/RuleManufacture.cpp
@@ -36,6 +36,10 @@ RuleManufacture::RuleManufacture(const std::string &name) : _name(name), _space(
  */
 void RuleManufacture::load(const YAML::Node &node, int listOrder)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent, listOrder);
+	}
 	bool same = (1 == _producedItems.size() && _name == _producedItems.begin()->first);
 	_name = node["name"].as<std::string>(_name);
 	if (same)

--- a/src/Mod/RuleMissionScript.cpp
+++ b/src/Mod/RuleMissionScript.cpp
@@ -57,6 +57,10 @@ RuleMissionScript::~RuleMissionScript()
  */
 void RuleMissionScript::load(const YAML::Node& node)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent);
+	}
 	_varName = node["varName"].as<std::string>(_varName);
 	_firstMonth = node["firstMonth"].as<int>(_firstMonth);
 	_lastMonth = node["lastMonth"].as<int>(_lastMonth);

--- a/src/Mod/RuleRegion.cpp
+++ b/src/Mod/RuleRegion.cpp
@@ -52,6 +52,10 @@ RuleRegion::~RuleRegion()
  */
 void RuleRegion::load(const YAML::Node &node)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent);
+	}
 	_type = node["type"].as<std::string>(_type);
 	_cost = node["cost"].as<int>(_cost);
 	std::vector< std::vector<double> > areas;

--- a/src/Mod/RuleResearch.cpp
+++ b/src/Mod/RuleResearch.cpp
@@ -32,6 +32,10 @@ RuleResearch::RuleResearch(const std::string & name) : _name(name), _cost(0), _p
  */
 void RuleResearch::load(const YAML::Node &node, int listOrder)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent, listOrder);
+	}
 	_name = node["name"].as<std::string>(_name);
 	_lookup = node["lookup"].as<std::string>(_lookup);
 	_cutscene = node["cutscene"].as<std::string>(_cutscene);

--- a/src/Mod/RuleSoldier.cpp
+++ b/src/Mod/RuleSoldier.cpp
@@ -51,6 +51,10 @@ RuleSoldier::~RuleSoldier()
  */
 void RuleSoldier::load(const YAML::Node &node, Mod *mod)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent, mod);
+	}
 	_type = node["type"].as<std::string>(_type);
 	// Just in case
 	if (_type == "XCOM")

--- a/src/Mod/RuleTerrain.cpp
+++ b/src/Mod/RuleTerrain.cpp
@@ -51,6 +51,10 @@ RuleTerrain::~RuleTerrain()
  */
 void RuleTerrain::load(const YAML::Node &node, Mod *mod)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent, mod);
+	}
 	if (const YAML::Node &map = node["mapDataSets"])
 	{
 		_mapDataSets.clear();

--- a/src/Mod/RuleUfo.cpp
+++ b/src/Mod/RuleUfo.cpp
@@ -46,6 +46,10 @@ RuleUfo::~RuleUfo()
  */
 void RuleUfo::load(const YAML::Node &node, Mod *mod)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent, mod);
+	}
 	_type = node["type"].as<std::string>(_type);
 	_size = node["size"].as<std::string>(_size);
 	_sprite = node["sprite"].as<int>(_sprite);

--- a/src/Mod/UfoTrajectory.cpp
+++ b/src/Mod/UfoTrajectory.cpp
@@ -71,6 +71,10 @@ UfoTrajectory::UfoTrajectory(const std::string &id) : _id(id), _groundTimer(5)
  */
 void UfoTrajectory::load(const YAML::Node &node)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent);
+	}
 	_id = node["id"].as<std::string>(_id);
 	_groundTimer = node["groundTimer"].as<size_t>(_groundTimer);
 	_waypoints = node["waypoints"].as< std::vector<TrajectoryWaypoint> >(_waypoints);

--- a/src/Mod/Unit.cpp
+++ b/src/Mod/Unit.cpp
@@ -46,6 +46,10 @@ Unit::~Unit()
  */
 void Unit::load(const YAML::Node &node, Mod *mod)
 {
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent, mod);
+	}
 	_type = node["type"].as<std::string>(_type);
 	_race = node["race"].as<std::string>(_race);
 	_rank = node["rank"].as<std::string>(_rank);


### PR DESCRIPTION
Option for modders to share lot of values between nodes in yaml.
This is work around of lack support of "<<" in yaml-cpp (http://yaml.org/type/merge.html).

This will allow that some nodes could have common values that are same for each node.

``` yaml
items:
  - &refA
    type: TEST_A
    transferTime: 100
    clipSize: 5
  - nodeRef: *refA
    type: TEST_B
  - nodeRef: *refA
    type: TEST_C
  - nodeRef: *refA
    type: TEST_D
```

Now all items have same `transferTime` and `clipSize`.
