### PR TITLE
Displaying shotgun pellets also in ammo articles

### DIFF
--- a/src/Ufopaedia/ArticleStateItem.cpp
+++ b/src/Ufopaedia/ArticleStateItem.cpp
@@ -245,6 +245,10 @@ namespace OpenXcom
 
 				ss.str(L"");ss.clear();
 				ss << item->getPower();
+				if (item->getShotgunPellets())
+				{
+					ss << L"x" << item->getShotgunPellets();
+				}
 				_txtAmmoDamage[0]->setText(ss.str());
 				break;
 			default: break;


### PR DESCRIPTION
Separate pedia articles with ammo info only didn't show number of pellets next to damage info.