### PR TITLE
Fix invalid _targetVoxel when LOF is blocked

### DIFF
--- a/src/Battlescape/ProjectileFlyBState.cpp
+++ b/src/Battlescape/ProjectileFlyBState.cpp
@@ -229,7 +229,8 @@ void ProjectileFlyBState::init()
 			{
 				if (!_parent->getTileEngine()->canTargetUnit(&originVoxel, targetTile, &_targetVoxel, _unit))
 				{
-					_targetVoxel = Position(-16,-16,-24); // out of bounds, even after voxel to tile calculation.
+					// target nothing, targets the middle of the tile
+					_targetVoxel = Position(_action.target.x*16 + 8, _action.target.y*16 + 8, _action.target.z*24 + 12);
 				}
 			}
 		}


### PR DESCRIPTION
Given the following situation:

	 012345678
	0   ____
	1  |    |
	2  |    |B
	3  |____|
	4      A

A takes an autoshot at B, which is visible, but LOF is blocked by a
wall to the north.

The first shot removes the northern wall at (6, 4):

	012345678
	1  ____
	2 |    |
	3 |    |B
	4 |___ |
	5     A

However, the second and third shots fly NW, perpendicular to the path to
B, removing the walls at (2, 2) and (3, 1)!

	012345678
	1   ___
	2      |
	3 |    |B
	4 |___ |
	5     A

In fact, the projectiles are flying towards (-16, -16, -24) due to
commit 62ec237f08530295a419e67a5a6b4336abc0df04.

This patch fixes this behavior by aiming at the middle of the target
tile in this case.