### PR TITLE
Only award revivedSoldier commendation once per medikit state

### DIFF
--- a/src/Battlescape/MedikitState.cpp
+++ b/src/Battlescape/MedikitState.cpp
@@ -119,7 +119,7 @@ MedikitButton::MedikitButton(int y) : InteractiveSurface(30, 20, 190, y)
  * @param targetUnit The wounded unit.
  * @param action The healing action.
  */
-MedikitState::MedikitState (BattleUnit *targetUnit, BattleAction *action) : _targetUnit(targetUnit), _action(action)
+MedikitState::MedikitState (BattleUnit *targetUnit, BattleAction *action) : _targetUnit(targetUnit), _action(action), _revivedSoldier(false)
 {
 	if (Options::maximizeInfoScreens)
 	{
@@ -232,7 +232,7 @@ void MedikitState::onHealClick(Action *)
 		if (_targetUnit->getStatus() == STATUS_UNCONSCIOUS && _targetUnit->getStunlevel() < _targetUnit->getHealth() && _targetUnit->getHealth() > 0)
 		{
 			_targetUnit->setTimeUnits(0);
-			_action->actor->getStatistics()->revivedSoldier++;
+			awardRevivedSoldier();
 		}
 		_unit->getStatistics()->woundsHealed++;
 	}
@@ -310,6 +310,22 @@ void MedikitState::update()
 	_stimulantTxt->setText(toString(_item->getStimulantQuantity()));
 	_healTxt->setText(toString(_item->getHealQuantity()));
 	_medikitView->invalidate();
+}
+
+/**
+ * Award statistic once per MedikitState.
+ */
+void MedikitState::awardRevivedSoldier()
+{
+	if (_revivedSoldier)
+	{
+		return;
+	}
+	else
+	{
+		_action->actor->getStatistics()->revivedSoldier++;
+		_revivedSoldier = true;
+	}
 }
 
 }

--- a/src/Battlescape/MedikitState.h
+++ b/src/Battlescape/MedikitState.h
@@ -42,6 +42,7 @@ class MedikitState : public State
 	BattleItem *_item;
 	BattleAction *_action;
 	int _tu;
+	bool _revivedSoldier;
 	/// Handler for the end button.
 	void onEndClick(Action *action);
 	/// Handler for the heal button.
@@ -52,6 +53,8 @@ class MedikitState : public State
 	void onPainKillerClick(Action *action);
 	/// Updates the medikit interface.
 	void update();
+	/// Award BattleUnitStatistics.revivedSoldier.
+	void awardRevivedSoldier();
 public:
 	/// Creates the MedikitState.
 	MedikitState(BattleUnit *targetUnit, BattleAction *action);

--- a/src/Savegame/BattleUnitStatistics.h
+++ b/src/Savegame/BattleUnitStatistics.h
@@ -303,31 +303,30 @@ struct BattleUnitKills
 */
 struct BattleUnitStatistics
 {
-	/// Variables
-	bool wasUnconcious;						// Tracks if the soldier fell unconcious
-	int shotAtCounter;                      // Tracks how many times the unit was shot at
-	int hitCounter;							// Tracks how many times the unit was hit
-	int shotByFriendlyCounter;				// Tracks how many times the unit was hit by a friendly
-	int shotFriendlyCounter;				// Tracks how many times the unit was hit a friendly
-	bool loneSurvivor;						// Tracks if the soldier was the only survivor
-	bool ironMan;							// Tracks if the soldier was the only soldier on the mission
-	int longDistanceHitCounter;				// Tracks how many long distance shots were landed
-	int lowAccuracyHitCounter;				// Tracks how many times the unit landed a low probability shot
-	int shotsFiredCounter;					// Tracks how many times a unit has shot
-	int shotsLandedCounter;					// Tracks how many times a unit has hit his target
-	std::vector<BattleUnitKills*> kills;	// Tracks kills
-	int daysWounded;                        // Tracks how many days the unit was wounded for
-	bool KIA;								// Tracks if the soldier was killed in battle
-	bool nikeCross;							// Tracks if a soldier killed every alien
-	bool mercyCross;                        // Tracks if a soldier stunned every alien
-	int woundsHealed;                       // Tracks how many times a fatal wound was healed by this unit
-	UnitStats delta;                        // Tracks the increase in unit stats (is not saved, only used during debriefing)
-	int appliedStimulant;                   // Tracks how many times this soldier applied stimulant
-	int appliedPainKill;                    // Tracks how many times this soldier applied pain killers
-	int revivedSoldier;                     // Tracks how many times this soldier revived another unit
-	bool MIA;								// Tracks if the soldier was left behind :(
-	int martyr;								// Tracks how many kills the soldier landed on the turn of his death
-	int slaveKills;                         // Tracks how many kills the soldier landed thanks to a mind controlled unit.
+	bool wasUnconcious;                  ///< Tracks if the soldier fell unconcious
+	int shotAtCounter;                   ///< Tracks how many times the unit was shot at
+	int hitCounter;                      ///< Tracks how many times the unit was hit
+	int shotByFriendlyCounter;           ///< Tracks how many times the unit was hit by a friendly
+	int shotFriendlyCounter;             ///< Tracks how many times the unit was hit a friendly
+	bool loneSurvivor;                   ///< Tracks if the soldier was the only survivor
+	bool ironMan;                        ///< Tracks if the soldier was the only soldier on the mission
+	int longDistanceHitCounter;          ///< Tracks how many long distance shots were landed
+	int lowAccuracyHitCounter;           ///< Tracks how many times the unit landed a low probability shot
+	int shotsFiredCounter;               ///< Tracks how many times a unit has shot
+	int shotsLandedCounter;              ///< Tracks how many times a unit has hit his target
+	std::vector<BattleUnitKills*> kills; ///< Tracks kills
+	int daysWounded;                     ///< Tracks how many days the unit was wounded for
+	bool KIA;                            ///< Tracks if the soldier was killed in battle
+	bool nikeCross;                      ///< Tracks if a soldier killed every alien
+	bool mercyCross;                     ///< Tracks if a soldier stunned every alien
+	int woundsHealed;                    ///< Tracks how many times a fatal wound was healed by this unit
+	UnitStats delta;                     ///< Tracks the increase in unit stats (is not saved, only used during debriefing)
+	int appliedStimulant;                ///< Tracks how many times this soldier applied stimulant
+	int appliedPainKill;                 ///< Tracks how many times this soldier applied pain killers
+	int revivedSoldier;                  ///< Tracks how many times this soldier revived another unit
+	bool MIA;                            ///< Tracks if the soldier was left behind :(
+	int martyr;                          ///< Tracks how many kills the soldier landed on the turn of his death
+	int slaveKills;                      ///< Tracks how many kills the soldier landed thanks to a mind controlled unit.
 
 	/// Functions
 	// Duplicate entry check


### PR DESCRIPTION
When an unconscious soldier has multiple wounds, but is revived after the 1st heal action, the current situation increase the revivedSoldier on each subsequent healing action (assuming the player did not exit the medikit).

This PR ensures it will only be awarded once.

> note:
>  This PR deliberately does not change the different medikit behavior regarding simulant and heal 
>  actions. Which can be observed in the attached mod+savegame:
>  When selected soldier operates medikit on unconscious one it is standing over.
>  * Using simulants to revive the soldier will exit immediately if target regains consciousness
>  * Using heal will not exit immediately if soldier regains consciousness

[commendationsHealMedikitExample.zip](https://github.com/SupSuper/OpenXcom/files/1605231/commendationsHealMedikitExample.zip)
