### PR TITLE
Fix out-of-bounds access in `instruments' array

### DIFF
--- a/src/Engine/Adlib/adlplayer.cpp
+++ b/src/Engine/Adlib/adlplayer.cpp
@@ -730,7 +730,7 @@ void init_music_data(unsigned char* music_ptr,int length)
 		if (adl_gv_FORMAT==1) 
 		{
 			j = *(music_ptr+4);
-			if (j>16) j=16;
+			if (j>15) j=15;
 			instruments[j].start_address = music_ptr+5;
 		}
 		else


### PR DESCRIPTION
There are only 16 elements, so index 16 is out-of-bounds