### PR TITLE
Fix #1217

### DIFF
--- a/src/Battlescape/UnitDieBState.cpp
+++ b/src/Battlescape/UnitDieBState.cpp
@@ -317,21 +317,19 @@ void UnitDieBState::convertUnitToCorpse()
 	}
 	else
 	{
-		// Convert backwards (last to first tile) to ensure resulting corpse gets
-		// assigned correct location (when size > 1).
-		int i = size*size;
+		// Reverse iteration to ensure resulting corpse is assigned correct position.
 		for (int y = size - 1; y >= 0; y--)
 		{
 			for (int x = size - 1; x >= 0; x--)
 			{
-				BattleItem *corpse = new BattleItem(_parent->getMod()->getItem(_unit->getArmor()->getCorpseBattlescape()[i]), _parent->getSave()->getCurrentItemId());
+				int idx = size * y + x;
+				BattleItem *corpse = new BattleItem(_parent->getMod()->getItem(_unit->getArmor()->getCorpseBattlescape()[idx]), _parent->getSave()->getCurrentItemId());
 				corpse->setUnit(_unit);
 				if (_parent->getSave()->getTile(lastPosition + Position(x,y,0))->getUnit() == _unit) // check in case unit was displaced by another unit
 				{
 					_parent->getSave()->getTile(lastPosition + Position(x,y,0))->setUnit(0);
 				}
 				_parent->dropItem(lastPosition + Position(x,y,0), corpse, true);
-				i--;
 			}
 		}
 	}

--- a/src/Battlescape/UnitDieBState.cpp
+++ b/src/Battlescape/UnitDieBState.cpp
@@ -332,6 +332,7 @@ void UnitDieBState::convertUnitToCorpse()
 				i++;
 			}
 		}
+		_unit->setPosition(lastPosition); // Position of corpse should equal position of unit.
 	}
 }
 

--- a/src/Battlescape/UnitDieBState.cpp
+++ b/src/Battlescape/UnitDieBState.cpp
@@ -317,10 +317,12 @@ void UnitDieBState::convertUnitToCorpse()
 	}
 	else
 	{
-		int i = 0;
-		for (int y = 0; y < size; y++)
+		// Convert backwards (last to first tile) to ensure resulting corpse gets
+		// assigned correct location (when size > 1).
+		int i = size*size;
+		for (int y = size - 1; y >= 0; y--)
 		{
-			for (int x = 0; x < size; x++)
+			for (int x = size - 1; x >= 0; x--)
 			{
 				BattleItem *corpse = new BattleItem(_parent->getMod()->getItem(_unit->getArmor()->getCorpseBattlescape()[i]), _parent->getSave()->getCurrentItemId());
 				corpse->setUnit(_unit);
@@ -329,10 +331,9 @@ void UnitDieBState::convertUnitToCorpse()
 					_parent->getSave()->getTile(lastPosition + Position(x,y,0))->setUnit(0);
 				}
 				_parent->dropItem(lastPosition + Position(x,y,0), corpse, true);
-				i++;
+				i--;
 			}
 		}
-		_unit->setPosition(lastPosition); // Position of corpse should equal position of unit.
 	}
 }
 


### PR DESCRIPTION
Make sure position of a corpse equals last position of original unit.

`dropItem()` updates `lastPosition` of `_unit`. This causes an offset of 1 on both the x and y values for 2x2 sized vehicles.

With thanks to _hellrazor_ for testing multiple cases.