### PR TITLE
Fixed int-in-bool-context warning/error for gcc 7.1

### DIFF
--- a/src/Engine/InteractiveSurface.cpp
+++ b/src/Engine/InteractiveSurface.cpp
@@ -76,7 +76,7 @@ void InteractiveSurface::setButtonPressed(Uint8 button, bool pressed)
 	}
 	else
 	{
-		_buttonsPressed = _buttonsPressed & (!SDL_BUTTON(button));
+		_buttonsPressed = _buttonsPressed & (~SDL_BUTTON(button));
 	}
 }
 


### PR DESCRIPTION
For gcc 7.1 compilation causes a warning when ints are used as bools. We also enable warnings-as-errors. This causes the compilation to fail with the following error.

```
In file included from /usr/include/SDL/SDL_events.h:35:0,
                 from /usr/include/SDL/SDL.h:37,
                 from src/Engine/InteractiveSurface.h:20,
                 from src/Engine/InteractiveSurface.cpp:19:
src/Engine/InteractiveSurface.cpp: In Elementfunktion »void OpenXcom::InteractiveSurface::setButtonPressed(Uint8, bool)«:
/usr/include/SDL/SDL_mouse.h:122:27: Fehler: »<<« in booleschem Kontext, meinten Sie »<«? [-Werror=int-in-bool-context]
 #define SDL_BUTTON(X)  (1 << ((X)-1))
                        ~~~^~~~~~~~~~~
src/Engine/InteractiveSurface.cpp:79:41: Anmerkung: bei Substitution des Makros »SDL_BUTTON«
   _buttonsPressed = _buttonsPressed & (!SDL_BUTTON(button));
                                         ^~~~~~~~~~
cc1plus: Alle Warnungen werden als Fehler behandelt
```

Sorry for the German locale. Anyways, This PR fixes it,