### PR TITLE
Rollback OptionsBaseState.cpp file.

### DIFF
--- a/src/Menu/OptionsBaseState.cpp
+++ b/src/Menu/OptionsBaseState.cpp
@@ -219,12 +219,7 @@ void OptionsBaseState::btnOkClick(Action *)
 			Options::useOpenGL != Options::newOpenGL ||
 			Options::useScaleFilter != Options::newScaleFilter ||
 			Options::useHQXFilter != Options::newHQXFilter ||
-			Options::useOpenGLShader != Options::newOpenGLShader ||
-			(!Options::fullscreen && !Options::allowResize && Options::rootWindowedMode
-				&& (Options::newFullscreen || Options::newAllowResize ||
-					!Options::newRootWindowedMode ||
-					Options::windowedModePositionX != Options::newWindowedModePositionX ||
-					Options::windowedModePositionY != Options::newWindowedModePositionY)))
+			Options::useOpenGLShader != Options::newOpenGLShader)
 		{
 			_game->pushState(new OptionsConfirmState(_origin));
 		}


### PR DESCRIPTION
As the window cannot be moved if resolution is not changed, additional confirmation conditions are not appropriate, so it's better to remove them.