### PR TITLE
Diary psi-related bugs

### DIFF
--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -639,7 +639,7 @@ void BattlescapeGame::checkForCasualties(BattleItem *murderweapon, BattleUnit *m
 				// This must be a mind controlled unit. Find out who mind controlled him and award the kill to that unit.
 				for (std::vector<BattleUnit*>::iterator i = _save->getUnits()->begin(); i != _save->getUnits()->end(); ++i)
 				{
-					if ((*i)->getId() == murderer->getMurdererId() && (*i)->getGeoscapeSoldier())
+					if ((*i)->getId() == murderer->getMindControllerId() && (*i)->getGeoscapeSoldier())
 					{
 						(*i)->getStatistics()->kills.push_back(new BattleUnitKills(killStat));
 						if (victim->getFaction() == FACTION_HOSTILE)

--- a/src/Battlescape/PsiAttackBState.cpp
+++ b/src/Battlescape/PsiAttackBState.cpp
@@ -169,7 +169,7 @@ void PsiAttackBState::psiAttack()
 			{
 				killStat.status = STATUS_PANICKING;
 				_unit->getStatistics()->kills.push_back(new BattleUnitKills(killStat));
-				_target->setMurdererId(_unit->getId());
+				_target->setMindControllerId(_unit->getId());
 			}
 			if (_parent->getSave()->getSide() == FACTION_PLAYER)
 			{
@@ -183,7 +183,7 @@ void PsiAttackBState::psiAttack()
 			{
 				killStat.status = STATUS_TURNING;
 				_unit->getStatistics()->kills.push_back(new BattleUnitKills(killStat));
-				_target->setMurdererId(_unit->getId());
+				_target->setMindControllerId(_unit->getId());
 			}
 			_target->convertToFaction(_unit->getFaction());
 			_parent->getTileEngine()->calculateFOV(_target->getPosition());

--- a/src/Battlescape/PsiAttackBState.cpp
+++ b/src/Battlescape/PsiAttackBState.cpp
@@ -164,12 +164,12 @@ void PsiAttackBState::psiAttack()
 			int moraleLoss = (110-_target->getBaseStats()->bravery);
 			if (moraleLoss > 0)
 			_target->moraleChange(-moraleLoss);
+			_target->setMindControllerId(_unit->getId());
 			// Award Panic battle unit kill
 			if (!_unit->getStatistics()->duplicateEntry(STATUS_PANICKING, _target->getId()))
 			{
 				killStat.status = STATUS_PANICKING;
-				_unit->getStatistics()->kills.push_back(new BattleUnitKills(killStat));
-				_target->setMindControllerId(_unit->getId());
+				_unit->getStatistics()->kills.push_back(new BattleUnitKills(killStat));				
 			}
 			if (_parent->getSave()->getSide() == FACTION_PLAYER)
 			{
@@ -182,9 +182,9 @@ void PsiAttackBState::psiAttack()
 			if (!_unit->getStatistics()->duplicateEntry(STATUS_TURNING, _target->getId()))
 			{
 				killStat.status = STATUS_TURNING;
-				_unit->getStatistics()->kills.push_back(new BattleUnitKills(killStat));
-				_target->setMindControllerId(_unit->getId());
+				_unit->getStatistics()->kills.push_back(new BattleUnitKills(killStat));				
 			}
+			_target->setMindControllerId(_unit->getId());
 			_target->convertToFaction(_unit->getFaction());
 			_parent->getTileEngine()->calculateFOV(_target->getPosition());
 			_parent->getTileEngine()->calculateUnitLighting();

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -55,7 +55,7 @@ BattleUnit::BattleUnit(Soldier *soldier, int depth) :
 	_expBravery(0), _expReactions(0), _expFiring(0), _expThrowing(0), _expPsiSkill(0), _expPsiStrength(0), _expMelee(0),
 	_motionPoints(0), _kills(0), _hitByFire(false), _moraleRestored(0), _coverReserve(0), _charging(0), _turnsSinceSpotted(255),
 	_statistics(), _murdererId(0), _fatalShotSide(SIDE_FRONT), _fatalShotBodyPart(BODYPART_HEAD),
-	_geoscapeSoldier(soldier), _unitRules(0), _rankInt(0), _turretType(-1), _hidingForTurn(false), _respawn(false)
+	_geoscapeSoldier(soldier), _unitRules(0), _rankInt(0), _turretType(-1), _hidingForTurn(false), _respawn(false), _mindControllerID(0)
 {
 	_name = soldier->getName(true);
 	_id = soldier->getId();
@@ -169,7 +169,7 @@ BattleUnit::BattleUnit(Unit *unit, UnitFaction faction, int id, Armor *armor, St
 	_moraleRestored(0), _coverReserve(0), _charging(0), _turnsSinceSpotted(255),
 	_statistics(), _murdererId(0), _fatalShotSide(SIDE_FRONT), _fatalShotBodyPart(BODYPART_HEAD),
 	_armor(armor), _geoscapeSoldier(0),  _unitRules(unit), _rankInt(0),
-	_turretType(-1), _hidingForTurn(false), _respawn(false)
+	_turretType(-1), _hidingForTurn(false), _respawn(false), _mindControllerID(0)
 {
 	_type = unit->getType();
 	_rank = unit->getRank();
@@ -371,6 +371,7 @@ void BattleUnit::load(const YAML::Node &node)
 			_recolor.push_back(std::make_pair(p[i][0].as<int>(), p[i][1].as<int>()));
 		}
 	}
+	_mindControllerID = node["mincControllerID"].as<int>(_mindControllerID);
 }
 
 /**
@@ -441,6 +442,7 @@ YAML::Node BattleUnit::save() const
 		p.push_back((int)_recolor[i].second);
 		node["recolor"].push_back(p);
 	}
+	node["mindControllerID"] = _mindControllerID;
 
 	return node;
 }
@@ -3219,6 +3221,24 @@ std::string BattleUnit::getMurdererWeaponAmmo() const
 void BattleUnit::setMurdererWeaponAmmo(std::string weaponAmmo)
 {
     _murdererWeaponAmmo = weaponAmmo;
+}
+
+/**
+ * Sets the unit mind controller's id.
+ * @param int mind controller id.
+ */
+void BattleUnit::setMindControllerId(int id)
+{
+	_mindControllerID = id;
+}
+
+/**
+ * Gets the unit mind controller's id.
+ * @return int mind controller id.
+ */
+int BattleUnit::getMindControllerId() const
+{
+	return _mindControllerID;
 }
 
 }

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -101,6 +101,7 @@ private:
 	std::string _activeHand;
 	BattleUnitStatistics* _statistics;
 	int _murdererId;	// used to credit the murderer with the kills that this unit got by blowing up on death
+	int _mindControllerID;	// used to credit the mind controller with the kills of the mind controllee
 	UnitSide _fatalShotSide;
 	UnitBodyPart _fatalShotBodyPart;
 	std::string _murdererWeapon, _murdererWeaponAmmo;
@@ -486,10 +487,15 @@ public:
     std::string getMurdererWeapon() const;
     /// Set the unit murderer's weapon.
     void setMurdererWeapon(std::string weapon);
-       /// Get the unit murderer's weapon's ammo.
+    /// Get the unit murderer's weapon's ammo.
     std::string getMurdererWeaponAmmo() const;
     /// Set the unit murderer's weapon's ammo.
-    void setMurdererWeaponAmmo(std::string weaponAmmo);   
+    void setMurdererWeaponAmmo(std::string weaponAmmo);
+    /// Set the unit mind controller's id.
+	void setMindControllerId(int id);
+	/// Get the unit mind controller's id.
+	int getMindControllerId() const;
+    
 };
 
 }


### PR DESCRIPTION
Forum user Countdown3 pointed these out to me.

The first commit uses a new var, _mindControllerID, to remember who last used a psi attack on a unit. Before hand, _murdererId was used, but of course this could be overridden if, for example, a mind controlled unit was shot. 

The second commit removes the setting of _mindControllerID from an if loop that ensured that duplicate entries were not added to a diary. The fact that a unit is psi attacking another unit should be remembered regardless of the number of the attack was done. This is important when multiple units are all psi attacking the same other unit.