### PR TITLE
fix behavior of fixed weapons in inventory screen

### DIFF
--- a/src/Battlescape/Inventory.cpp
+++ b/src/Battlescape/Inventory.cpp
@@ -525,7 +525,7 @@ void Inventory::mouseClick(Action *action, State *state)
 					x += _groundOffset;
 				}
 				BattleItem *item = _selUnit->getItem(slot, x, y);
-				if (item != 0)
+				if (item != 0 && !item->getRules()->isFixed())
 				{
 					if ((SDL_GetModState() & KMOD_CTRL))
 					{

--- a/src/Battlescape/InventoryState.cpp
+++ b/src/Battlescape/InventoryState.cpp
@@ -610,11 +610,12 @@ static void _clearInventory(Game *game, std::vector<BattleItem*> *unitInv, Tile 
 		if ((*i)->getRules()->isFixed()) {
 			// don't drop fixed weapons
 			++i;
-		} else {
-			(*i)->setOwner(NULL);
-			groundTile->addItem(*i, groundRuleInv);
-			i = unitInv->erase(i);
+			continue;
 		}
+
+		(*i)->setOwner(NULL);
+		groundTile->addItem(*i, groundRuleInv);
+		i = unitInv->erase(i);
 	}
 }
 


### PR DESCRIPTION
ensure fixed weapons can't be removed/added by ctrl-clicking or via
inventory template operations

This ensures tank-like units that show up on the equip screen (e.g. attack dogs in Final Mod Pack) can't have their fixed weapons replaced before battle.