### PR TITLE
Allow different cutscenes when aborting mission

### DIFF
--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -2005,7 +2005,11 @@ void BattlescapeState::finishBattle(bool abort, int inExitArea)
 		std::string cutscene;
 		if (ruleDeploy)
 		{
-			if (abort || inExitArea == 0)
+			if (abort)
+			{
+				cutscene = ruleDeploy->getAbortCutscene();
+			}
+			else if (inExitArea == 0)
 			{
 				cutscene = ruleDeploy->getLoseCutscene();
 			}

--- a/src/Mod/AlienDeployment.cpp
+++ b/src/Mod/AlienDeployment.cpp
@@ -145,6 +145,7 @@ void AlienDeployment::load(const YAML::Node &node, Mod *mod)
 	_finalDestination = node["finalDestination"].as<bool>(_finalDestination);
 	_winCutscene = node["winCutscene"].as<std::string>(_winCutscene);
 	_loseCutscene = node["loseCutscene"].as<std::string>(_loseCutscene);
+	_abortCutscene = node["abortCutscene"].as<std::string>(_abortCutscene);
 	_script = node["script"].as<std::string>(_script);
 	_alert = node["alert"].as<std::string>(_alert);
 	_alertBackground = node["alertBackground"].as<std::string>(_alertBackground);
@@ -310,6 +311,15 @@ std::string AlienDeployment::getWinCutscene() const
 std::string AlienDeployment::getLoseCutscene() const
 {
 	return _loseCutscene;
+}
+
+/**
+* Gets the cutscene to play when the mission is aborted.
+* @return the cutscene to play when the mission is aborted.
+*/
+std::string AlienDeployment::getAbortCutscene() const
+{
+	return _abortCutscene;
 }
 
 /**

--- a/src/Mod/AlienDeployment.h
+++ b/src/Mod/AlienDeployment.h
@@ -69,7 +69,7 @@ private:
 	int _shade;
 	std::string _nextStage, _race, _script;
 	bool _finalDestination, _isAlienBase;
-	std::string _winCutscene, _loseCutscene;
+	std::string _winCutscene, _loseCutscene, _abortCutscene;
 	std::string _alert, _alertBackground;
 	BriefingData _briefingData;
 	std::string _markerName, _objectivePopup, _objectiveCompleteText, _objectiveFailedText;
@@ -108,6 +108,8 @@ public:
 	std::string getWinCutscene() const;
 	/// Gets the cutscene to play when this mission is lost.
 	std::string getLoseCutscene() const;
+	/// Gets the cutscene to play when this mission is aborted.
+	std::string getAbortCutscene() const;
 	/// Gets the alert message for this mission type.
 	std::string getAlertMessage() const;
 	/// Gets the alert background for this mission type.


### PR DESCRIPTION
The PlayStation version of UFO plays a special cutscene when a mission is aborted. This will allow mods to map a cutscene to this particular event.