### PR TITLE
Fix a leak of BattleUnitKills if the debrief is not shown

### DIFF
--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -296,12 +296,9 @@ BattleUnit::~BattleUnit()
 {
 	for (int i = 0; i < 5; ++i)
 		if (_cache[i]) delete _cache[i];
-	if (!getGeoscapeSoldier())
+	for (std::vector<BattleUnitKills*>::const_iterator i = _statistics->kills.begin(); i != _statistics->kills.end(); ++i)
 	{
-		for (std::vector<BattleUnitKills*>::const_iterator i = _statistics->kills.begin(); i != _statistics->kills.end(); ++i)
-		{
-			delete *i;
-		}
+		delete *i;
 	}
 	delete _statistics;
 	delete _currentAIState;

--- a/src/Savegame/SoldierDiary.cpp
+++ b/src/Savegame/SoldierDiary.cpp
@@ -166,12 +166,13 @@ void SoldierDiary::updateDiary(BattleUnitStatistics *unitStatistics, std::vector
 {
 	if (allMissionStatistics->empty()) return;
 	MissionStatistics* missionStatistics = allMissionStatistics->back();
-	std::vector<BattleUnitKills*> unitKills = unitStatistics->kills;
+	std::vector<BattleUnitKills*> &unitKills = unitStatistics->kills;
 	for (std::vector<BattleUnitKills*>::const_iterator kill = unitKills.begin() ; kill != unitKills.end() ; ++kill)
 	{
 		(*kill)->makeTurnUnique();
 		_killList.push_back(*kill);
 	}
+	unitKills.clear();
 	if (missionStatistics->success)
 	{
 		if (unitStatistics->loneSurvivor)


### PR DESCRIPTION
The destructor for a BattleUnit doesn't delete the BattleUnitKills if
there is a valid Soldier* for the unit, on the assumption that the
object will pass ownership to the SoldierDiary, but that ownership move
only occurs on the DebriefingState, so if you happen to leave a battle
in a way that doesn't show that it will leak (e.g. 'Abandon Game')

This changes the BattleUnit destructor to unconditionally destroy any
remaining BattleUnitKills objects, and the SoliderDiary::updateDiary()
function to empty the BattleUnit's list when it takes ownership.