### PR TITLE
CTRL+G not properly taken into account when used from the Options Video State.

### DIFF
--- a/src/Engine/Game.cpp
+++ b/src/Engine/Game.cpp
@@ -231,7 +231,6 @@ void Game::run()
 					_screen->handle(&action);
 					_cursor->handle(&action);
 					_fpsCounter->handle(&action);
-					_states.back()->handle(&action);
 					if (action.getDetails()->type == SDL_KEYDOWN)
 					{
 						// "ctrl-g" grab input
@@ -254,6 +253,7 @@ void Game::run()
 							}
 						}
 					}
+					_states.back()->handle(&action);
 					break;
 			}
 		}


### PR DESCRIPTION
Moving a line downward because CTRL+G is not properly taken into account when used from the Options Video State.
`_states.back()->handle(&action);` has to be called after the "ctrl-g" key is processed.
Note: not sure how is handled `Options::debug`.