### PR TITLE
Track which race attacks you in a base defense

### DIFF
--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -729,7 +729,7 @@ void DebriefingState::prepareDebriefing()
 			// Loop through the UFOs and see which one is sitting on top of the base... that is probably the one attacking you.
 			for (std::vector<Ufo*>::iterator k = save->getUfos()->begin(); k != save->getUfos()->end(); ++k)
 			{
-				if ((*k)->getLongitude() == base->getLongitude() && (*k)->getLatitude() == base->getLatitude())
+				if (AreSame((*k)->getLongitude(), base->getLongitude()) && AreSame((*k)->getLatitude(), base->getLatitude()))
 				{
 					_missionStatistics->ufo = (*k)->getRules()->getType();
 					_missionStatistics->alienRace = (*k)->getAlienRace();

--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -726,6 +726,16 @@ void DebriefingState::prepareDebriefing()
 					break;
 				}
 			}
+			// Loop through the UFOs and see which one is sitting on top of the base... that is probably the one attacking you.
+			for (std::vector<Ufo*>::iterator k = save->getUfos()->begin(); k != save->getUfos()->end(); ++k)
+			{
+				if ((*k)->getLongitude() == base->getLongitude() && (*k)->getLatitude() == base->getLatitude())
+				{
+					_missionStatistics->ufo = (*k)->getRules()->getType();
+					_missionStatistics->alienRace = (*k)->getAlienRace();
+					break;
+				}
+			}
 			if (aborted)
 			{
 				_destroyBase = true;


### PR DESCRIPTION
Before, the diary mission state would not list what UFO or race attacked the player in a base defence mission. This fixes that! Probably. I suppose if there are two UFOs who are directly over the player's base then only the first one will be considered the attacker... but, what are the odds of that happening??