### PR TITLE
Use C++ limits, instead of rolling our own.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Data folders:
 - /Users/Shared/OpenXcom
 - . (the current directory)
 
-### Linux
+### Linux / \*BSD
 
 User folder:
 - $XDG\_DATA\_HOME/openxcom (if $XDG\_DATA\_HOME is defined)
@@ -137,6 +137,7 @@ Data folders:
 - $HOME/.local/share/openxcom (if $XDG\_DATA\_HOME is not defined)
 - $XDG\_DATA\_DIRS/openxcom (for each directory in $XDG\_DATA\_DIRS if $XDG\_DATA\_DIRS is defined)
 - /usr/local/share/openxcom
+- /usr/share/openxcom
 - . (the current directory)
 
 ## Configuration

--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -134,13 +134,11 @@ void showError(const std::string &error)
 static char const *getHome()
 {
 	char const *home = getenv("HOME");
-#ifndef _WIN32
 	if (!home)
 	{
 		struct passwd *const pwd = getpwuid(getuid());
 		home = pwd->pw_dir;
 	}
-#endif
 	return home;
 }
 #endif
@@ -220,16 +218,13 @@ std::vector<std::string> findDataFolders()
 	list.push_back("/Users/Shared/OpenXcom/");
 #else
 	list.push_back("/usr/local/share/openxcom/");
-#ifndef __FreeBSD__
 	list.push_back("/usr/share/openxcom/");
-#endif
 #ifdef DATADIR
 	snprintf(path, MAXPATHLEN, "%s/", DATADIR);
 	list.push_back(path);
 #endif
 
 #endif
-	
 	// Get working directory
 	list.push_back("./");
 #endif
@@ -251,7 +246,6 @@ std::vector<std::string> findUserFolders()
 	return list;
 #endif
 
-	
 #ifdef _WIN32
 	char path[MAX_PATH];
 

--- a/src/Engine/RNG.cpp
+++ b/src/Engine/RNG.cpp
@@ -18,11 +18,9 @@
  */
 #include "RNG.h"
 #include <cmath>
+#include <limits>
 #include <time.h>
 #include <stdlib.h>
-#ifndef UINT64_MAX
-#define UINT64_MAX 0xffffffffffffffffULL
-#endif
 
 namespace OpenXcom
 {
@@ -78,7 +76,7 @@ void setSeed(uint64_t n)
 int generate(int min, int max)
 {
 	uint64_t num = next();
-	return (int)(num % (max - min + 1) + min);
+	return num % (max - min + 1) + min;
 }
 
 /**
@@ -90,7 +88,8 @@ int generate(int min, int max)
 double generate(double min, double max)
 {
 	double num = next();
-	return (num / ((double)UINT64_MAX / (max - min)) + min);
+	double int_max = (double)std::numeric_limits<uint64_t>::max();
+	return num / (int_max / (max - min)) + min;
 }
 
 /**
@@ -102,7 +101,7 @@ double generate(double min, double max)
  */
 int seedless(int min, int max)
 {
-	return (rand() % (max - min + 1) + min);
+	return rand() % (max - min + 1) + min;
 }
 
 
@@ -138,7 +137,7 @@ double boxMuller(double m, double s)
 		use_last = 1;
 	}
 
-	return( m + y1 * s );
+	return m + y1 * s;
 }
 
 /**
@@ -149,7 +148,7 @@ double boxMuller(double m, double s)
  */
 bool percent(int value)
 {
-	return (generate(0, 99) < value);
+	return generate(0, 99) < value;
 }
 
 /**
@@ -160,7 +159,7 @@ bool percent(int value)
 int generateEx(int max)
 {
 	uint64_t num = next();
-	return (int)(num % max);
+	return num % max;
 }
 
 }


### PR DESCRIPTION
While here, remove redundant casts on return types, remove parentheses
around return, as it's not a function call. This makes the overall style
more consistent.

Taken from: FreeBSD ports
Original author: madpilot@FreeBSD.org