### PR TITLE
Add Reworked Research Functions

### DIFF
--- a/src/Battlescape/Pathfinding.h
+++ b/src/Battlescape/Pathfinding.h
@@ -83,6 +83,8 @@ public:
 	int getStartDirection() const;
 	/// Dequeues a direction.
 	int dequeuePath();
+	/// Increase TU cost to move from 1 tile to other specifically for walls/doors.
+	void incDoorWallCost(Tile *tile, int part, int *wallcost, int *doorcost, int direction);
 	/// Gets the TU cost to move from 1 tile to the other.
 	int getTUCost(Position startPosition, int direction, Position *endPosition, BattleUnit *unit, BattleUnit *target, bool missile);
 	/// Aborts the current path.

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -1939,46 +1939,43 @@ int TileEngine::unitOpensDoor(BattleUnit *unit, bool rClick, int dir)
 			{
 			case 0: // north
 				checkPositions.push_back(std::make_pair(Position(0, 0, 0), O_NORTHWALL)); // origin
-				if (x != 0)
-				{
-					checkPositions.push_back(std::make_pair(Position(0, -1, 0), O_WESTWALL)); // one tile north
-				}
-				break;
-			case 1: // north east
-				checkPositions.push_back(std::make_pair(Position(0, 0, 0), O_NORTHWALL)); // origin
-				checkPositions.push_back(std::make_pair(Position(1, -1, 0), O_WESTWALL)); // one tile north-east
-				if (rClick)
-				{
-					checkPositions.push_back(std::make_pair(Position(1, 0, 0), O_WESTWALL)); // one tile east
-					checkPositions.push_back(std::make_pair(Position(1, 0, 0), O_NORTHWALL)); // one tile east
-				}
-				break;
-			case 2: // east
-				checkPositions.push_back(std::make_pair(Position(1, 0, 0), O_WESTWALL)); // one tile east
-				break;
-			case 3: // south-east
-				if (!y)
-					checkPositions.push_back(std::make_pair(Position(1, 1, 0), O_WESTWALL)); // one tile south-east
-				if (!x)
-					checkPositions.push_back(std::make_pair(Position(1, 1, 0), O_NORTHWALL)); // one tile south-east
-				if (rClick)
-				{
-					checkPositions.push_back(std::make_pair(Position(1, 0, 0), O_WESTWALL)); // one tile east
-					checkPositions.push_back(std::make_pair(Position(0, 1, 0), O_NORTHWALL)); // one tile south
-				}
-				break;
-			case 4: // south
-				checkPositions.push_back(std::make_pair(Position(0, 1, 0), O_NORTHWALL)); // one tile south
-				break;
-			case 5: // south-west
-				checkPositions.push_back(std::make_pair(Position(0, 0, 0), O_WESTWALL)); // origin
-				checkPositions.push_back(std::make_pair(Position(-1, 1, 0), O_NORTHWALL)); // one tile south-west
-				if (rClick)
-				{
-					checkPositions.push_back(std::make_pair(Position(0, 1, 0), O_WESTWALL)); // one tile south
-					checkPositions.push_back(std::make_pair(Position(0, 1, 0), O_NORTHWALL)); // one tile south
-				}
-				break;
+                if (x != 0) //bigunit walks through parallel door
+                {
+                    checkPositions.push_back(std::make_pair(Position(0, -1, 0), O_WESTWALL)); // one tile north
+                }
+                break;
+            case 1: // north east
+                checkPositions.push_back(std::make_pair(Position(0, 0, 0), O_NORTHWALL)); // origin
+                checkPositions.push_back(std::make_pair(Position(1, 0, 0), O_WESTWALL)); // one tile east
+                checkPositions.push_back(std::make_pair(Position(1, -1, 0), O_WESTWALL)); // one tile north-east
+                checkPositions.push_back(std::make_pair(Position(1, 0, 0), O_NORTHWALL)); // one tile east
+                break;
+            case 2: // east
+                checkPositions.push_back(std::make_pair(Position(1, 0, 0), O_WESTWALL)); // one tile east
+                if (y != 0)
+                {
+                    checkPositions.push_back(std::make_pair(Position(1, 0, 0), O_NORTHWALL)); // one tile east
+                }
+                break;
+            case 3: // south-east
+                checkPositions.push_back(std::make_pair(Position(1, 0, 0), O_WESTWALL)); // one tile east
+                checkPositions.push_back(std::make_pair(Position(0, 1, 0), O_NORTHWALL)); // one tile south
+                checkPositions.push_back(std::make_pair(Position(1, 1, 0), O_NORTHWALL)); // one tile south-east
+                checkPositions.push_back(std::make_pair(Position(1, 1, 0), O_WESTWALL)); // one tile south-east
+                break;
+            case 4: // south
+                checkPositions.push_back(std::make_pair(Position(0, 1, 0), O_NORTHWALL)); // one tile south
+                if (x != 0)
+                {
+                    checkPositions.push_back(std::make_pair(Position(0, 1, 0), O_WESTWALL)); // one tile south
+                }
+                break;
+            case 5: // south-west
+                checkPositions.push_back(std::make_pair(Position(0, 0, 0), O_WESTWALL)); // origin
+                checkPositions.push_back(std::make_pair(Position(0, 1, 0), O_NORTHWALL)); // one tile south
+                checkPositions.push_back(std::make_pair(Position(-1, 1, 0), O_NORTHWALL)); // one tile south-west
+                checkPositions.push_back(std::make_pair(Position(0, 1, 0), O_WESTWALL)); // one tile south
+                break;
 			case 6: // west
 				checkPositions.push_back(std::make_pair(Position(0, 0, 0), O_WESTWALL)); // origin
 				if (y != 0)
@@ -1989,61 +1986,43 @@ int TileEngine::unitOpensDoor(BattleUnit *unit, bool rClick, int dir)
 			case 7: // north-west
 				checkPositions.push_back(std::make_pair(Position(0, 0, 0), O_WESTWALL)); // origin
 				checkPositions.push_back(std::make_pair(Position(0, 0, 0), O_NORTHWALL)); // origin
-				if (x)
-				{
-					checkPositions.push_back(std::make_pair(Position(-1, -1, 0), O_WESTWALL)); // one tile north
-				}
-				if (y)
-				{
-					checkPositions.push_back(std::make_pair(Position(-1, -1, 0), O_NORTHWALL)); // one tile north
-				}
-				if (rClick)
-				{
-					checkPositions.push_back(std::make_pair(Position(0, -1, 0), O_WESTWALL)); // one tile north
-					checkPositions.push_back(std::make_pair(Position(-1, 0, 0), O_NORTHWALL)); // one tile west
-				}
+    			checkPositions.push_back(std::make_pair(Position(-1, 0, 0), O_NORTHWALL)); // one tile west
+    			checkPositions.push_back(std::make_pair(Position(0, -1, 0), O_WESTWALL)); // one tile north
 				break;
 			default:
 				break;
 			}
-
 			int part = 0;
 			for (std::vector<std::pair<Position, int> >::const_iterator i = checkPositions.begin(); i != checkPositions.end() && door == -1; ++i)
 			{
 				tile = _save->getTile(unit->getPosition() + Position(x,y,z) + i->first);
-				if (tile)
+    			part = i->second;
+    			if (tile &&	tile->getMapData(part) && (tile->getMapData(part)->isDoor() || tile->getMapData(part)->isUFODoor()))
 				{
-					door = tile->openDoor(i->second, unit, _save->getBattleGame()->getReservedAction());
-					if (door != -1)
+    				TUCost = tile->getTUCost(part, unit->getMovementType());
+    				if (dir & 1)
 					{
-						part = i->second;
-						if (door == 1)
+						if (tile->getMapData(part)->isDoor() && !rClick) //skip diagonal hinged doors except for rClick
 						{
-							checkAdjacentDoors(unit->getPosition() + Position(x,y,z) + i->first, i->second);
+							TUCost = 0;
+							door = -1;
+							continue;
+						}
+						else 
+						{
+//        					TUCost = (int)((double)TUCost * 1.5); //diagonal ufodoor open
 						}
 					}
+                    door = tile->openDoor(part, TUCost, unit, _save->getBattleGame()->getReservedAction());
+                    if (door == 1)
+                    {
+                        checkAdjacentDoors(unit->getPosition() + Position(x,y,z) + i->first, part);
+                    }
 				}
 			}
-			if (door == 0 && rClick)
-			{
-				if (part == O_WESTWALL)
-				{
-					part = O_NORTHWALL;
-				}
-				else
-				{
-					part = O_WESTWALL;
-				}
-				TUCost = tile->getTUCost(part, unit->getMovementType());
-			}
-			else if (door == 1 || door == 4)
-			{
-				TUCost = tile->getTUCost(part, unit->getMovementType());
-			}
-		}
-	}
-
-	if (TUCost != 0)
+        }
+    }
+    if (TUCost != 0 && (door == 1 || (rClick && door == 0)))
 	{
 		if (_save->getBattleGame()->checkReservedTU(unit, TUCost))
 		{

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -53,8 +53,9 @@ const int TileEngine::heightFromCenter[11] = {0,-2,+2,-4,+4,-6,+6,-8,+8,-12,+12}
  * @param save Pointer to SavedBattleGame object.
  * @param voxelData List of voxel data.
  */
-TileEngine::TileEngine(SavedBattleGame *save, std::vector<Uint16> *voxelData) : _save(save), _voxelData(voxelData), _personalLighting(true)
+TileEngine::TileEngine(SavedBattleGame *save, std::vector<Uint16> *voxelData) : _save(save), _voxelData(voxelData), _personalLighting(true), _cacheTile(0), _cacheTileBelow(0)
 {
+    _cacheTilePos = Position(-1,-1,-1);
 }
 
 /**
@@ -678,6 +679,7 @@ bool TileEngine::canTargetTile(Position *originVoxel, Tile *tile, int part, Posi
 		return false;
 	}
 
+    voxelCheckFlush();
 // find out height range
 
 	if (!minZfound)
@@ -1048,6 +1050,7 @@ BattleUnit *TileEngine::hit(Position center, int power, ItemDamageType type, Bat
 
 	BattleUnit *bu = tile->getUnit();
 	int adjustedDamage = 0;
+    voxelCheckFlush();
 	const int part = voxelCheck(center, unit);
 	if (part >= V_FLOOR && part <= V_OBJECT)
 	{
@@ -2128,6 +2131,11 @@ int TileEngine::calculateLine(Position origin, Position target, bool storeTrajec
 	Position lastPoint(origin);
 	int result;
 	int steps = 0;
+    bool excludeAllUnits = false;
+    if (_save->isBeforeGame())
+    {
+        excludeAllUnits = true; // don't start unit spotting before pre-game inventory stuff (large units on the craftInventory tile will cause a crash if they're "spotted")
+    }
 
 	//start and end points
 	x0 = origin.x;	 x1 = target.x;
@@ -2168,6 +2176,8 @@ int TileEngine::calculateLine(Position origin, Position target, bool storeTrajec
 	//starting point
 	y = y0;
 	z = z0;
+    
+    if (doVoxelCheck) voxelCheckFlush();
 
 	//step through longest delta (which we have swapped to x)
 	for (x = x0; x != (x1+step_x); x += step_x)
@@ -2186,7 +2196,7 @@ int TileEngine::calculateLine(Position origin, Position target, bool storeTrajec
 		//passes through this point?
 		if (doVoxelCheck)
 		{
-			result = voxelCheck(Position(cx, cy, cz), excludeUnit, false, onlyVisible, excludeAllBut);
+            result = voxelCheck(Position(cx, cy, cz), excludeUnit, excludeAllUnits, onlyVisible, excludeAllBut);
 			if (result != V_EMPTY)
 			{
 				if (trajectory)
@@ -2234,7 +2244,7 @@ int TileEngine::calculateLine(Position origin, Position target, bool storeTrajec
 				cx = x;	cz = z; cy = y;
 				if (swap_xz) std::swap(cx, cz);
 				if (swap_xy) std::swap(cx, cy);
-				result = voxelCheck(Position(cx, cy, cz), excludeUnit, false, onlyVisible, excludeAllBut);
+                result = voxelCheck(Position(cx, cy, cz), excludeUnit, excludeAllUnits, onlyVisible, excludeAllBut);
 				if (result != V_EMPTY)
 				{
 					if (trajectory != 0)
@@ -2258,7 +2268,7 @@ int TileEngine::calculateLine(Position origin, Position target, bool storeTrajec
 				cx = x;	cz = z; cy = y;
 				if (swap_xz) std::swap(cx, cz);
 				if (swap_xy) std::swap(cx, cy);
-				result = voxelCheck(Position(cx, cy, cz), excludeUnit, false, onlyVisible,  excludeAllBut);
+                result = voxelCheck(Position(cx, cy, cz), excludeUnit, excludeAllUnits, onlyVisible, excludeAllBut);
 				if (result != V_EMPTY)
 				{
 					if (trajectory != 0)
@@ -2358,7 +2368,8 @@ int TileEngine::castedShade(Position voxel)
 
 	Position tmpVoxel = voxel;
 	int z;
-
+    
+    voxelCheckFlush();
 	for (z = zstart; z>0; z--)
 	{
 		tmpVoxel.z = z;
@@ -2380,6 +2391,8 @@ bool TileEngine::isVoxelVisible(Position voxel)
 		return true; // visible!
 	Position tmpVoxel = voxel;
 	int zend = (zstart/24)*24 +24;
+    
+    voxelCheckFlush();
 	for (int z = zstart; z<zend; z++)
 	{
 		tmpVoxel.z=z;
@@ -2404,33 +2417,48 @@ bool TileEngine::isVoxelVisible(Position voxel)
  */
 int TileEngine::voxelCheck(Position voxel, BattleUnit *excludeUnit, bool excludeAllUnits, bool onlyVisible, BattleUnit *excludeAllBut)
 {
-	if (_save->isBeforeGame())
+    if (voxel.x < 0 || voxel.y < 0 || voxel.z < 0) //preliminary out of map
 	{
-		excludeAllUnits = true; // don't start unit spotting before pre-game inventory stuff (large units on the craftInventory tile will cause a crash if they're "spotted")
+        return V_OUTOFBOUNDS;
 	}
-	Tile *tile = _save->getTile(voxel / Position(16, 16, 24));
-	// check if we are not out of the map
-	if (tile == 0 || voxel.x < 0 || voxel.y < 0 || voxel.z < 0)
+    Position pos = voxel / Position(16, 16, 24);
+    Tile *tile, *tileBelow;
+    if (_cacheTilePos==pos)
 	{
-		return V_OUTOFBOUNDS;
+        tile = _cacheTile;
+        tileBelow = _cacheTileBelow;
+    }
+    else
+    {
+        tile = _save->getTile(pos);
+        if (!tile) // check if we are not out of the map
+        {
+            return V_OUTOFBOUNDS; //not even cache
+        }
+        tileBelow = _save->getTile(pos + Position(0,0,-1));
+        _cacheTilePos = pos;
+        _cacheTile = tile;
+        _cacheTileBelow = tileBelow;
 	}
-	Tile *tileBelow = _save->getTile(tile->getPosition() + Position(0,0,-1));
+
 	if (tile->isVoid() && tile->getUnit() == 0 && (!tileBelow || tileBelow->getUnit() == 0))
 	{
 		return V_EMPTY;
 	}
-
-	if ((voxel.z % 24 == 0 || voxel.z % 24 == 1) && tile->getMapData(O_FLOOR) && tile->getMapData(O_FLOOR)->isGravLift())
+    
+    if (tile->getMapData(O_FLOOR) && tile->getMapData(O_FLOOR)->isGravLift() && (voxel.z % 24 == 0 || voxel.z % 24 == 1))
 	{
 		if ((tile->getPosition().z == 0) || (tileBelow && tileBelow->getMapData(O_FLOOR) && !tileBelow->getMapData(O_FLOOR)->isGravLift()))
-			return V_FLOOR;
+        {
+            return V_FLOOR;
+        }
 	}
 
 	// first we check terrain voxel data, not to allow 2x2 units stick through walls
 	for (int i=0; i< 4; ++i)
 	{
 		MapData *mp = tile->getMapData(i);
-		if (tile->isUfoDoorOpen(i))
+        if (((i==1) || (i==2)) && tile->isUfoDoorOpen(i))
 			continue;
 		if (mp != 0)
 		{
@@ -2451,8 +2479,7 @@ int TileEngine::voxelCheck(Position voxel, BattleUnit *excludeUnit, bool exclude
 		// in this case we couldn't have unit standing at current tile.
 		if (unit == 0 && tile->hasNoFloor(0))
 		{
-			tile = _save->getTile(Position(voxel.x/16, voxel.y/16, (voxel.z/24)-1)); //below
-			if (tile) unit = tile->getUnit();
+            if (tileBelow) unit = tileBelow->getUnit();
 		}
 
 		if (unit != 0 && unit != excludeUnit && (!excludeAllBut || unit == excludeAllBut) && (!onlyVisible || unit->getVisible() ) )
@@ -2479,6 +2506,13 @@ int TileEngine::voxelCheck(Position voxel, BattleUnit *excludeUnit, bool exclude
 		}
 	}
 	return V_EMPTY;
+}
+
+void TileEngine::voxelCheckFlush(void)
+{
+    _cacheTilePos = Position(-1,-1,-1);
+    _cacheTile = 0;
+    _cacheTileBelow = 0;
 }
 
 /**

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -53,9 +53,8 @@ const int TileEngine::heightFromCenter[11] = {0,-2,+2,-4,+4,-6,+6,-8,+8,-12,+12}
  * @param save Pointer to SavedBattleGame object.
  * @param voxelData List of voxel data.
  */
-TileEngine::TileEngine(SavedBattleGame *save, std::vector<Uint16> *voxelData) : _save(save), _voxelData(voxelData), _personalLighting(true), _cacheTile(0), _cacheTileBelow(0)
+TileEngine::TileEngine(SavedBattleGame *save, std::vector<Uint16> *voxelData) : _save(save), _voxelData(voxelData), _personalLighting(true)
 {
-    _cacheTilePos = Position(-1,-1,-1);
 }
 
 /**
@@ -679,7 +678,6 @@ bool TileEngine::canTargetTile(Position *originVoxel, Tile *tile, int part, Posi
 		return false;
 	}
 
-    voxelCheckFlush();
 // find out height range
 
 	if (!minZfound)
@@ -1050,7 +1048,6 @@ BattleUnit *TileEngine::hit(Position center, int power, ItemDamageType type, Bat
 
 	BattleUnit *bu = tile->getUnit();
 	int adjustedDamage = 0;
-    voxelCheckFlush();
 	const int part = voxelCheck(center, unit);
 	if (part >= V_FLOOR && part <= V_OBJECT)
 	{
@@ -2131,11 +2128,6 @@ int TileEngine::calculateLine(Position origin, Position target, bool storeTrajec
 	Position lastPoint(origin);
 	int result;
 	int steps = 0;
-    bool excludeAllUnits = false;
-    if (_save->isBeforeGame())
-    {
-        excludeAllUnits = true; // don't start unit spotting before pre-game inventory stuff (large units on the craftInventory tile will cause a crash if they're "spotted")
-    }
 
 	//start and end points
 	x0 = origin.x;	 x1 = target.x;
@@ -2176,8 +2168,6 @@ int TileEngine::calculateLine(Position origin, Position target, bool storeTrajec
 	//starting point
 	y = y0;
 	z = z0;
-    
-    if (doVoxelCheck) voxelCheckFlush();
 
 	//step through longest delta (which we have swapped to x)
 	for (x = x0; x != (x1+step_x); x += step_x)
@@ -2196,7 +2186,7 @@ int TileEngine::calculateLine(Position origin, Position target, bool storeTrajec
 		//passes through this point?
 		if (doVoxelCheck)
 		{
-            result = voxelCheck(Position(cx, cy, cz), excludeUnit, excludeAllUnits, onlyVisible, excludeAllBut);
+			result = voxelCheck(Position(cx, cy, cz), excludeUnit, false, onlyVisible, excludeAllBut);
 			if (result != V_EMPTY)
 			{
 				if (trajectory)
@@ -2244,7 +2234,7 @@ int TileEngine::calculateLine(Position origin, Position target, bool storeTrajec
 				cx = x;	cz = z; cy = y;
 				if (swap_xz) std::swap(cx, cz);
 				if (swap_xy) std::swap(cx, cy);
-                result = voxelCheck(Position(cx, cy, cz), excludeUnit, excludeAllUnits, onlyVisible, excludeAllBut);
+				result = voxelCheck(Position(cx, cy, cz), excludeUnit, false, onlyVisible, excludeAllBut);
 				if (result != V_EMPTY)
 				{
 					if (trajectory != 0)
@@ -2268,7 +2258,7 @@ int TileEngine::calculateLine(Position origin, Position target, bool storeTrajec
 				cx = x;	cz = z; cy = y;
 				if (swap_xz) std::swap(cx, cz);
 				if (swap_xy) std::swap(cx, cy);
-                result = voxelCheck(Position(cx, cy, cz), excludeUnit, excludeAllUnits, onlyVisible, excludeAllBut);
+				result = voxelCheck(Position(cx, cy, cz), excludeUnit, false, onlyVisible,  excludeAllBut);
 				if (result != V_EMPTY)
 				{
 					if (trajectory != 0)
@@ -2368,8 +2358,7 @@ int TileEngine::castedShade(Position voxel)
 
 	Position tmpVoxel = voxel;
 	int z;
-    
-    voxelCheckFlush();
+
 	for (z = zstart; z>0; z--)
 	{
 		tmpVoxel.z = z;
@@ -2391,8 +2380,6 @@ bool TileEngine::isVoxelVisible(Position voxel)
 		return true; // visible!
 	Position tmpVoxel = voxel;
 	int zend = (zstart/24)*24 +24;
-    
-    voxelCheckFlush();
 	for (int z = zstart; z<zend; z++)
 	{
 		tmpVoxel.z=z;
@@ -2417,48 +2404,33 @@ bool TileEngine::isVoxelVisible(Position voxel)
  */
 int TileEngine::voxelCheck(Position voxel, BattleUnit *excludeUnit, bool excludeAllUnits, bool onlyVisible, BattleUnit *excludeAllBut)
 {
-    if (voxel.x < 0 || voxel.y < 0 || voxel.z < 0) //preliminary out of map
+	if (_save->isBeforeGame())
 	{
-        return V_OUTOFBOUNDS;
+		excludeAllUnits = true; // don't start unit spotting before pre-game inventory stuff (large units on the craftInventory tile will cause a crash if they're "spotted")
 	}
-    Position pos = voxel / Position(16, 16, 24);
-    Tile *tile, *tileBelow;
-    if (_cacheTilePos==pos)
+	Tile *tile = _save->getTile(voxel / Position(16, 16, 24));
+	// check if we are not out of the map
+	if (tile == 0 || voxel.x < 0 || voxel.y < 0 || voxel.z < 0)
 	{
-        tile = _cacheTile;
-        tileBelow = _cacheTileBelow;
-    }
-    else
-    {
-        tile = _save->getTile(pos);
-        if (!tile) // check if we are not out of the map
-        {
-            return V_OUTOFBOUNDS; //not even cache
-        }
-        tileBelow = _save->getTile(pos + Position(0,0,-1));
-        _cacheTilePos = pos;
-        _cacheTile = tile;
-        _cacheTileBelow = tileBelow;
+		return V_OUTOFBOUNDS;
 	}
-
+	Tile *tileBelow = _save->getTile(tile->getPosition() + Position(0,0,-1));
 	if (tile->isVoid() && tile->getUnit() == 0 && (!tileBelow || tileBelow->getUnit() == 0))
 	{
 		return V_EMPTY;
 	}
-    
-    if (tile->getMapData(O_FLOOR) && tile->getMapData(O_FLOOR)->isGravLift() && (voxel.z % 24 == 0 || voxel.z % 24 == 1))
+
+	if ((voxel.z % 24 == 0 || voxel.z % 24 == 1) && tile->getMapData(O_FLOOR) && tile->getMapData(O_FLOOR)->isGravLift())
 	{
 		if ((tile->getPosition().z == 0) || (tileBelow && tileBelow->getMapData(O_FLOOR) && !tileBelow->getMapData(O_FLOOR)->isGravLift()))
-        {
-            return V_FLOOR;
-        }
+			return V_FLOOR;
 	}
 
 	// first we check terrain voxel data, not to allow 2x2 units stick through walls
 	for (int i=0; i< 4; ++i)
 	{
 		MapData *mp = tile->getMapData(i);
-        if (((i==1) || (i==2)) && tile->isUfoDoorOpen(i))
+		if (tile->isUfoDoorOpen(i))
 			continue;
 		if (mp != 0)
 		{
@@ -2479,7 +2451,8 @@ int TileEngine::voxelCheck(Position voxel, BattleUnit *excludeUnit, bool exclude
 		// in this case we couldn't have unit standing at current tile.
 		if (unit == 0 && tile->hasNoFloor(0))
 		{
-            if (tileBelow) unit = tileBelow->getUnit();
+			tile = _save->getTile(Position(voxel.x/16, voxel.y/16, (voxel.z/24)-1)); //below
+			if (tile) unit = tile->getUnit();
 		}
 
 		if (unit != 0 && unit != excludeUnit && (!excludeAllBut || unit == excludeAllBut) && (!onlyVisible || unit->getVisible() ) )
@@ -2506,13 +2479,6 @@ int TileEngine::voxelCheck(Position voxel, BattleUnit *excludeUnit, bool exclude
 		}
 	}
 	return V_EMPTY;
-}
-
-void TileEngine::voxelCheckFlush(void)
-{
-    _cacheTilePos = Position(-1,-1,-1);
-    _cacheTile = 0;
-    _cacheTileBelow = 0;
 }
 
 /**

--- a/src/Battlescape/TileEngine.h
+++ b/src/Battlescape/TileEngine.h
@@ -47,9 +47,6 @@ private:
 	void addLight(Position center, int power, int layer);
 	int blockage(Tile *tile, const int part, ItemDamageType type, int direction = -1, bool checkingFromOrigin = false);
 	bool _personalLighting;
-    Tile *_cacheTile;
-    Tile *_cacheTileBelow;
-    Position _cacheTilePos;
 public:
 	/// Creates a new TileEngine class.
 	TileEngine(SavedBattleGame *save, std::vector<Uint16> *voxelData);
@@ -117,8 +114,6 @@ public:
 	bool isVoxelVisible(Position voxel);
 	/// Checks what type of voxel occupies this space.
 	int voxelCheck(Position voxel, BattleUnit *excludeUnit, bool excludeAllUnits = false, bool onlyVisible = false, BattleUnit *excludeAllBut = 0);
-    /// Flushes cache of voxel check
-    void voxelCheckFlush(void);
 	/// Blows this tile up.
 	bool detonate(Tile* tile);
 	/// Validates a throwing action.

--- a/src/Battlescape/TileEngine.h
+++ b/src/Battlescape/TileEngine.h
@@ -47,6 +47,9 @@ private:
 	void addLight(Position center, int power, int layer);
 	int blockage(Tile *tile, const int part, ItemDamageType type, int direction = -1, bool checkingFromOrigin = false);
 	bool _personalLighting;
+    Tile *_cacheTile;
+    Tile *_cacheTileBelow;
+    Position _cacheTilePos;
 public:
 	/// Creates a new TileEngine class.
 	TileEngine(SavedBattleGame *save, std::vector<Uint16> *voxelData);
@@ -114,6 +117,8 @@ public:
 	bool isVoxelVisible(Position voxel);
 	/// Checks what type of voxel occupies this space.
 	int voxelCheck(Position voxel, BattleUnit *excludeUnit, bool excludeAllUnits = false, bool onlyVisible = false, BattleUnit *excludeAllBut = 0);
+    /// Flushes cache of voxel check
+    void voxelCheckFlush(void);
 	/// Blows this tile up.
 	bool detonate(Tile* tile);
 	/// Validates a throwing action.

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -1135,98 +1135,105 @@ const std::vector<const RuleResearch *> & SavedGame::getDiscoveredResearch() con
  */
 void SavedGame::getAvailableResearchProjects (std::vector<RuleResearch *> & projects, const Mod * mod, Base * base) const
 {
-	const std::vector<const RuleResearch *> & discovered(getDiscoveredResearch());
-	std::vector<std::string> researchProjects = mod->getResearchList();
-	const std::vector<ResearchProject *> & baseResearchProjects = base->getResearch();
-	std::vector<const RuleResearch *> unlocked;
-	for (std::vector<const RuleResearch *>::const_iterator it = discovered.begin(); it != discovered.end(); ++it)
-	{
-		for (std::vector<std::string>::const_iterator itUnlocked = (*it)->getUnlocked().begin(); itUnlocked != (*it)->getUnlocked().end(); ++itUnlocked)
-		{
-			unlocked.push_back(mod->getResearch(*itUnlocked, true));
-		}
-	}
-	for (std::vector<std::string>::const_iterator iter = researchProjects.begin(); iter != researchProjects.end(); ++iter)
-	{
-		RuleResearch *research = mod->getResearch(*iter);
-		if (!isResearchAvailable(research, unlocked, mod))
-		{
-			continue;
-		}
-		std::vector<const RuleResearch *>::const_iterator itDiscovered = std::find(discovered.begin(), discovered.end(), research);
+    const std::vector<const RuleResearch *> & discovered(getDiscoveredResearch());
+    std::vector<std::string> researchProjects = mod->getResearchList();
+    const std::vector<ResearchProject *> & baseResearchProjects = base->getResearch();
+    std::vector<const RuleResearch *> unlocked;
+    for (std::vector<const RuleResearch *>::const_iterator it = discovered.begin(); it != discovered.end(); ++it)
+    {
+        for (std::vector<std::string>::const_iterator itUnlocked = (*it)->getUnlocked().begin(); itUnlocked != (*it)->getUnlocked().end(); ++itUnlocked)
+        {
+            unlocked.push_back(mod->getResearch(*itUnlocked, true));
+        }
+    }
+    for (std::vector<std::string>::const_iterator iter = researchProjects.begin(); iter != researchProjects.end(); ++iter)
+    {
+        RuleResearch *research = mod->getResearch(*iter);
+        /*
+         * Check if a research is available,
+         * when this is not the case remove from list
+         */
+        if (!isResearchAvailable(research, unlocked, mod))
+        {
+            continue;
+        }
 
-		bool liveAlien = mod->getUnit(research->getName()) != 0;
+        /*
+         * Check if the research has "requires" which need to be satisfied,
+         * if so count them and check if all of them are in "discovered",
+         * if not remove from list.
+         * Check is performed here in case a modder thinks giving a "requires" to alive aliens or item with getOneFree is somehow approriate.
+         * We also do not call all the rest of the function, hopefully saving some performance.
+         */
+        if (!research->getRequirements().empty())
+        {
+            size_t countRequirements(0);
+            for (size_t itReqs = 0; itReqs != research->getRequirements().size(); ++itReqs)
+            {
+                std::vector<const RuleResearch *>::const_iterator itDiscovered = std::find(discovered.begin(), discovered.end(), mod->getResearch(research->getRequirements().at(itReqs)));
+                if (itDiscovered != discovered.end())
+                {
+                    countRequirements++;
+                }
+            }
+            if (countRequirements != research->getRequirements().size())
+            {
+                continue;
+            }
+        }
 
-		if (itDiscovered != discovered.end())
-		{
-			bool cull = true;
-			if (!research->getGetOneFree().empty())
-			{
-				for (std::vector<std::string>::const_iterator ohBoy = research->getGetOneFree().begin(); ohBoy != research->getGetOneFree().end(); ++ohBoy)
-				{
-					std::vector<const RuleResearch *>::const_iterator more_iteration = std::find(discovered.begin(), discovered.end(), mod->getResearch(*ohBoy));
-					if (more_iteration == discovered.end())
-					{
-						cull = false;
-						break;
-					}
-				}
-			}
-			if (!liveAlien && cull)
-			{
-				continue;
-			}
-			else
-			{
-				std::vector<std::string>::const_iterator leaderCheck = std::find(research->getUnlocked().begin(), research->getUnlocked().end(), "STR_LEADER_PLUS");
-				std::vector<std::string>::const_iterator cmnderCheck = std::find(research->getUnlocked().begin(), research->getUnlocked().end(), "STR_COMMANDER_PLUS");
+        /* 
+         * Lets check the list of already discovered researches and take care of cleaning up
+         * the research menu list when needed, but keep alive aliens and items with getOneFree around
+         * as long as they have something to discover by the player.
+         */
+        std::vector<const RuleResearch *>::const_iterator itDiscovered = std::find(discovered.begin(), discovered.end(), research);
+        bool liveAlien = mod->getUnit(research->getName()) != 0;
+        if (itDiscovered != discovered.end())
+        {
+            bool remove = true;
+            /* Check if research is a item with getOneFree,
+             * which is still available,
+             * if so do not remove from list
+             */
+            if (!liveAlien && !research->getGetOneFree().empty())
+            {
+                if (isResearchAvailable(research, unlocked, mod))
+                {
+                    remove = false;
+                }
+            }
+            if (!liveAlien && remove)
+            {
+                continue;
+            }
 
-				bool leader ( leaderCheck != research->getUnlocked().end());
-				bool cmnder ( cmnderCheck != research->getUnlocked().end());
-
-				if (leader)
-				{
-					std::vector<const RuleResearch*>::const_iterator found = std::find(discovered.begin(), discovered.end(), mod->getResearch("STR_LEADER_PLUS"));
-					if (found == discovered.end())
-						cull = false;
-				}
-
-				if (cmnder)
-				{
-					std::vector<const RuleResearch*>::const_iterator found = std::find(discovered.begin(), discovered.end(), mod->getResearch("STR_COMMANDER_PLUS"));
-					if (found == discovered.end())
-						cull = false;
-				}
-
-				if (cull)
-					continue;
-			}
-		}
-
-		if (std::find_if (baseResearchProjects.begin(), baseResearchProjects.end(), findRuleResearch(research)) != baseResearchProjects.end())
-		{
-			continue;
-		}
-		if (research->needItem() && base->getStorageItems()->getItem(research->getName()) == 0)
-		{
-			continue;
-		}
-		if (!research->getRequirements().empty())
-		{
-			size_t tally(0);
-			for (size_t itreq = 0; itreq != research->getRequirements().size(); ++itreq)
-			{
-				itDiscovered = std::find(discovered.begin(), discovered.end(), mod->getResearch(research->getRequirements().at(itreq)));
-				if (itDiscovered != discovered.end())
-				{
-					tally++;
-				}
-			}
-			if (tally != research->getRequirements().size())
-				continue;
-		}
-		projects.push_back (research);
-	}
+            /*
+             * Check if alive alien still is available for research,
+             * if so do not remove from list
+            */
+            else if (liveAlien)
+            {
+                if (isResearchAvailable(research, unlocked, mod))
+                {
+                    remove = false;
+                }
+                if (remove)
+                {
+                    continue;
+                }
+            }
+        }
+        if (std::find_if (baseResearchProjects.begin(), baseResearchProjects.end(), findRuleResearch(research)) != baseResearchProjects.end())
+        {
+            continue;
+        }
+        if (research->needItem() && base->getStorageItems()->getItem(research->getName()) == 0)
+        {
+            continue;
+        }
+        projects.push_back (research);
+    }
 }
 
 /**
@@ -1266,61 +1273,86 @@ void SavedGame::getAvailableProductions (std::vector<RuleManufacture *> & produc
  */
 bool SavedGame::isResearchAvailable (RuleResearch * r, const std::vector<const RuleResearch *> & unlocked, const Mod * mod) const
 {
-	if (r == 0)
-	{
-		return false;
-	}
-	std::vector<std::string> deps = r->getDependencies();
-	const std::vector<const RuleResearch *> & discovered(getDiscoveredResearch());
-	bool liveAlien = mod->getUnit(r->getName()) != 0;
-	if (_debug || std::find(unlocked.begin(), unlocked.end(), r) != unlocked.end())
-	{
-		return true;
-	}
-	else if (liveAlien)
-	{
-		if (!r->getGetOneFree().empty())
-		{
-			std::vector<std::string>::const_iterator leaderCheck = std::find(r->getUnlocked().begin(), r->getUnlocked().end(), "STR_LEADER_PLUS");
-			std::vector<std::string>::const_iterator cmnderCheck = std::find(r->getUnlocked().begin(), r->getUnlocked().end(), "STR_COMMANDER_PLUS");
+    if (r == 0)
+    {
+        return false;
+    }
+    const std::vector<const RuleResearch *> & discovered(getDiscoveredResearch());
+    bool liveAlien = mod->getUnit(r->getName()) != 0;
+    if (_debug  || std::find(unlocked.begin(), unlocked.end(), r) != unlocked.end())
+    {
+        return true;
+    }
 
-			bool leader ( leaderCheck != r->getUnlocked().end());
-			bool cmnder ( cmnderCheck != r->getUnlocked().end());
+	/*
+     * Checks if research has "dependencies",
+     * if so count how many of them are in discovered
+     * if all are in discovered make research available.
+     * Check is performed here in case a modder thinks giving a "requires" to alive aliens or item with getOneFree is somehow approriate.
+     * We also do not call all the rest of the function, hopefully saving some performance.
+     */
+    if (!r->getDependencies().empty())
+    {
+        size_t countDependencies(0);
+        for (size_t itDeps = 0; itDeps != r->getDependencies().size(); ++itDeps)
+        {
+            std::vector<const RuleResearch *>::const_iterator itDiscovered = std::find(discovered.begin(), discovered.end(), mod->getResearch(r->getDependencies().at(itDeps)));
+            if (itDiscovered != discovered.end())
+            {
+                countDependencies++;
+            }
+        }
+        if (countDependencies != r->getDependencies().size())
+        {
+            return false;
+        }
+    }
 
-			if (leader)
-			{
-				std::vector<const RuleResearch*>::const_iterator found = std::find(discovered.begin(), discovered.end(), mod->getResearch("STR_LEADER_PLUS"));
-				if (found == discovered.end())
-					return true;
-			}
+    /*
+     * Check if research is either a alive alien or has "getOneFree",
+     * if so count how many of the researches "getOneFree" and "unlocks" are in discovered,
+     * if at least one of each are not in discovered keep research available
+     */
+    else if (liveAlien || !r->getGetOneFree().empty())
+    {
+        size_t countUnlocks(0);
+        size_t countGetOneFree(0);
 
-			if (cmnder)
-			{
-				std::vector<const RuleResearch*>::const_iterator found = std::find(discovered.begin(), discovered.end(), mod->getResearch("STR_COMMANDER_PLUS"));
-				if (found == discovered.end())
-					return true;
-			}
-		}
-	}
-	for (std::vector<std::string>::const_iterator itFree = r->getGetOneFree().begin(); itFree != r->getGetOneFree().end(); ++itFree)
-	{
-		if (std::find(unlocked.begin(), unlocked.end(), mod->getResearch(*itFree)) == unlocked.end())
-		{
-			return true;
-		}
-	}
+        if (!r->getGetOneFree().empty())
+        {
+            for (size_t itGetOneFree = 0; itGetOneFree != r->getGetOneFree().size(); ++itGetOneFree)
+            {
+                std::vector<const RuleResearch *>::const_iterator itDiscovered = std::find(discovered.begin(), discovered.end(), mod->getResearch(r->getGetOneFree().at(itGetOneFree)));
+                if (itDiscovered != discovered.end())
+                {
+                    countGetOneFree++;
+                }
+            }
+        }
 
-	for (std::vector<std::string>::const_iterator iter = deps.begin(); iter != deps.end(); ++ iter)
-	{
-		RuleResearch *research = mod->getResearch(*iter);
-		std::vector<const RuleResearch *>::const_iterator itDiscovered = std::find(discovered.begin(), discovered.end(), research);
-		if (itDiscovered == discovered.end())
-		{
-			return false;
-		}
-	}
+        if (!r->getUnlocked().empty())
+        {
+            for (size_t itUnlocks = 0; itUnlocks != r->getUnlocked().size(); ++itUnlocks)
+            {
+                std::vector<const RuleResearch *>::const_iterator itDiscovered = std::find(discovered.begin(), discovered.end(), mod->getResearch(r->getUnlocked().at(itUnlocks)));
+                if (itDiscovered != discovered.end())
+                {
+                    countUnlocks++;
+                }
+            }
+        }
 
-	return true;
+        /*
+         *  When counters of "getOneFree" and "unlocks" are
+         *  equal to the respective size of the research,
+         *  remove topic, since nothing more can be discovered by the player
+        */
+        if (countUnlocks == r->getUnlocked().size() && countGetOneFree == r->getGetOneFree().size())
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 /**

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -1192,7 +1192,8 @@ void SavedGame::getAvailableResearchProjects (std::vector<RuleResearch *> & proj
         if (itDiscovered != discovered.end())
         {
             bool remove = true;
-            /* Check if research is a item with getOneFree,
+            /*
+             * Check if research is a item with getOneFree,
              * which is still available,
              * if so do not remove from list
              */
@@ -1211,7 +1212,7 @@ void SavedGame::getAvailableResearchProjects (std::vector<RuleResearch *> & proj
             /*
              * Check if alive alien still is available for research,
              * if so do not remove from list
-            */
+             */
             else if (liveAlien)
             {
                 if (isResearchAvailable(research, unlocked, mod))
@@ -1346,7 +1347,7 @@ bool SavedGame::isResearchAvailable (RuleResearch * r, const std::vector<const R
          *  When counters of "getOneFree" and "unlocks" are
          *  equal to the respective size of the research,
          *  remove topic, since nothing more can be discovered by the player
-        */
+         */
         if (countUnlocks == r->getUnlocked().size() && countGetOneFree == r->getGetOneFree().size())
         {
             return false;

--- a/src/Savegame/Tile.cpp
+++ b/src/Savegame/Tile.cpp
@@ -330,17 +330,18 @@ int Tile::getFootstepSound(Tile *tileBelow) const
 /**
  * Open a door on this tile.
  * @param part
- * @param unit
- * @param reserve
+ * @param TUcost default 0
+ * @param unit deafult 0
+ * @param reserve default 0
  * @return a value: 0(normal door), 1(ufo door) or -1 if no door opened or 3 if ufo door(=animated) is still opening 4 if not enough TUs
  */
-int Tile::openDoor(int part, BattleUnit *unit, BattleActionType reserve)
+int Tile::openDoor(int part, int TUcost, BattleUnit *unit, BattleActionType reserve)
 {
 	if (!_objects[part]) return -1;
 
 	if (_objects[part]->isDoor() && unit->getArmor()->getSize() == 1) // don't allow double-wide units to open swinging doors due to engine limitations
 	{
-		if (unit && unit->getTimeUnits() < _objects[part]->getTUCost(unit->getMovementType()) + unit->getActionTUs(reserve, unit->getMainHandWeapon(false)))
+		if (unit && unit->getTimeUnits() < TUcost + unit->getActionTUs(reserve, unit->getMainHandWeapon(false)))
 			return 4;
 		if (_unit && _unit != unit && _unit->getPosition() != getPosition())
 			return -1;
@@ -351,7 +352,7 @@ int Tile::openDoor(int part, BattleUnit *unit, BattleActionType reserve)
 	}
 	if (_objects[part]->isUFODoor() && _currentFrame[part] == 0) // ufo door part 0 - door is closed
 	{
-		if (unit &&	unit->getTimeUnits() < _objects[part]->getTUCost(unit->getMovementType()) + unit->getActionTUs(reserve, unit->getMainHandWeapon(false)))
+		if (unit &&	unit->getTimeUnits() < TUcost + unit->getActionTUs(reserve, unit->getMainHandWeapon(false)))
 			return 4;
 		_currentFrame[part] = 1; // start opening door
 		return 1;

--- a/src/Savegame/Tile.h
+++ b/src/Savegame/Tile.h
@@ -130,7 +130,7 @@ public:
 	/// Gets the floor object footstep sound.
 	int getFootstepSound(Tile *tileBelow) const;
 	/// Open a door, returns the ID, 0(normal), 1(ufo) or -1 if no door opened.
-	int openDoor(int part, BattleUnit *Unit = 0, BattleActionType reserve = BA_NONE);
+	int openDoor(int part, int TUcost = 0, BattleUnit *Unit = 0, BattleActionType reserve = BA_NONE);
 
 	/**
 	 * Check if the ufo door is open or opening. Used for visibility/light blocking checks.
@@ -141,6 +141,16 @@ public:
 	bool isUfoDoorOpen(int part) const
 	{
 		return (_objects[part] && _objects[part]->isUFODoor() && _currentFrame[part] != 0);
+	}
+
+	/**
+	 * Check if the ufo door is closed. Used for pathfinding.
+	 * @param part
+	 * @return bool
+	 */
+	bool isUfoDoorClosed(int part) const
+	{
+		return (_objects[part] && _objects[part]->isUFODoor() && _currentFrame[part] == 0);
 	}
 
 	/// Close ufo door.


### PR DESCRIPTION
Made the code m
ore understandable.
Alive aliens and items with "getOneFree" will now stay researchable for the player as long as there is a undiscovered "getOneFree" or "unlocks", in the ruleset.

The alive alien check is now much more understandable and basically allows unhardocding of STR_LEADER_PLUS and STR_COMMANDER_PLUS, the explizit check for these are not needed anymore.

I tested the code against vanilla and my own mod. Works :)