### PR TITLE
Vs2017 compile

### DIFF
--- a/src/Engine/FlcPlayer.cpp
+++ b/src/Engine/FlcPlayer.cpp
@@ -21,7 +21,9 @@
  * Based on http://www.libsdl.org/projects/flxplay/
  */
 #ifdef _MSC_VER
+#ifndef _SCL_SECURE_NO_WARNINGS
 #define _SCL_SECURE_NO_WARNINGS
+#endif
 #endif
 #include "FlcPlayer.h"
 #include <algorithm>

--- a/src/OpenXcom.2010.vcxproj
+++ b/src/OpenXcom.2010.vcxproj
@@ -108,6 +108,7 @@
       <TargetMachine>MachineX86</TargetMachine>
       <GenerateMapFile>false</GenerateMapFile>
       <MapExports>false</MapExports>
+      <IgnoreSpecificDefaultLibraries>MSVCRT</IgnoreSpecificDefaultLibraries>
     </Link>
     <PostBuildEvent>
       <Command>copy /y "$(ProjectDir)..\deps\lib\$(Platform)\*.dll" "$(ProjectDir)..\bin\$(Platform)\"</Command>
@@ -155,7 +156,7 @@
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level1</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <IntrinsicFunctions>true</IntrinsicFunctions>

--- a/src/pch.h
+++ b/src/pch.h
@@ -7,7 +7,9 @@
 
 // c++ headers
 #ifdef _MSC_VER
+#ifndef _SCL_SECURE_NO_WARNINGS
 #define _SCL_SECURE_NO_WARNINGS
+#endif
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 #define _USE_MATH_DEFINES


### PR DESCRIPTION
Used these precompiled dependancies:
  https://openxcom.org/forum/index.php/topic,3937.msg80377.html#msg80377

Had some warnings that I have now fixed.

Release compile now also have level 1 warnings (same as debug already had) now we don't have thousands of warnings.

Also we should have a link on this page to the precompiled dependancies:
http://ufopaedia.org/index.php/Compiling_with_Microsoft_Visual_C%2B%2B_(OpenXcom)