### PR TITLE
Use the GNUInstallDirs for the .desktop and icons.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,10 +165,14 @@ if ( BUILD_PACKAGE )
 endif()
 
 if ( NOT WIN32 )
-  install(FILES "${CMAKE_SOURCE_DIR}/res/linux/openxcom.desktop"     DESTINATION share/applications)
-  install(FILES "${CMAKE_SOURCE_DIR}/res/linux/icons/openxcom_48x48.png"   DESTINATION share/icons/hicolor/48x48/apps RENAME openxcom.png)
-  install(FILES "${CMAKE_SOURCE_DIR}/res/linux/icons/openxcom_128x128.png"   DESTINATION share/icons/hicolor/128x128/apps RENAME openxcom.png)
-  install(FILES "${CMAKE_SOURCE_DIR}/res/linux/icons/openxcom.svg"   DESTINATION share/icons/hicolor/scalable/apps)
+  install(FILES "${CMAKE_SOURCE_DIR}/res/linux/openxcom.desktop"
+    DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/applications")
+  install(FILES "${CMAKE_SOURCE_DIR}/res/linux/icons/openxcom_48x48.png"
+    DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/icons/hicolor/48x48/apps" RENAME openxcom.png)
+  install(FILES "${CMAKE_SOURCE_DIR}/res/linux/icons/openxcom_128x128.png"
+    DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/icons/hicolor/128x128/apps" RENAME openxcom.png)
+  install(FILES "${CMAKE_SOURCE_DIR}/res/linux/icons/openxcom.svg"
+    DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/icons/hicolor/scalable/apps")
 endif ()
 
 add_subdirectory ( docs )


### PR DESCRIPTION
Should be no functional change for people who dont have exotic
filesystem layouts but offer flexibility to those who do.