### PR TITLE
Unified (and fixed) chart labeling algorithm

### DIFF
--- a/src/Geoscape/GraphsState.cpp
+++ b/src/Geoscape/GraphsState.cpp
@@ -699,7 +699,6 @@ void GraphsState::drawCountryLines()
 	double range = upperLimit - lowerLimit;
 	double low = lowerLimit;
 	int grids = 9; // cells in grid
-	if (low<0) grids--;
 	int check = _income ? 50 : 10;
 	while (range > check * grids)
 	{
@@ -870,14 +869,13 @@ void GraphsState::drawRegionLines()
 	double low = lowerLimit;
 	int check = 10;
 	int grids = 9; // cells in grid
-	if (low<0) grids--;
 	while (range > check * grids)
 	{
 		check *= 2;
 	}
 
 	lowerLimit = 0;
-	upperLimit = check * 9;
+	upperLimit = check * grids;
 
 	if (low < 0)
 	{
@@ -1052,14 +1050,13 @@ void GraphsState::drawFinanceLines()
 	double low = lowerLimit;
 	int check = 250;
 	int grids = 9; // cells in grid
-	if (low<0) grids--;
 	while (range > check * grids)
 	{
 		check *= 2;
 	}
 
 	lowerLimit = 0;
-	upperLimit = check * 9;
+	upperLimit = check * grids;
 
 	if (low < 0)
 	{


### PR DESCRIPTION
Country lines were drawn incorrectly.
When there was negative score, the *full* range was compared against only 8/9 of available chart space.

Technical:
1. the "check" is calculated against (0, range)
2. but "range" includes the portion below X axis too, so grids-- is not necessary/is wrong
3. the shift below X axis is done later (correctly)