### PR TITLE
Remove a FreeBSD specific ifdef and a redundant _WIN32 ifdef

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Data folders:
 - $HOME/.local/share/openxcom (if $XDG\_DATA\_HOME is not defined)
 - $XDG\_DATA\_DIRS/openxcom (for each directory in $XDG\_DATA\_DIRS if $XDG\_DATA\_DIRS is defined)
 - /usr/local/share/openxcom
+- /usr/share/openxcom
 - . (the current directory)
 
 ## Configuration

--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -134,13 +134,11 @@ void showError(const std::string &error)
 static char const *getHome()
 {
 	char const *home = getenv("HOME");
-#ifndef _WIN32
 	if (!home)
 	{
 		struct passwd *const pwd = getpwuid(getuid());
 		home = pwd->pw_dir;
 	}
-#endif
 	return home;
 }
 #endif
@@ -220,16 +218,13 @@ std::vector<std::string> findDataFolders()
 	list.push_back("/Users/Shared/OpenXcom/");
 #else
 	list.push_back("/usr/local/share/openxcom/");
-#ifndef __FreeBSD__
 	list.push_back("/usr/share/openxcom/");
-#endif
 #ifdef DATADIR
 	snprintf(path, MAXPATHLEN, "%s/", DATADIR);
 	list.push_back(path);
 #endif
 
 #endif
-	
 	// Get working directory
 	list.push_back("./");
 #endif
@@ -251,7 +246,6 @@ std::vector<std::string> findUserFolders()
 	return list;
 #endif
 
-	
 #ifdef _WIN32
 	char path[MAX_PATH];
 


### PR DESCRIPTION
It's fine to also check in /usr/share/openxcom under FreeBSD, no need to
special case this. Update the docs to reflect that this is being checked
always (this was an omission from the Linux docs previously.)

Trim some trailing tabs while here.