### PR TITLE
Don't reset _configFolder if it isn't necessary

### DIFF
--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -759,7 +759,11 @@ void setFolders()
 	if (_userFolder.empty())
 	{
 		std::vector<std::string> user = CrossPlatform::findUserFolders();
-		_configFolder = CrossPlatform::findConfigFolder();
+
+		if (_configFolder.empty())
+		{
+			_configFolder = CrossPlatform::findConfigFolder();
+		}
 
 		// Look for an existing user folder
 		for (std::vector<std::string>::reverse_iterator i = user.rbegin(); i != user.rend(); ++i)


### PR DESCRIPTION
On Linux the -config/-cfg argument is ignored if the -user argument isn't used at the same time.

This fixes the problem.