### PR TITLE
OpenBSD also requires linking with libexecinfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ if ( NOT OPENGL_FOUND )
     "Continuing building without OpenGL support."
     )
   add_definitions(-D__NO_OPENGL)
+else ()
+    include_directories ( ${OPENGL_INCLUDE_DIR} )
 endif ()
 
 # Read version number

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -449,7 +449,7 @@ if ( WIN32 )
 endif ()
 
 # backtrace(3) requires libexecinfo on some *BSD systems
-if (${CMAKE_SYSTEM_NAME} MATCHES FreeBSD OR ${CMAKE_SYSTEM_NAME} MATCHES NetBSD)
+if (${CMAKE_SYSTEM_NAME} MATCHES FreeBSD OR ${CMAKE_SYSTEM_NAME} MATCHES NetBSD OR ${CMAKE_SYSTEM_NAME} MATCHES OpenBSD)
   set ( system_libs -lexecinfo )
 endif ()
 


### PR DESCRIPTION
Hi!
These patches unbreak building latest OpenXcom on OpenBSD.