### PR TITLE
Check for upper tile's existence

### DIFF
--- a/src/Battlescape/Pathfinding.cpp
+++ b/src/Battlescape/Pathfinding.cpp
@@ -299,7 +299,7 @@ int Pathfinding::getTUCost(const Position &startPosition, int direction, Positio
 			Position verticalOffset (0, 0, 0);
 
 			// if we are on a stairs try to go up a level
-			if (direction < DIR_UP && startTile->getTerrainLevel() <= -16 && !aboveDestination->hasNoFloor(destinationTile) && !triedStairs)
+			if (direction < DIR_UP && startTile->getTerrainLevel() <= -16 && aboveDestination &&!aboveDestination->hasNoFloor(destinationTile) && !triedStairs)
 			{
 					numberOfPartsGoingUp++;
 


### PR DESCRIPTION
In Pathfinding.cpp, the aboveDestination pointer is not checked before being used. Judging by the surrounding code, this is probably an oversight more than anything else (belowDestination pointer is actually checked).
