### PR TITLE
Save options.cfg ordered and with empty line at EOF

### DIFF
--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -931,6 +931,52 @@ void load(const std::string &filename)
 	}
 }
 
+void writeNode(const YAML::Node& node, YAML::Emitter& emitter)
+{
+	switch (node.Type())
+	{
+		case YAML::NodeType::Sequence:
+		{
+			emitter << YAML::BeginSeq;
+			for (size_t i = 0; i < node.size(); i++)
+			{
+				writeNode(node[i], emitter);
+			}
+			emitter << YAML::EndSeq;
+			break;
+		}
+		case YAML::NodeType::Map:
+		{
+			emitter << YAML::BeginMap;
+
+			// First collect all the keys
+			std::vector<std::string> keys(node.size());
+			int key_it = 0;
+			for (YAML::const_iterator it = node.begin(); it != node.end(); ++it)
+			{
+				keys[key_it++] = it->first.as<std::string>();
+			}
+
+			// Then sort them
+			std::sort(keys.begin(), keys.end());
+
+			// Then emit all the entries in sorted order.
+			for(size_t i = 0; i < keys.size(); i++)
+			{
+				emitter << YAML::Key;
+				emitter << keys[i];
+				emitter << YAML::Value;
+				writeNode(node[keys[i]], emitter);
+			}
+			emitter << YAML::EndMap;
+			break;
+		}
+		default:
+			emitter << node;
+			break;
+	}
+}
+
 /**
  * Saves options to a YAML file.
  * @param filename YAML filename.
@@ -963,7 +1009,7 @@ void save(const std::string &filename)
 			doc["mods"].push_back(mod);
 		}
 
-		out << doc;
+		writeNode(doc, out);
 
 		sav << out.c_str() << std::endl;
 	}

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -965,7 +965,7 @@ void save(const std::string &filename)
 
 		out << doc;
 
-		sav << out.c_str();
+		sav << out.c_str() << std::endl;
 	}
 	catch (YAML::Exception &e)
 	{


### PR DESCRIPTION
This makes the file much easier to compare between changes, and also makes it easier to version control.

Based on (OK, completely ripped off) [code by @hersh](https://github.com/jbeder/yaml-cpp/issues/169#issuecomment-219763811).