### PR TITLE
Reduced compilation time and simplified include hierarchy.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required ( VERSION 2.8.5 )
 set ( CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules" )
 include(GNUInstallDirs)
 
+set (CMAKE_CXX_STANDARD 11)
+
 option ( DEV_BUILD "Development Build. Disable this for release builds" ON )
 option ( BUILD_PACKAGE "Prepares build for creation of a package with CPack" ON )
 option ( ENABLE_WARNING "Always show warnings (even for release builds)" OFF )

--- a/src/Basescape/SoldierDiaryMissionState.cpp
+++ b/src/Basescape/SoldierDiaryMissionState.cpp
@@ -31,6 +31,8 @@
 #include "../Savegame/MissionStatistics.h"
 #include "../Savegame/BattleUnitStatistics.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 
@@ -130,7 +132,7 @@ void SoldierDiaryMissionState::init()
 		missionId = 0;
 	}
 	int daysWounded = missionStatistics->at(missionId)->injuryList[_soldier->getId()];
-	
+
 	_lstKills->clearList();
 	_txtTitle->setText(tr(missionStatistics->at(missionId)->type));
 	if (missionStatistics->at(missionId)->isUfoMission())
@@ -145,7 +147,7 @@ void SoldierDiaryMissionState::init()
 	_txtDaylight->setText(tr("STR_DAYLIGHT_TYPE").arg(tr(missionStatistics->at(missionId)->getDaylightString())));
 	_txtDaysWounded->setText(tr("STR_DAYS_WOUNDED").arg(daysWounded));
 	_txtDaysWounded->setVisible(daysWounded != 0);
-	
+
 	int kills = 0;
 	bool stunOrKill = false;
 

--- a/src/Battlescape/AIModule.cpp
+++ b/src/Battlescape/AIModule.cpp
@@ -16,8 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <climits>
-#include <algorithm>
 #include "AIModule.h"
 #include "../Savegame/BattleItem.h"
 #include "../Savegame/Node.h"
@@ -35,6 +33,11 @@
 #include "../Mod/Mod.h"
 #include "../Mod/RuleItem.h"
 #include "../fmath.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <climits>
+#include <algorithm>
 
 namespace OpenXcom
 {

--- a/src/Battlescape/AIModule.cpp
+++ b/src/Battlescape/AIModule.cpp
@@ -26,13 +26,14 @@
 #include "BattlescapeState.h"
 #include "../Savegame/Tile.h"
 #include "Pathfinding.h"
-#include "../Engine/RNG.h"
 #include "../Engine/Logger.h"
 #include "../Engine/Game.h"
 #include "../Mod/Armor.h"
 #include "../Mod/Mod.h"
 #include "../Mod/RuleItem.h"
 #include "../fmath.h"
+#include "../Engine/RNG.hpp"
+#include "../Engine/RNG.h"
 
 #include <yaml-cpp/yaml.h>
 

--- a/src/Battlescape/AIModule.h
+++ b/src/Battlescape/AIModule.h
@@ -17,12 +17,19 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
 #include "BattlescapeGame.h"
 #include "Position.h"
 #include "../Savegame/BattleUnit.h"
 #include <vector>
 
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -16,7 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <sstream>
 #include "BattlescapeGame.h"
 #include "BattlescapeState.h"
 #include "Map.h"
@@ -57,6 +56,9 @@
 #include "../Engine/Logger.h"
 #include "../Savegame/BattleUnitStatistics.h"
 #include "../fmath.h"
+
+#include <algorithm>
+#include <sstream>
 
 namespace OpenXcom
 {

--- a/src/Battlescape/BattlescapeGame.h
+++ b/src/Battlescape/BattlescapeGame.h
@@ -18,7 +18,8 @@
  * along with OpenXcom.  If not, see <http:///www.gnu.org/licenses/>.
  */
 #include "Position.h"
-#include <SDL.h>
+#include <SDL_stdinc.h>
+
 #include <string>
 #include <list>
 #include <vector>

--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -16,9 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <assert.h>
-#include <fstream>
-#include <sstream>
 #include "BattlescapeGenerator.h"
 #include "TileEngine.h"
 #include "Inventory.h"
@@ -60,6 +57,11 @@
 #include "../Mod/AlienDeployment.h"
 #include "../Mod/RuleBaseFacility.h"
 #include "../Mod/Texture.h"
+
+#include <assert.h>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
 
 namespace OpenXcom
 {

--- a/src/Battlescape/Map.h
+++ b/src/Battlescape/Map.h
@@ -19,8 +19,11 @@
  */
 #include "../Engine/InteractiveSurface.h"
 #include "../Engine/Options.h"
+
 #include "Position.h"
+
 #include <vector>
+#include <list>
 
 namespace OpenXcom
 {

--- a/src/Battlescape/MiniMapView.cpp
+++ b/src/Battlescape/MiniMapView.cpp
@@ -16,7 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <algorithm>
 #include "../fmath.h"
 #include "MiniMapView.h"
 #include "MiniMapState.h"
@@ -32,6 +31,10 @@
 #include "../Mod/Armor.h"
 #include "../Engine/Options.h"
 #include "../Engine/Screen.h"
+
+#include <SDL_timer.h>
+
+#include <algorithm>
 
 namespace OpenXcom
 {

--- a/src/Battlescape/Position.cpp
+++ b/src/Battlescape/Position.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010-2016 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "Position.hpp"
+
+namespace OpenXcom
+{
+
+std::ostream& operator<<(std::ostream& out, const OpenXcom::Position& pos){
+        out << "(" << pos.x << "," << pos.y << ","<< pos.z << ")";
+        return out;
+}
+
+
+std::wostream& operator<<(std::wostream& wout, const OpenXcom::Position& pos){
+        wout << "(" << pos.x << "," << pos.y << ","<< pos.z << ")";
+        return wout;
+}
+
+}

--- a/src/Battlescape/Position.h
+++ b/src/Battlescape/Position.h
@@ -17,7 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
+
+#include <iosfwd>
 
 namespace OpenXcom
 {
@@ -68,46 +69,10 @@ public:
 
 };
 
-inline std::ostream& operator<<(std::ostream& out, const Position& pos)
-{
-	out << "(" << pos.x << "," << pos.y << ","<< pos.z << ")";
-	return out;
-}
+std::ostream& operator<<(std::ostream& out, const Position& pos);
 
-
-inline std::wostream& operator<<(std::wostream& wout, const Position& pos)
-{
-	wout << "(" << pos.x << "," << pos.y << ","<< pos.z << ")";
-	return wout;
-}
+std::wostream& operator<<(std::wostream& wout, const Position& pos);
 
 typedef Position Vector3i;
 
-}
-
-namespace YAML
-{
-	template<>
-	struct convert<OpenXcom::Position>
-	{
-		static Node encode(const OpenXcom::Position& rhs)
-		{
-			Node node;
-			node.push_back(rhs.x);
-			node.push_back(rhs.y);
-			node.push_back(rhs.z);
-			return node;
-		}
-
-		static bool decode(const Node& node, OpenXcom::Position& rhs)
-		{
-			if (!node.IsSequence() || node.size() != 3)
-				return false;
-
-			rhs.x = node[0].as<int>();
-			rhs.y = node[1].as<int>();
-			rhs.z = node[2].as<int>();
-			return true;
-		}
-	};
 }

--- a/src/Battlescape/Position.hpp
+++ b/src/Battlescape/Position.hpp
@@ -1,0 +1,45 @@
+#pragma once
+/*
+ * Copyright 2010-2016 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "Position.h"
+
+#include <yaml-cpp/yaml.h>
+
+namespace YAML{
+        template<>
+        struct convert<OpenXcom::Position>{
+                static Node encode(const OpenXcom::Position& rhs){
+                        Node node;
+                        node.push_back(rhs.x);
+                        node.push_back(rhs.y);
+                        node.push_back(rhs.z);
+                        return node;
+                }
+
+                static bool decode(const Node& node, OpenXcom::Position& rhs){
+                        if (!node.IsSequence() || node.size() != 3)
+                                return false;
+
+                        rhs.x = node[0].as<int>();
+                        rhs.y = node[1].as<int>();
+                        rhs.z = node[2].as<int>();
+                        return true;
+                }
+        };
+}

--- a/src/Battlescape/TileEngine.h
+++ b/src/Battlescape/TileEngine.h
@@ -17,10 +17,12 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <vector>
 #include "Position.h"
 #include "../Mod/RuleItem.h"
-#include <SDL.h>
+
+#include <SDL_stdinc.h>
+
+#include <vector>
 
 namespace OpenXcom
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,6 +123,7 @@ set ( engine_src
   Engine/Options.cpp
   Engine/Palette.cpp
   Engine/RNG.cpp
+  Engine/RNG-ETI.cpp
   Engine/Scalers/hq2x.cpp
   Engine/Scalers/hq3x.cpp
   Engine/Scalers/hq4x.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,7 @@ set ( battlescape_src
   Battlescape/Projectile.cpp
   Battlescape/ProjectileFlyBState.cpp
   Battlescape/PromotionsState.cpp
+  Battlescape/Position.cpp
   Battlescape/PsiAttackBState.cpp
   Battlescape/ScannerState.cpp
   Battlescape/ScannerView.cpp
@@ -295,6 +296,7 @@ set ( savegame_src
   Savegame/GameTime.cpp
   Savegame/ItemContainer.cpp
   Savegame/MissionSite.cpp
+  Savegame/MissionStatistics.cpp
   Savegame/MovingTarget.cpp
   Savegame/Node.cpp
   Savegame/Production.cpp

--- a/src/Engine/Action.h
+++ b/src/Engine/Action.h
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <SDL.h>
+#include <SDL_events.h> //For SDL_Event.
 
 namespace OpenXcom
 {

--- a/src/Engine/CrossPlatform.h
+++ b/src/Engine/CrossPlatform.h
@@ -17,10 +17,11 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <SDL.h>
 #include <string>
 #include <vector>
 #include <utility>
+
+#include <SDL_events.h> //For SDL_Event.
 
 namespace OpenXcom
 {

--- a/src/Engine/Font.cpp
+++ b/src/Engine/Font.cpp
@@ -22,6 +22,8 @@
 #include "FileMap.h"
 #include "Language.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Engine/Font.h
+++ b/src/Engine/Font.h
@@ -21,8 +21,17 @@
 #include <vector>
 #include <utility>
 #include <string>
-#include <SDL.h>
-#include <yaml-cpp/yaml.h>
+
+#include <SDL_video.h> //For SDL_Color, SDL_Rect.
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Engine/Game.cpp
+++ b/src/Engine/Game.cpp
@@ -17,10 +17,6 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "Game.h"
-#include <algorithm>
-#include <cmath>
-#include <sstream>
-#include <SDL_mixer.h>
 #include "State.h"
 #include "Screen.h"
 #include "Sound.h"
@@ -38,6 +34,14 @@
 #include "CrossPlatform.h"
 #include "FileMap.h"
 #include "../Menu/TestState.h"
+
+#include <SDL_mixer.h>
+#include <SDL.h>
+#include <yaml-cpp/yaml.h>
+
+#include <algorithm>
+#include <cmath>
+#include <sstream>
 
 namespace OpenXcom
 {

--- a/src/Engine/Game.h
+++ b/src/Engine/Game.h
@@ -17,9 +17,10 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <SDL_events.h> //For SDL_Event.
+
 #include <list>
 #include <string>
-#include <SDL.h>
 
 namespace OpenXcom
 {

--- a/src/Engine/InteractiveSurface.h
+++ b/src/Engine/InteractiveSurface.h
@@ -17,10 +17,13 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <SDL.h>
-#include <map>
 #include "Surface.h"
 #include "State.h"
+
+#include <SDL_mouse.h>
+#include <SDL_keysym.h>
+
+#include <map>
 
 namespace OpenXcom
 {

--- a/src/Engine/Language.cpp
+++ b/src/Engine/Language.cpp
@@ -17,11 +17,6 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "Language.h"
-#include <fstream>
-#include <cassert>
-#include <set>
-#include <climits>
-#include <algorithm>
 #include "CrossPlatform.h"
 #include "Logger.h"
 #include "Options.h"
@@ -34,6 +29,14 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
+
+#include <fstream>
+#include <cassert>
+#include <set>
+#include <climits>
+#include <algorithm>
+
+#include <yaml-cpp/yaml.h>
 
 namespace OpenXcom
 {

--- a/src/Engine/Language.h
+++ b/src/Engine/Language.h
@@ -17,11 +17,12 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include "LocalizedText.h"
+#include "../Savegame/Soldier.h"
+
 #include <map>
 #include <vector>
 #include <string>
-#include "LocalizedText.h"
-#include "../Savegame/Soldier.h"
 
 namespace OpenXcom
 {

--- a/src/Engine/Logger.h
+++ b/src/Engine/Logger.h
@@ -54,7 +54,7 @@ public:
 	Logger();
 	virtual ~Logger();
 	std::ostringstream& get(SeverityLevel level = LOG_INFO);
-	
+
 	static SeverityLevel& reportingLevel();
 	static std::string& logFile();
 	static std::string toString(SeverityLevel level);

--- a/src/Engine/OpenGL.h
+++ b/src/Engine/OpenGL.h
@@ -11,7 +11,6 @@
 
 #ifndef __NO_OPENGL
 
-#include <SDL.h>
 #include <SDL_opengl.h>
 #include <string>
 

--- a/src/Engine/OpenGL.h
+++ b/src/Engine/OpenGL.h
@@ -11,6 +11,7 @@
 
 #ifndef __NO_OPENGL
 
+#include <SDL_stdinc.h>
 #include <SDL_opengl.h>
 #include <string>
 

--- a/src/Engine/OptionInfo.cpp
+++ b/src/Engine/OptionInfo.cpp
@@ -17,8 +17,13 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "OptionInfo.h"
-#include <algorithm>
 #include "Exception.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <algorithm>
+#include <sstream>
+#include <iomanip>
 
 namespace OpenXcom
 {
@@ -107,8 +112,7 @@ void OptionInfo::load(const YAML::Node &node) const
  * (eg. for command-line options).
  * @param map Options map.
  */
-void OptionInfo::load(const std::map<std::string, std::string> &map) const
-{
+void OptionInfo::load(const std::map<std::string, std::string> &map) const{
 	std::string id = _id;
 	std::transform(id.begin(), id.end(), id.begin(), ::tolower);
 	std::map<std::string, std::string>::const_iterator it = map.find(id);

--- a/src/Engine/OptionInfo.h
+++ b/src/Engine/OptionInfo.h
@@ -17,10 +17,19 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
+#include <SDL_keyboard.h> //For SDLKey.
+
 #include <string>
 #include <map>
-#include <SDL.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -19,21 +19,26 @@
 
 #include "Options.h"
 #include "../version.h"
+#include "Exception.h"
+#include "Logger.h"
+#include "CrossPlatform.h"
+#include "FileMap.h"
+#include "Screen.h"
+
 #include <SDL.h>
 #include <SDL_keysym.h>
 #include <SDL_mixer.h>
+#include <SDL_keyboard.h> //For SDLKey, transitively provided to Options.inc.h.
+#include <SDL_video.h> //For SDL_GrabMode, transitively provided to Options.inc.h.
+
+#include <yaml-cpp/yaml.h>
+
 #include <stdio.h>
 #include <iostream>
 #include <map>
 #include <sstream>
 #include <fstream>
 #include <algorithm>
-#include <yaml-cpp/yaml.h>
-#include "Exception.h"
-#include "Logger.h"
-#include "CrossPlatform.h"
-#include "FileMap.h"
-#include "Screen.h"
 
 namespace OpenXcom
 {

--- a/src/Engine/Options.h
+++ b/src/Engine/Options.h
@@ -17,11 +17,12 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <SDL.h>
-#include <string>
-#include <vector>
+#include <SDL_video.h> //For SDL_GrabMode, transitively provided to Options.inc.h.
 #include "OptionInfo.h"
 #include "ModInfo.h"
+
+#include <string>
+#include <vector>
 
 namespace OpenXcom
 {

--- a/src/Engine/Palette.h
+++ b/src/Engine/Palette.h
@@ -17,8 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <SDL_video.h> //For SDL_Color.
+
 #include <string>
-#include <SDL.h>
 
 namespace OpenXcom
 {

--- a/src/Engine/RNG-ETI.cpp
+++ b/src/Engine/RNG-ETI.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010-2016 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "RNG.ipp"
+
+#include "../Battlescape/Position.h"
+
+#include <vector>
+#include <algorithm>
+
+/*
+* ETI stands for Externalized Template Instantiation.
+*/
+
+namespace OpenXcom
+{
+namespace RNG
+{
+
+template void shuffle<std::vector<OpenXcom::Position, std::allocator<OpenXcom::Position> > >(std::vector<OpenXcom::Position, std::allocator<OpenXcom::Position> >&);
+
+
+}
+}

--- a/src/Engine/RNG.cpp
+++ b/src/Engine/RNG.cpp
@@ -64,7 +64,7 @@ uint64_t getSeed()
  * Changes the current seed in use by the generator.
  * @param n New seed.
  */
-void setSeed(uint64_t n)
+void setSeed(const uint64_t n)
 {
 	x = n;
 }
@@ -75,7 +75,7 @@ void setSeed(uint64_t n)
  * @param max Maximum number, inclusive.
  * @return Generated number.
  */
-int generate(int min, int max)
+int generate(const int min,const int max)
 {
 	uint64_t num = next();
 	return (int)(num % (max - min + 1) + min);
@@ -87,9 +87,9 @@ int generate(int min, int max)
  * @param max Maximum number.
  * @return Generated number.
  */
-double generate(double min, double max)
+double generate(const double min,const double max)
 {
-	double num = next();
+	const double num = next();
 	return (num / ((double)UINT64_MAX / (max - min)) + min);
 }
 
@@ -100,7 +100,7 @@ double generate(double min, double max)
  * @param max Maximum number, inclusive.
  * @return Generated number.
  */
-int seedless(int min, int max)
+int seedless(const int min,const int max)
 {
 	return (rand() % (max - min + 1) + min);
 }
@@ -147,7 +147,7 @@ double boxMuller(double m, double s)
  * @param value Value percentage (0-100%)
  * @return True if the chance succeeded.
  */
-bool percent(int value)
+bool percent(const int value)
 {
 	return (generate(0, 99) < value);
 }
@@ -157,12 +157,12 @@ bool percent(int value)
  * @param max Maximum number, exclusive.
  * @return Generated number.
  */
-int generateEx(int max)
+int generateEx(const int max)
 {
 	uint64_t num = next();
 	return (int)(num % max);
 }
 
-}
 
+}
 }

--- a/src/Engine/RNG.h
+++ b/src/Engine/RNG.h
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <algorithm>
 #define __STDC_LIMIT_MACROS
 #include <stdint.h>
 
@@ -34,29 +33,26 @@ namespace RNG
 	/// Gets the seed in use.
 	uint64_t getSeed();
 	/// Sets the seed in use.
-	void setSeed(uint64_t n);
+	void setSeed(const uint64_t n);
 	/// Generates a random integer number, inclusive.
-	int generate(int min, int max);
+	int generate(const int min,const int max);
 	/// Generates a random floating-point number.
-	double generate(double min, double max);
+	double generate(const double min,const double max);
 	/// Generates a random integer number, inclusive (non-seed version).
-	int seedless(int min, int max);
+	int seedless(const int min,const int max);
 	/// Get normally distributed value.
-	double boxMuller(double m = 0, double s = 1);
+	double boxMuller(const double m = 0,const double s = 1);
 	/// Generates a percentage chance.
-	bool percent(int value);
+	bool percent(const int value);
 	/// Generates a random integer number, exclusive.
-	int generateEx(int max);
+	int generateEx(const int max);
 	/// Shuffles a list randomly.
 	/**
 	 * Randomly changes the orders of the elements in a list.
 	 * @param list The container to randomize.
 	 */
 	template <typename T>
-	void shuffle(T &list)
-	{
-		std::random_shuffle(list.begin(), list.end(), generateEx);
-	}
+	void shuffle(T &list);
 }
 
 }

--- a/src/Engine/RNG.hpp
+++ b/src/Engine/RNG.hpp
@@ -1,0 +1,31 @@
+#pragma once
+/*
+ * Copyright 2010-2016 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+
+namespace OpenXcom
+{
+namespace RNG
+{
+
+template <typename T> void shuffle(T &list);
+
+}
+}

--- a/src/Engine/RNG.ipp
+++ b/src/Engine/RNG.ipp
@@ -1,0 +1,41 @@
+#pragma once
+/*
+ * Copyright 2010-2016 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "RNG.hpp"
+/*
+* Weird case; the .h should be enough by normal expectations.
+* This was done this way to allow the original .cpp to remain in place
+* as closely to the original as possible.
+*/
+#include "RNG.h"
+
+#include <algorithm>
+
+namespace OpenXcom
+{
+namespace RNG
+{
+
+template <typename T> void shuffle(T &list)
+{
+        std::random_shuffle(list.begin(), list.end(), generateEx);
+}
+
+}
+}

--- a/src/Engine/Screen.h
+++ b/src/Engine/Screen.h
@@ -1,4 +1,4 @@
-	#pragma once
+#pragma once
 /*
  * Copyright 2010-2016 OpenXcom Developers.
  *
@@ -17,9 +17,11 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <SDL.h>
-#include <string>
 #include "OpenGL.h"
+
+#include <string>
+
+#include <SDL_video.h> //For SDL_Surface, SDL_Rect.
 
 namespace OpenXcom
 {

--- a/src/Engine/State.h
+++ b/src/Engine/State.h
@@ -19,7 +19,8 @@
  */
 #include <vector>
 #include <string>
-#include <SDL.h>
+
+#include <SDL_video.h>  // For SDL_color.
 
 namespace OpenXcom
 {

--- a/src/Engine/Surface.h
+++ b/src/Engine/Surface.h
@@ -17,8 +17,10 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <SDL.h>
 #include <string>
+
+#include <SDL_stdinc.h>
+#include <SDL_video.h>   //For SDL_Surface, SDL_Rect
 
 namespace OpenXcom
 {

--- a/src/Engine/SurfaceSet.h
+++ b/src/Engine/SurfaceSet.h
@@ -19,7 +19,8 @@
  */
 #include <map>
 #include <string>
-#include <SDL.h>
+
+#include <SDL_video.h> // For SDL_Color.
 
 namespace OpenXcom
 {

--- a/src/Engine/Timer.cpp
+++ b/src/Engine/Timer.cpp
@@ -20,12 +20,14 @@
 #include "Game.h"
 #include "Options.h"
 
+#include <SDL_timer.h> //For SDL_GetTicks().
+
 namespace OpenXcom
 {
-	
+
 namespace
 {
-	
+
 const Uint32 accurate = 4;
 Uint32 slowTick()
 {
@@ -40,7 +42,7 @@ Uint32 slowTick()
 }//namespace
 
 Uint32 Timer::gameSlowSpeed = 1;
-int Timer::maxFrameSkip = 8; // this is a pretty good default at 60FPS. 
+int Timer::maxFrameSkip = 8; // this is a pretty good default at 60FPS.
 
 
 /**

--- a/src/Engine/Timer.h
+++ b/src/Engine/Timer.h
@@ -17,9 +17,10 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <SDL.h>
 #include "State.h"
 #include "Surface.h"
+
+#include <SDL_stdinc.h>
 
 namespace OpenXcom
 {
@@ -37,7 +38,7 @@ class Timer
 public:
 	static int maxFrameSkip;
 	static Uint32 gameSlowSpeed;
-	
+
 private:
 	Uint32 _start;
 	Uint32 _frameSkipStart;

--- a/src/Geoscape/Globe.cpp
+++ b/src/Geoscape/Globe.cpp
@@ -17,7 +17,6 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "Globe.h"
-#include <algorithm>
 #include "../fmath.h"
 #include "../Engine/Action.h"
 #include "../Engine/SurfaceSet.h"
@@ -53,6 +52,10 @@
 #include "../Mod/RuleGlobe.h"
 #include "../Interface/Cursor.h"
 #include "../Engine/Screen.h"
+
+#include <SDL_timer.h> //For SDL_GetTicks().
+
+#include <algorithm>
 
 namespace OpenXcom
 {

--- a/src/Menu/LoadGameState.cpp
+++ b/src/Menu/LoadGameState.cpp
@@ -17,7 +17,6 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "LoadGameState.h"
-#include <sstream>
 #include "../Engine/Logger.h"
 #include "../Savegame/SavedBattleGame.h"
 #include "../Engine/Game.h"
@@ -34,6 +33,10 @@
 #include "../Engine/Sound.h"
 #include "../Mod/RuleInterface.h"
 #include "StatisticsState.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <sstream>
 
 namespace OpenXcom
 {

--- a/src/Menu/LoadGameState.h
+++ b/src/Menu/LoadGameState.h
@@ -18,10 +18,12 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "../Engine/State.h"
-#include <SDL.h>
-#include <string>
 #include "OptionsBaseState.h"
 #include "../Savegame/SavedGame.h"
+
+#include <SDL_video.h> //For SDL_Color.
+
+#include <string>
 
 namespace OpenXcom
 {

--- a/src/Menu/SaveGameState.cpp
+++ b/src/Menu/SaveGameState.cpp
@@ -17,7 +17,6 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "SaveGameState.h"
-#include <sstream>
 #include "../Engine/Logger.h"
 #include "../Engine/Game.h"
 #include "../Engine/Exception.h"
@@ -31,6 +30,10 @@
 #include "../Savegame/SavedGame.h"
 #include "../Mod/Mod.h"
 #include "../Mod/RuleInterface.h"
+
+#include <sstream>
+
+#include <yaml-cpp/yaml.h>
 
 namespace OpenXcom
 {

--- a/src/Menu/SaveGameState.h
+++ b/src/Menu/SaveGameState.h
@@ -18,10 +18,12 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "../Engine/State.h"
-#include <SDL.h>
-#include <string>
 #include "OptionsBaseState.h"
 #include "../Savegame/SavedGame.h"
+
+#include <SDL_video.h> //For SDL_Color.
+
+#include <string>
 
 namespace OpenXcom
 {

--- a/src/Menu/StartState.cpp
+++ b/src/Menu/StartState.cpp
@@ -38,6 +38,8 @@
 #include <SDL_mixer.h>
 #include <SDL_thread.h>
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Menu/StartState.h
+++ b/src/Menu/StartState.h
@@ -18,6 +18,9 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "../Engine/State.h"
+
+#include <SDL_thread.h> //For SDL_Thread.
+
 #include <sstream>
 
 namespace OpenXcom

--- a/src/Mod/AlienDeployment.cpp
+++ b/src/Mod/AlienDeployment.cpp
@@ -18,6 +18,8 @@
  */
 #include "AlienDeployment.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace YAML
 {
 	template<>

--- a/src/Mod/AlienDeployment.h
+++ b/src/Mod/AlienDeployment.h
@@ -17,11 +17,20 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <vector>
-#include <string>
-#include <yaml-cpp/yaml.h>
 #include "Mod.h"
 #include "../Savegame/WeightedOptions.h"
+
+#include <vector>
+#include <string>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/AlienRace.cpp
+++ b/src/Mod/AlienRace.cpp
@@ -18,6 +18,8 @@
  */
 #include "AlienRace.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/AlienRace.h
+++ b/src/Mod/AlienRace.h
@@ -19,7 +19,15 @@
  */
 #include <string>
 #include <vector>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 enum AlienRank{AR_HUMAN = -1, AR_COMMANDER, AR_LEADER, AR_ENGINEER, AR_MEDIC, AR_NAVIGATOR, AR_SOLDIER, AR_TERRORIST, AR_TERRORIST2};
 

--- a/src/Mod/Armor.cpp
+++ b/src/Mod/Armor.cpp
@@ -17,6 +17,9 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "Armor.h"
+#include "Unit.hpp"
+
+#include <yaml-cpp/yaml.h>
 
 namespace OpenXcom
 {

--- a/src/Mod/Armor.h
+++ b/src/Mod/Armor.h
@@ -17,11 +17,20 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <string>
-#include <vector>
-#include <yaml-cpp/yaml.h>
 #include "MapData.h"
 #include "Unit.h"
+
+#include <string>
+#include <vector>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/ArticleDefinition.cpp
+++ b/src/Mod/ArticleDefinition.cpp
@@ -19,6 +19,8 @@
 
 #include "ArticleDefinition.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace YAML
 {
 	template<>

--- a/src/Mod/ArticleDefinition.h
+++ b/src/Mod/ArticleDefinition.h
@@ -19,7 +19,15 @@
  */
 #include <string>
 #include <vector>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/ExtraSounds.cpp
+++ b/src/Mod/ExtraSounds.cpp
@@ -19,6 +19,8 @@
 
 #include "ExtraSounds.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/ExtraSounds.h
+++ b/src/Mod/ExtraSounds.h
@@ -22,6 +22,7 @@
 * we require in member function definitions.
 */
 #include <map>
+#include <string>
 
 namespace YAML
 {

--- a/src/Mod/ExtraSounds.h
+++ b/src/Mod/ExtraSounds.h
@@ -17,7 +17,16 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+#include <map>
+
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/ExtraSprites.cpp
+++ b/src/Mod/ExtraSprites.cpp
@@ -19,6 +19,8 @@
 
 #include "ExtraSprites.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/ExtraSprites.h
+++ b/src/Mod/ExtraSprites.h
@@ -22,6 +22,7 @@
 * we require in member function definitions.
 */
 #include <map>
+#include <string>
 
 namespace YAML
 {

--- a/src/Mod/ExtraSprites.h
+++ b/src/Mod/ExtraSprites.h
@@ -17,7 +17,16 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+#include <map>
+
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/ExtraStrings.cpp
+++ b/src/Mod/ExtraStrings.cpp
@@ -19,6 +19,8 @@
 
 #include "ExtraStrings.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/ExtraStrings.h
+++ b/src/Mod/ExtraStrings.h
@@ -17,9 +17,17 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
 #include <string>
 #include <map>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/MCDPatch.cpp
+++ b/src/Mod/MCDPatch.cpp
@@ -20,6 +20,8 @@
 #include "MapDataSet.h"
 #include "MapData.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/MCDPatch.h
+++ b/src/Mod/MCDPatch.h
@@ -18,7 +18,16 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <string>
-#include <yaml-cpp/yaml.h>
+#include <vector>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/MapBlock.cpp
+++ b/src/Mod/MapBlock.cpp
@@ -17,10 +17,15 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "MapBlock.h"
-#include <sstream>
-#include <algorithm>
 #include "../Battlescape/Position.h"
 #include "../Engine/Exception.h"
+
+#include "../Battlescape/Position.hpp"
+
+#include "yaml-cpp/yaml.h"
+
+#include <sstream>
+#include <algorithm>
 
 namespace OpenXcom
 {
@@ -80,6 +85,7 @@ void MapBlock::load(const YAML::Node &node)
 			_revealedFloors.push_back(map.as<int>(0));
 		}
 	}
+
 	_items = node["items"].as< std::map<std::string, std::vector<Position> > >(_items);
 }
 

--- a/src/Mod/MapBlock.h
+++ b/src/Mod/MapBlock.h
@@ -19,7 +19,16 @@
  */
 #include <string>
 #include <vector>
-#include <yaml-cpp/yaml.h>
+#include <map>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/MapDataSet.cpp
+++ b/src/Mod/MapDataSet.cpp
@@ -18,11 +18,14 @@
  */
 #include "MapDataSet.h"
 #include "MapData.h"
-#include <fstream>
 #include <SDL_endian.h>
 #include "../Engine/Exception.h"
 #include "../Engine/SurfaceSet.h"
 #include "../Engine/FileMap.h"
+
+#include <fstream>
+
+#include <yaml-cpp/yaml.h>
 
 namespace OpenXcom
 {

--- a/src/Mod/MapDataSet.h
+++ b/src/Mod/MapDataSet.h
@@ -17,10 +17,19 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <SDL.h>
+
 #include <string>
 #include <vector>
-#include <SDL.h>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/MapScript.cpp
+++ b/src/Mod/MapScript.cpp
@@ -22,6 +22,7 @@
 #include "../Engine/RNG.h"
 #include "../Engine/Exception.h"
 
+#include <algorithm>
 
 namespace OpenXcom
 {

--- a/src/Mod/MapScript.h
+++ b/src/Mod/MapScript.h
@@ -17,12 +17,20 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <vector>
-#include <string>
-#include <yaml-cpp/yaml.h>
 #include <SDL_video.h>
 #include "RuleTerrain.h"
 #include "MapBlock.h"
+#include <vector>
+#include <string>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -17,15 +17,25 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <map>
-#include <vector>
-#include <string>
-#include <SDL.h>
-#include <yaml-cpp/yaml.h>
 #include "../Engine/Options.h"
 #include "../Savegame/GameTime.h"
 #include "Unit.h"
 #include "RuleAlienMission.h"
+
+#include <SDL_video.h> //For SDL_Color.
+
+#include <map>
+#include <vector>
+#include <string>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {
@@ -137,7 +147,7 @@ private:
 	int _costEngineer, _costScientist, _timePersonnel, _initialFunding, _turnAIUseGrenade, _turnAIUseBlaster, _defeatScore, _defeatFunds;
 	std::pair<std::string, int> _alienFuel;
 	std::string _fontName, _finalResearch;
-	YAML::Node _startingBase;
+	YAML::Node *_startingBase;
 	GameTime _startingTime;
 	StatAdjustment _statAdjustment[5];
 

--- a/src/Mod/Polygon.cpp
+++ b/src/Mod/Polygon.cpp
@@ -19,6 +19,10 @@
 #include "Polygon.h"
 #include "../fmath.h"
 
+#include <yaml-cpp/yaml.h>
+
+#include <vector>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/Polygon.h
+++ b/src/Mod/Polygon.h
@@ -18,7 +18,15 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <SDL_types.h>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/Polyline.cpp
+++ b/src/Mod/Polyline.cpp
@@ -19,6 +19,10 @@
 #include "Polyline.h"
 #include "../fmath.h"
 
+#include <vector>
+
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/Polyline.h
+++ b/src/Mod/Polyline.h
@@ -17,7 +17,15 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleAlienMission.cpp
+++ b/src/Mod/RuleAlienMission.cpp
@@ -19,6 +19,8 @@
 #include "RuleAlienMission.h"
 #include "../Savegame/WeightedOptions.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace YAML
 {
 	template<>

--- a/src/Mod/RuleAlienMission.h
+++ b/src/Mod/RuleAlienMission.h
@@ -20,7 +20,15 @@
 #include <vector>
 #include <map>
 #include <string>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleBaseFacility.cpp
+++ b/src/Mod/RuleBaseFacility.cpp
@@ -19,6 +19,8 @@
 #include "RuleBaseFacility.h"
 #include "Mod.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/RuleBaseFacility.h
+++ b/src/Mod/RuleBaseFacility.h
@@ -19,7 +19,15 @@
  */
 #include <string>
 #include <vector>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleCommendations.cpp
+++ b/src/Mod/RuleCommendations.cpp
@@ -19,6 +19,8 @@
 
 #include "RuleCommendations.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/RuleCommendations.h
+++ b/src/Mod/RuleCommendations.h
@@ -17,7 +17,18 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+#include <map>
+#include <vector>
+
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleCommendations.h
+++ b/src/Mod/RuleCommendations.h
@@ -24,6 +24,7 @@
 */
 #include <map>
 #include <vector>
+#include <string>
 
 namespace YAML
 {

--- a/src/Mod/RuleConverter.cpp
+++ b/src/Mod/RuleConverter.cpp
@@ -18,6 +18,8 @@
  */
 #include "RuleConverter.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/RuleConverter.h
+++ b/src/Mod/RuleConverter.h
@@ -20,7 +20,15 @@
 #include <map>
 #include <vector>
 #include <string>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleCountry.cpp
+++ b/src/Mod/RuleCountry.cpp
@@ -20,6 +20,8 @@
 #include "../Engine/RNG.h"
 #include "../fmath.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/RuleCountry.h
+++ b/src/Mod/RuleCountry.h
@@ -18,7 +18,16 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <string>
-#include <yaml-cpp/yaml.h>
+#include <vector>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleCraft.cpp
+++ b/src/Mod/RuleCraft.cpp
@@ -20,6 +20,8 @@
 #include "RuleTerrain.h"
 #include "Mod.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/RuleCraft.h
+++ b/src/Mod/RuleCraft.h
@@ -19,7 +19,15 @@
  */
 #include <vector>
 #include <string>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleCraftWeapon.cpp
+++ b/src/Mod/RuleCraftWeapon.cpp
@@ -19,6 +19,8 @@
 #include "RuleCraftWeapon.h"
 #include "Mod.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/RuleCraftWeapon.h
+++ b/src/Mod/RuleCraftWeapon.h
@@ -17,9 +17,17 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <string>
-#include <yaml-cpp/yaml.h>
 #include "../Savegame/CraftWeaponProjectile.h"
+#include <string>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleGlobe.cpp
+++ b/src/Mod/RuleGlobe.cpp
@@ -18,7 +18,6 @@
  */
 #include "RuleGlobe.h"
 #include <SDL_endian.h>
-#include <fstream>
 #include "../Engine/Exception.h"
 #include "Polygon.h"
 #include "Polyline.h"
@@ -27,6 +26,10 @@
 #include "../Geoscape/Globe.h"
 #include "../Engine/FileMap.h"
 #include "../fmath.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <fstream>
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleGlobe.h
+++ b/src/Mod/RuleGlobe.h
@@ -19,7 +19,17 @@
  */
 #include <list>
 #include <string>
-#include <yaml-cpp/yaml.h>
+#include <map>
+#include <vector>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleInterface.cpp
+++ b/src/Mod/RuleInterface.cpp
@@ -18,6 +18,9 @@
  */
 
 #include "RuleInterface.h"
+
+#include <yaml-cpp/yaml.h>
+
 #include <climits>
 
 namespace OpenXcom
@@ -104,3 +107,4 @@ const std::string &RuleInterface::getMusic() const
 }
 
 }
+

--- a/src/Mod/RuleInterface.h
+++ b/src/Mod/RuleInterface.h
@@ -19,7 +19,15 @@
  */
 #include <string>
 #include <map>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleInventory.cpp
+++ b/src/Mod/RuleInventory.cpp
@@ -17,8 +17,11 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "RuleInventory.h"
-#include <cmath>
 #include "RuleItem.h"
+
+#include <cmath>
+
+#include <yaml-cpp/yaml.h>
 
 namespace YAML
 {

--- a/src/Mod/RuleInventory.h
+++ b/src/Mod/RuleInventory.h
@@ -20,7 +20,15 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -23,6 +23,8 @@
 #include "../Engine/Surface.h"
 #include "Mod.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/RuleItem.h
+++ b/src/Mod/RuleItem.h
@@ -19,7 +19,15 @@
  */
 #include <string>
 #include <vector>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleManufacture.cpp
+++ b/src/Mod/RuleManufacture.cpp
@@ -18,6 +18,8 @@
  */
 #include "RuleManufacture.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 /**

--- a/src/Mod/RuleManufacture.h
+++ b/src/Mod/RuleManufacture.h
@@ -19,7 +19,16 @@
  */
 #include <string>
 #include <map>
-#include <yaml-cpp/yaml.h>
+#include <vector>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleMissionScript.cpp
+++ b/src/Mod/RuleMissionScript.cpp
@@ -19,6 +19,8 @@
 #include "RuleMissionScript.h"
 #include "../Engine/Exception.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/RuleMissionScript.h
+++ b/src/Mod/RuleMissionScript.h
@@ -17,11 +17,21 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include "../Savegame/WeightedOptions.h"
+
 #include <string>
 #include <vector>
 #include <map>
-#include <yaml-cpp/yaml.h>
-#include "../Savegame/WeightedOptions.h"
+#include <set>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleMusic.cpp
+++ b/src/Mod/RuleMusic.cpp
@@ -18,6 +18,9 @@
  */
 
 #include "RuleMusic.h"
+
+#include <yaml-cpp/yaml.h>
+
 #include <climits>
 
 namespace OpenXcom
@@ -30,7 +33,7 @@ namespace OpenXcom
  * also, 0.76 is roughly optimal for all the TFTD tracks.
  * @param type String defining the type.
  */
-RuleMusic::RuleMusic(const std::string &type) : _type(type), _catPos(INT_MAX), _normalization(0.76f) 
+RuleMusic::RuleMusic(const std::string &type) : _type(type), _catPos(INT_MAX), _normalization(0.76f)
 {
 }
 

--- a/src/Mod/RuleMusic.h
+++ b/src/Mod/RuleMusic.h
@@ -18,7 +18,15 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <string>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleRegion.cpp
+++ b/src/Mod/RuleRegion.cpp
@@ -16,10 +16,15 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <assert.h>
 #include "RuleRegion.h"
 #include "City.h"
 #include "../Engine/RNG.h"
+
+#include "RuleRegion.hpp"
+
+#include <assert.h>
+
+#include <yaml-cpp/yaml.h>
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleRegion.h
+++ b/src/Mod/RuleRegion.h
@@ -17,11 +17,20 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <string>
-#include <vector>
-#include <yaml-cpp/yaml.h>
 #include "../fmath.h"
 #include "../Savegame/WeightedOptions.h"
+
+#include <string>
+#include <vector>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {
@@ -122,57 +131,4 @@ public:
 	const std::vector<MissionZone> &getMissionZones() const;
 };
 
-}
-
-namespace YAML
-{
-	template<>
-	struct convert<OpenXcom::MissionArea>
-	{
-		static Node encode(const OpenXcom::MissionArea& rhs)
-		{
-			Node node;
-			node.push_back(rhs.lonMin / M_PI * 180.0);
-			node.push_back(rhs.lonMax / M_PI * 180.0);
-			node.push_back(rhs.latMin / M_PI * 180.0);
-			node.push_back(rhs.latMax / M_PI * 180.0);
-			return node;
-		}
-
-		static bool decode(const Node& node, OpenXcom::MissionArea& rhs)
-		{
-			if (!node.IsSequence() || node.size() < 4)
-				return false;
-
-			rhs.lonMin = node[0].as<double>() * M_PI / 180.0;
-			rhs.lonMax = node[1].as<double>() * M_PI / 180.0;
-			rhs.latMin = node[2].as<double>() * M_PI / 180.0;
-			rhs.latMax = node[3].as<double>() * M_PI / 180.0;
-			if (rhs.latMin > rhs.latMax)
-				std::swap(rhs.latMin, rhs.latMax);
-			if (node.size() >= 5) rhs.texture = node[4].as<int>();
-			if (node.size() >= 6) rhs.name = node[5].as<std::string>();
-			return true;
-		}
-	};
-
-	template<>
-	struct convert<OpenXcom::MissionZone>
-	{
-		static Node encode(const OpenXcom::MissionZone& rhs)
-		{
-			Node node;
-			node = rhs.areas;
-			return node;
-		}
-
-		static bool decode(const Node& node, OpenXcom::MissionZone& rhs)
-		{
-			if (!node.IsSequence())
-				return false;
-
-			rhs.areas = node.as< std::vector<OpenXcom::MissionArea> >(rhs.areas);
-			return true;
-		}
-	};
 }

--- a/src/Mod/RuleRegion.hpp
+++ b/src/Mod/RuleRegion.hpp
@@ -1,0 +1,75 @@
+#pragma once
+/*
+ * Copyright 2010-2016 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "RuleRegion.h"
+
+#include <yaml-cpp/yaml.h>
+
+namespace YAML
+{
+	template<>
+	struct convert<OpenXcom::MissionArea>
+	{
+		static Node encode(const OpenXcom::MissionArea& rhs)
+		{
+			Node node;
+			node.push_back(rhs.lonMin / M_PI * 180.0);
+			node.push_back(rhs.lonMax / M_PI * 180.0);
+			node.push_back(rhs.latMin / M_PI * 180.0);
+			node.push_back(rhs.latMax / M_PI * 180.0);
+			return node;
+		}
+
+		static bool decode(const Node& node, OpenXcom::MissionArea& rhs)
+		{
+			if (!node.IsSequence() || node.size() < 4)
+				return false;
+
+			rhs.lonMin = node[0].as<double>() * M_PI / 180.0;
+			rhs.lonMax = node[1].as<double>() * M_PI / 180.0;
+			rhs.latMin = node[2].as<double>() * M_PI / 180.0;
+			rhs.latMax = node[3].as<double>() * M_PI / 180.0;
+			if (rhs.latMin > rhs.latMax)
+				std::swap(rhs.latMin, rhs.latMax);
+			if (node.size() >= 5) rhs.texture = node[4].as<int>();
+			if (node.size() >= 6) rhs.name = node[5].as<std::string>();
+			return true;
+		}
+	};
+
+	template<>
+	struct convert<OpenXcom::MissionZone>
+	{
+		static Node encode(const OpenXcom::MissionZone& rhs)
+		{
+			Node node;
+			node = rhs.areas;
+			return node;
+		}
+
+		static bool decode(const Node& node, OpenXcom::MissionZone& rhs)
+		{
+			if (!node.IsSequence())
+				return false;
+
+			rhs.areas = node.as< std::vector<OpenXcom::MissionArea> >(rhs.areas);
+			return true;
+		}
+	};
+}

--- a/src/Mod/RuleResearch.cpp
+++ b/src/Mod/RuleResearch.cpp
@@ -19,6 +19,8 @@
 #include "RuleResearch.h"
 #include "../Engine/Exception.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/RuleResearch.h
+++ b/src/Mod/RuleResearch.h
@@ -19,7 +19,15 @@
  */
 #include <string>
 #include <vector>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleSoldier.cpp
+++ b/src/Mod/RuleSoldier.cpp
@@ -21,6 +21,10 @@
 #include "SoldierNamePool.h"
 #include "../Engine/FileMap.h"
 
+#include "Unit.hpp"
+
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/RuleSoldier.h
+++ b/src/Mod/RuleSoldier.h
@@ -17,9 +17,18 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <string>
-#include <yaml-cpp/yaml.h>
 #include "Unit.h"
+
+#include <string>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleTerrain.cpp
+++ b/src/Mod/RuleTerrain.cpp
@@ -23,6 +23,8 @@
 #include "../Engine/RNG.h"
 #include "Mod.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/RuleTerrain.h
+++ b/src/Mod/RuleTerrain.h
@@ -17,10 +17,19 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include "MapBlock.h"
+
 #include <vector>
 #include <string>
-#include <yaml-cpp/yaml.h>
-#include "MapBlock.h"
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleUfo.cpp
+++ b/src/Mod/RuleUfo.cpp
@@ -19,6 +19,8 @@
 #include "RuleUfo.h"
 #include "RuleTerrain.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Mod/RuleUfo.h
+++ b/src/Mod/RuleUfo.h
@@ -18,7 +18,15 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <string>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleVideo.cpp
+++ b/src/Mod/RuleVideo.cpp
@@ -17,8 +17,11 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "RuleVideo.h"
-#include <climits>
 #include "../Engine/Screen.h"
+
+#include <climits>
+
+#include <yaml-cpp/yaml.h>
 
 namespace OpenXcom
 {

--- a/src/Mod/RuleVideo.h
+++ b/src/Mod/RuleVideo.h
@@ -17,11 +17,20 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
+#include "../Interface/Text.h"
+
 #include <vector>
 #include <string>
 #include <map>
-#include "../Interface/Text.h"
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/SoldierNamePool.cpp
+++ b/src/Mod/SoldierNamePool.cpp
@@ -17,10 +17,13 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "SoldierNamePool.h"
-#include <sstream>
 #include "../Savegame/Soldier.h"
 #include "../Engine/RNG.h"
 #include "../Engine/Language.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <sstream>
 
 namespace OpenXcom
 {

--- a/src/Mod/SoundDefinition.cpp
+++ b/src/Mod/SoundDefinition.cpp
@@ -18,9 +18,11 @@
  */
 #include "SoundDefinition.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
-	
+
 SoundDefinition::SoundDefinition(const std::string &type) : _type(type)
 {
 }

--- a/src/Mod/SoundDefinition.h
+++ b/src/Mod/SoundDefinition.h
@@ -17,9 +17,17 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
 #include <vector>
 #include <string>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Mod/StatString.cpp
+++ b/src/Mod/StatString.cpp
@@ -17,8 +17,11 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "StatString.h"
-#include <vector>
 #include "../Engine/Language.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <vector>
 
 namespace OpenXcom
 {

--- a/src/Mod/StatString.h
+++ b/src/Mod/StatString.h
@@ -21,6 +21,7 @@
 #include "StatStringCondition.h"
 
 #include <map>
+#include <string>
 
 /*
 * Instead of pulling in yaml-cpp, just pre-declare the require Node

--- a/src/Mod/StatString.h
+++ b/src/Mod/StatString.h
@@ -17,9 +17,19 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
 #include "Unit.h"
 #include "StatStringCondition.h"
+
+#include <map>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {
@@ -31,13 +41,13 @@ namespace OpenXcom
 
 /*
 NameStats in XCOMUTIL.CFG:
- 
+
 StatStrings, which were added in version 7.2, are used for automatically
 renaming soldiers.  They are case sensitive and they are processed in the
 order in which they are specified.  The format of these StatStrings is:
- 
+
   string statid:[lower]-[upper] [statid:[lower]-[upper] [...] ]
- 
+
   where string = string to add to name.  If length == 1, then the strings
 				 accumulate.  Otherwise, success ends the search.  All
 				 single character strings SHOULD come last, but that is
@@ -57,18 +67,18 @@ order in which they are specified.  The format of these StatStrings is:
 				 t = throwing accuracy
 		 lower = lower limit of stat (inclusive), defaults to 0
 		 upper = upper limit of stat (inclusive), defaults to 255
- 
+
 Stat ranges are ANDed together when testing for success.  To achieve a logical
 OR, list the same string more than once.  For example, Wimp b:0-10 and
 Wimp s:0-20 would designate a Wimp as either someone who is not brave or
 someone who is very weak.  By arranging the string properly, you can put all
 of your strengths before your weaknesses or list the stats in order, which is
-the default.  
- 
+the default.
+
 You may specify as many ranges for one StatString as you like, up to the limit
 of the memory I have allocated.  There is enough space for a total of more
 than 600 ranges to be defined.  Let me know if you need more.
- 
+
 The # character is a special string that will be replaced by numbers
 corresponding to the values of the statistics listed, divided by 10.  For
 example, # fr will generate the string 74 if the firing accuracy value is 72
@@ -78,7 +88,7 @@ example P p:0-255 followed by # p would generate P6 for a Psi Strength of 64,
 assuming that Psi Skill is non-zero.  Psi/MC Strength is always reported as
 zero unless Psi/MC Skill is greater than 0.  To test Psi/MC Strength without
 checking the Psi/MC Skill, use the q statid.
- 
+
 Since strings longer than one character will terminate the checking, these
 strings are normally listed first.  More stats accumulating after Snpr would
 ruin the usefulness of Snpr as an equipment type.  However, if you wanted to
@@ -88,12 +98,12 @@ example, if you wanted to know that your Snpr had a very low Psi/MC Strength
 and had little resistance to alien control, you could put x p:0-30 or x q:0-30
 at the start of the list to produce Snpr or xSnpr as your final code. This is
 what I did in the default case.  See the XCOMUTIL.CFG file for examples.
- 
+
 If the resulting string exceeds the maximum length for a name, the first
 name will be replaced by an initial.  If the string is still too long, the
 first name will be removed entirely.  If this string is still too long, no
-change will be made.  
- 
+change will be made.
+
 If / is used as a statid, it indicates that this is the last required name
 stat.  That is, if the name stats make the name too long, the total string
 will be reduced to the size at the moment that the / statid was

--- a/src/Mod/Texture.cpp
+++ b/src/Mod/Texture.cpp
@@ -20,6 +20,8 @@
 #include "../Savegame/Target.h"
 #include "../Engine/RNG.h"
 
+#include "Texture.hpp"
+
 namespace OpenXcom
 {
 

--- a/src/Mod/Texture.h
+++ b/src/Mod/Texture.h
@@ -18,9 +18,19 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "../fmath.h"
+
 #include <string>
 #include <vector>
-#include <yaml-cpp/yaml.h>
+#include <map>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {
@@ -62,43 +72,4 @@ public:
 	std::string getRandomDeployment() const;
 };
 
-}
-
-namespace YAML
-{
-	template<>
-	struct convert < OpenXcom::TerrainCriteria >
-	{
-		static Node encode(const OpenXcom::TerrainCriteria& rhs)
-		{
-			Node node;
-			node["name"] = rhs.name;
-			node["weight"] = rhs.weight;
-			std::vector<double> area;
-			area.push_back(rhs.lonMin);
-			area.push_back(rhs.lonMax);
-			area.push_back(rhs.latMin);
-			area.push_back(rhs.latMax);
-			node["area"] = area;
-			return node;
-		}
-
-		static bool decode(const Node& node, OpenXcom::TerrainCriteria& rhs)
-		{
-			if (!node.IsMap())
-				return false;
-
-			rhs.name = node["name"].as<std::string>(rhs.name);
-			rhs.weight = node["weight"].as<int>(rhs.weight);
-			if (node["area"])
-			{
-				std::vector<double> area = node["area"].as< std::vector<double> >();
-				rhs.lonMin = area[0] * M_PI / 180.0;
-				rhs.lonMax = area[1] * M_PI / 180.0;
-				rhs.latMin = area[2] * M_PI / 180.0;
-				rhs.latMax = area[3] * M_PI / 180.0;
-			}
-			return true;
-		}
-	};
 }

--- a/src/Mod/Texture.hpp
+++ b/src/Mod/Texture.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2010-2016 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "Texture.h"
+
+#include <yaml-cpp/yaml.h>
+
+namespace YAML
+{
+	template<>
+	struct convert < OpenXcom::TerrainCriteria >
+	{
+		static Node encode(const OpenXcom::TerrainCriteria& rhs)
+		{
+			Node node;
+			node["name"] = rhs.name;
+			node["weight"] = rhs.weight;
+			std::vector<double> area;
+			area.push_back(rhs.lonMin);
+			area.push_back(rhs.lonMax);
+			area.push_back(rhs.latMin);
+			area.push_back(rhs.latMax);
+			node["area"] = area;
+			return node;
+		}
+
+		static bool decode(const Node& node, OpenXcom::TerrainCriteria& rhs)
+		{
+			if (!node.IsMap())
+				return false;
+
+			rhs.name = node["name"].as<std::string>(rhs.name);
+			rhs.weight = node["weight"].as<int>(rhs.weight);
+			if (node["area"])
+			{
+				std::vector<double> area = node["area"].as< std::vector<double> >();
+				rhs.lonMin = area[0] * M_PI / 180.0;
+				rhs.lonMax = area[1] * M_PI / 180.0;
+				rhs.latMin = area[2] * M_PI / 180.0;
+				rhs.latMax = area[3] * M_PI / 180.0;
+			}
+			return true;
+		}
+	};
+}

--- a/src/Mod/UfoTrajectory.h
+++ b/src/Mod/UfoTrajectory.h
@@ -19,6 +19,7 @@
  */
 #include <vector>
 #include <string>
+
 #include <yaml-cpp/yaml.h>
 
 namespace OpenXcom

--- a/src/Mod/Unit.cpp
+++ b/src/Mod/Unit.cpp
@@ -20,6 +20,8 @@
 #include "../Engine/Exception.h"
 #include "Mod.h"
 
+#include "Unit.hpp"
+
 namespace OpenXcom
 {
 

--- a/src/Mod/Unit.h
+++ b/src/Mod/Unit.h
@@ -19,7 +19,15 @@
  */
 #include <string>
 #include <vector>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {
@@ -123,7 +131,7 @@ public:
 };
 
 }
-
+/*
 namespace YAML
 {
 	template<>
@@ -166,3 +174,4 @@ namespace YAML
 		}
 	};
 }
+*/

--- a/src/Mod/Unit.hpp
+++ b/src/Mod/Unit.hpp
@@ -1,0 +1,64 @@
+#pragma once
+/*
+ * Copyright 2010-2016 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "Unit.h"
+#include <yaml-cpp/yaml.h>
+
+namespace YAML
+{
+	template<>
+	struct convert<OpenXcom::UnitStats>
+	{
+		static Node encode(const OpenXcom::UnitStats& rhs)
+		{
+			Node node;
+			node["tu"] = rhs.tu;
+			node["stamina"] = rhs.stamina;
+			node["health"] = rhs.health;
+			node["bravery"] = rhs.bravery;
+			node["reactions"] = rhs.reactions;
+			node["firing"] = rhs.firing;
+			node["throwing"] = rhs.throwing;
+			node["strength"] = rhs.strength;
+			node["psiStrength"] = rhs.psiStrength;
+			node["psiSkill"] = rhs.psiSkill;
+			node["melee"] = rhs.melee;
+			return node;
+		}
+
+		static bool decode(const Node& node, OpenXcom::UnitStats& rhs)
+		{
+			if (!node.IsMap())
+				return false;
+
+			rhs.tu = node["tu"].as<int>(rhs.tu);
+			rhs.stamina = node["stamina"].as<int>(rhs.stamina);
+			rhs.health = node["health"].as<int>(rhs.health);
+			rhs.bravery = node["bravery"].as<int>(rhs.bravery);
+			rhs.reactions = node["reactions"].as<int>(rhs.reactions);
+			rhs.firing = node["firing"].as<int>(rhs.firing);
+			rhs.throwing = node["throwing"].as<int>(rhs.throwing);
+			rhs.strength = node["strength"].as<int>(rhs.strength);
+			rhs.psiStrength = node["psiStrength"].as<int>(rhs.psiStrength);
+			rhs.psiSkill = node["psiSkill"].as<int>(rhs.psiSkill);
+			rhs.melee = node["melee"].as<int>(rhs.melee);
+			return true;
+		}
+	};
+}

--- a/src/Savegame/AlienBase.cpp
+++ b/src/Savegame/AlienBase.cpp
@@ -19,6 +19,8 @@
 #include "AlienBase.h"
 #include "../Engine/Language.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/AlienBase.h
+++ b/src/Savegame/AlienBase.h
@@ -18,9 +18,18 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "Target.h"
-#include <string>
 #include "../Mod/AlienDeployment.h"
-#include <yaml-cpp/yaml.h>
+
+#include <string>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/AlienMission.h
+++ b/src/Savegame/AlienMission.h
@@ -18,7 +18,15 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <string>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/AlienStrategy.cpp
+++ b/src/Savegame/AlienStrategy.cpp
@@ -16,11 +16,14 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <assert.h>
 #include "AlienStrategy.h"
 #include "WeightedOptions.h"
 #include "../Mod/Mod.h"
 #include "../Mod/RuleRegion.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <assert.h>
 
 namespace OpenXcom
 {

--- a/src/Savegame/AlienStrategy.h
+++ b/src/Savegame/AlienStrategy.h
@@ -17,8 +17,16 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
 #include "WeightedOptions.h"
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/Base.cpp
+++ b/src/Savegame/Base.cpp
@@ -18,8 +18,6 @@
  */
 #include "Base.h"
 #include "../fmath.h"
-#include <stack>
-#include <algorithm>
 #include "BaseFacility.h"
 #include "../Mod/RuleBaseFacility.h"
 #include "Craft.h"
@@ -44,6 +42,11 @@
 #include "../Engine/Options.h"
 #include "../Mod/RuleSoldier.h"
 #include "../Engine/Logger.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <stack>
+#include <algorithm>
 
 namespace OpenXcom
 {

--- a/src/Savegame/Base.h
+++ b/src/Savegame/Base.h
@@ -20,7 +20,16 @@
 #include "Target.h"
 #include <string>
 #include <vector>
-#include <yaml-cpp/yaml.h>
+#include <list>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/BaseFacility.cpp
+++ b/src/Savegame/BaseFacility.cpp
@@ -20,6 +20,8 @@
 #include "../Mod/RuleBaseFacility.h"
 #include "Base.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/BaseFacility.h
+++ b/src/Savegame/BaseFacility.h
@@ -17,7 +17,15 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/BattleItem.cpp
+++ b/src/Savegame/BattleItem.cpp
@@ -22,6 +22,10 @@
 #include "../Mod/RuleItem.h"
 #include "../Mod/RuleInventory.h"
 
+#include "../Battlescape/Position.hpp"
+
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/BattleItem.h
+++ b/src/Savegame/BattleItem.h
@@ -17,7 +17,15 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -18,7 +18,6 @@
  */
 #include "BattleUnit.h"
 #include "BattleItem.h"
-#include <sstream>
 #include "../Engine/Surface.h"
 #include "../Engine/Language.h"
 #include "../Engine/Options.h"
@@ -37,6 +36,12 @@
 #include "SavedBattleGame.h"
 #include "BattleUnitStatistics.h"
 #include "../fmath.h"
+
+#include "../Battlescape/Position.hpp"
+
+#include <yaml-cpp/yaml.h>
+
+#include <sstream>
 
 namespace OpenXcom
 {
@@ -383,7 +388,8 @@ YAML::Node BattleUnit::save() const
 	node["genUnitArmor"] = _armor->getType();
 	node["faction"] = (int)_faction;
 	node["status"] = (int)_status;
-	node["position"] = _pos;
+	// HAX DO NOT COMMIT
+	//node["position"] = _pos;
 	node["direction"] = _direction;
 	node["directionTurret"] = _directionTurret;
 	node["tu"] = _tu;

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -17,9 +17,6 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <vector>
-#include <string>
-#include <yaml-cpp/yaml.h>
 #include "../Battlescape/Position.h"
 #include "../Battlescape/BattlescapeGame.h"
 #include "../Mod/RuleItem.h"
@@ -27,6 +24,18 @@
 #include "../Mod/MapData.h"
 #include "Soldier.h"
 #include "BattleItem.h"
+
+#include <vector>
+#include <string>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/BattleUnitStatistics.h
+++ b/src/Savegame/BattleUnitStatistics.h
@@ -16,11 +16,24 @@
 * You should have received a copy of the GNU General Public License
 * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <string>
-#include <sstream>
-#include <yaml-cpp/yaml.h>
 #include "BattleUnit.h"
 #include "../Engine/Language.h"
+
+#include <string>
+#include <sstream>
+
+/*
+* TODO: separate file by classes, then extract the definitions.
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+/*namespace YAML
+{
+class Node;
+}
+*/
+
+#include <yaml-cpp/yaml.h>
 
 namespace OpenXcom
 {

--- a/src/Savegame/Country.cpp
+++ b/src/Savegame/Country.cpp
@@ -20,6 +20,8 @@
 #include "../Mod/RuleCountry.h"
 #include "../Engine/RNG.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/Country.h
+++ b/src/Savegame/Country.h
@@ -18,7 +18,15 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <vector>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/Craft.cpp
+++ b/src/Savegame/Craft.cpp
@@ -37,6 +37,8 @@
 #include "../Mod/AlienDeployment.h"
 #include "../Engine/Logger.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/Craft.h
+++ b/src/Savegame/Craft.h
@@ -18,6 +18,7 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "MovingTarget.h"
+
 #include <utility>
 #include <vector>
 #include <string>

--- a/src/Savegame/CraftWeapon.cpp
+++ b/src/Savegame/CraftWeapon.cpp
@@ -17,12 +17,15 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "CraftWeapon.h"
-#include <cmath>
-#include <algorithm>
 #include "../Mod/RuleCraftWeapon.h"
 #include "../Mod/Mod.h"
 #include "../Mod/RuleItem.h"
 #include "CraftWeaponProjectile.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <cmath>
+#include <algorithm>
 
 namespace OpenXcom
 {

--- a/src/Savegame/CraftWeapon.h
+++ b/src/Savegame/CraftWeapon.h
@@ -17,7 +17,15 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/CraftWeaponProjectile.h
+++ b/src/Savegame/CraftWeaponProjectile.h
@@ -46,7 +46,7 @@ private:
 	bool _missed;
 
 	int _distanceCovered;
-	
+
 public:
 	CraftWeaponProjectile();
 	~CraftWeaponProjectile(void);

--- a/src/Savegame/EquipmentLayoutItem.cpp
+++ b/src/Savegame/EquipmentLayoutItem.cpp
@@ -18,6 +18,8 @@
  */
 #include "EquipmentLayoutItem.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/EquipmentLayoutItem.h
+++ b/src/Savegame/EquipmentLayoutItem.h
@@ -18,7 +18,15 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <string>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/GameTime.cpp
+++ b/src/Savegame/GameTime.cpp
@@ -19,6 +19,8 @@
 #include "GameTime.h"
 #include "../Engine/Language.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/GameTime.h
+++ b/src/Savegame/GameTime.h
@@ -18,7 +18,15 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <string>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/ItemContainer.cpp
+++ b/src/Savegame/ItemContainer.cpp
@@ -20,6 +20,8 @@
 #include "../Mod/Mod.h"
 #include "../Mod/RuleItem.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/ItemContainer.h
+++ b/src/Savegame/ItemContainer.h
@@ -19,7 +19,15 @@
  */
 #include <string>
 #include <map>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/MissionSite.cpp
+++ b/src/Savegame/MissionSite.cpp
@@ -21,6 +21,8 @@
 #include "../Mod/RuleAlienMission.h"
 #include "../Mod/AlienDeployment.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/MissionSite.h
+++ b/src/Savegame/MissionSite.h
@@ -19,7 +19,15 @@
  */
 #include "Target.h"
 #include <string>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/MissionStatistics.cpp
+++ b/src/Savegame/MissionStatistics.cpp
@@ -1,0 +1,153 @@
+/*
+* Copyright 2010-2016 OpenXcom Developers.
+*
+* This file is part of OpenXcom.
+*
+* OpenXcom is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* OpenXcom is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "MissionStatistics.h"
+
+#include <yaml-cpp/yaml.h>
+
+namespace OpenXcom
+{
+	// Load
+	void MissionStatistics::load(const YAML::Node &node)
+	{
+		id = node["id"].as<int>(id);
+		markerName = node["markerName"].as<std::string>(markerName);
+		markerId = node["markerId"].as<int>(markerId);
+		time.load(node["time"]);
+		region = node["region"].as<std::string>(region);
+		country = node["country"].as<std::string>(country);
+		type = node["type"].as<std::string>(type);
+		ufo = node["ufo"].as<std::string>(ufo);
+		success = node["success"].as<bool>(success);
+		score = node["score"].as<int>(score);
+		rating = node["rating"].as<std::string>(rating);
+		alienRace = node["alienRace"].as<std::string>(alienRace);
+		daylight = node["daylight"].as<int>(daylight);
+		injuryList = node["injuryList"].as< std::map<int, int> >(injuryList);
+		valiantCrux = node["valiantCrux"].as<bool>(valiantCrux);
+		lootValue = node["lootValue"].as<int>(lootValue);
+	}
+
+	// Save
+	YAML::Node MissionStatistics::save() const
+	{
+		YAML::Node node;
+		node["id"] = id;
+		if (!markerName.empty())
+		{
+			node["markerName"] = markerName;
+			node["markerId"] = markerId;
+		}
+		node["time"] = time.save();
+		node["region"] = region;
+		node["country"] = country;
+		node["type"] = type;
+		node["ufo"] = ufo;
+		node["success"] = success;
+		node["score"] = score;
+		node["rating"] = rating;
+		node["alienRace"] = alienRace;
+		node["daylight"] = daylight;
+		node["injuryList"] = injuryList;
+		if (valiantCrux) node["valiantCrux"] = valiantCrux;
+		if (lootValue) node["lootValue"] = lootValue;
+		return node;
+	}
+
+	std::wstring MissionStatistics::getMissionName(Language *lang) const
+	{
+		if (!markerName.empty())
+		{
+			return lang->getString(markerName).arg(markerId);
+		}
+		else
+		{
+			return lang->getString(type);
+		}
+	}
+
+	std::wstring MissionStatistics::getRatingString(Language *lang) const
+	{
+		std::wostringstream ss;
+		if (success)
+		{
+			ss << lang->getString("STR_VICTORY");
+		}
+		else
+		{
+			ss << lang->getString("STR_DEFEAT");
+		}
+		ss << L" - " << lang->getString(rating);
+		return ss.str();
+	}
+
+	std::string MissionStatistics::getLocationString() const
+	{
+		if (country == "STR_UNKNOWN")
+		{
+			return region;
+		}
+		else
+		{
+			return country;
+		}
+	}
+
+	std::string MissionStatistics::getDaylightString() const
+	{
+		if (daylight <= 5)
+		{
+			return "STR_DAY";
+		}
+		else
+		{
+			return "STR_NIGHT";
+		}
+	}
+
+	bool MissionStatistics::isAlienBase() const
+	{
+		if (type.find("STR_ALIEN_BASE") != std::string::npos || type.find("STR_ALIEN_COLONY") != std::string::npos)
+		{
+			return true;
+		}
+		return false;
+	}
+
+	bool MissionStatistics::isBaseDefense() const
+	{
+		if (type == "STR_BASE_DEFENSE")
+		{
+			return true;
+		}
+		return false;
+	}
+
+	bool MissionStatistics::isUfoMission() const
+	{
+		if(ufo != "NO_UFO")
+		{
+			return true;
+		}
+		return false;
+	}
+
+	MissionStatistics::MissionStatistics(const YAML::Node& node) : time(0, 0, 0, 0, 0, 0, 0) { load(node); }
+	MissionStatistics::MissionStatistics() : id(0), markerId(0), time(0, 0, 0, 0, 0, 0, 0), region("STR_REGION_UNKNOWN"), country("STR_UNKNOWN"), ufo("NO_UFO"), success(false), score(0), alienRace("STR_UNKNOWN"), daylight(0), valiantCrux(false), lootValue(0) { }
+	MissionStatistics::~MissionStatistics() { }
+}

--- a/src/Savegame/MissionStatistics.h
+++ b/src/Savegame/MissionStatistics.h
@@ -16,12 +16,21 @@
 * You should have received a copy of the GNU General Public License
 * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <yaml-cpp/yaml.h>
+#include "GameTime.h"
+#include "../Engine/Language.h"
+
 #include <map>
 #include <string>
 #include <sstream>
-#include "GameTime.h"
-#include "../Engine/Language.h"
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {
@@ -47,133 +56,28 @@ struct MissionStatistics
 	int lootValue;
 
 	// Load
-	void load(const YAML::Node &node)
-	{
-		id = node["id"].as<int>(id);
-		markerName = node["markerName"].as<std::string>(markerName);
-		markerId = node["markerId"].as<int>(markerId);
-		time.load(node["time"]);
-		region = node["region"].as<std::string>(region);
-		country = node["country"].as<std::string>(country);
-		type = node["type"].as<std::string>(type);
-		ufo = node["ufo"].as<std::string>(ufo);
-		success = node["success"].as<bool>(success);
-		score = node["score"].as<int>(score);
-		rating = node["rating"].as<std::string>(rating);
-		alienRace = node["alienRace"].as<std::string>(alienRace);
-		daylight = node["daylight"].as<int>(daylight);
-		injuryList = node["injuryList"].as< std::map<int, int> >(injuryList);
-		valiantCrux = node["valiantCrux"].as<bool>(valiantCrux);
-		lootValue = node["lootValue"].as<int>(lootValue);
-	}
+	void load(const YAML::Node &node);
 
 	// Save
-	YAML::Node save() const
-	{
-		YAML::Node node;
-		node["id"] = id;
-		if (!markerName.empty())
-		{
-			node["markerName"] = markerName;
-			node["markerId"] = markerId;
-		}
-		node["time"] = time.save();
-		node["region"] = region;
-		node["country"] = country;
-		node["type"] = type;
-		node["ufo"] = ufo;
-		node["success"] = success;
-		node["score"] = score;
-		node["rating"] = rating;
-		node["alienRace"] = alienRace;
-		node["daylight"] = daylight;
-		node["injuryList"] = injuryList;
-		if (valiantCrux) node["valiantCrux"] = valiantCrux;
-		if (lootValue) node["lootValue"] = lootValue;
-		return node;
-	}
+	YAML::Node save() const;
 
-	std::wstring getMissionName(Language *lang) const
-	{
-		if (!markerName.empty())
-		{
-			return lang->getString(markerName).arg(markerId);
-		}
-		else
-		{
-			return lang->getString(type);
-		}
-	}
+	std::wstring getMissionName(Language *lang) const;
 
-	std::wstring getRatingString(Language *lang) const
-	{
-		std::wostringstream ss;
-		if (success)
-		{
-			ss << lang->getString("STR_VICTORY");
-		}
-		else
-		{
-			ss << lang->getString("STR_DEFEAT");
-		}
-		ss << L" - " << lang->getString(rating);
-		return ss.str();
-	}
+	std::wstring getRatingString(Language *lang) const;
 
-	std::string getLocationString() const
-	{
-		if (country == "STR_UNKNOWN")
-		{
-			return region;
-		}
-		else
-		{
-			return country;
-		}
-	}
+	std::string getLocationString() const;
 
-	std::string getDaylightString() const
-	{
-		if (daylight <= 5)
-		{
-			return "STR_DAY";
-		}
-		else
-		{
-			return "STR_NIGHT";
-		}
-	}
+	std::string getDaylightString() const;
 
-	bool isAlienBase() const
-	{
-		if (type.find("STR_ALIEN_BASE") != std::string::npos || type.find("STR_ALIEN_COLONY") != std::string::npos)
-		{
-			return true;
-		}
-		return false;
-	}
+	bool isAlienBase() const;
 
-	bool isBaseDefense() const
-	{
-		if (type == "STR_BASE_DEFENSE")
-		{
-			return true;
-		}
-		return false;
-	}
+	bool isBaseDefense() const;
 
-	bool isUfoMission() const
-	{
-		if(ufo != "NO_UFO")
-		{
-			return true;
-		}
-		return false;
-	}
+	bool isUfoMission() const;
 
-	MissionStatistics(const YAML::Node& node) : time(0, 0, 0, 0, 0, 0, 0) { load(node); }
-	MissionStatistics() : id(0), markerId(0), time(0, 0, 0, 0, 0, 0, 0), region("STR_REGION_UNKNOWN"), country("STR_UNKNOWN"), ufo("NO_UFO"), success(false), score(0), alienRace("STR_UNKNOWN"), daylight(0), valiantCrux(false), lootValue(0) { }
-	~MissionStatistics() { }
+	MissionStatistics(const YAML::Node& node);
+	MissionStatistics();
+	~MissionStatistics();
 };
 
 }

--- a/src/Savegame/MovingTarget.cpp
+++ b/src/Savegame/MovingTarget.cpp
@@ -21,6 +21,8 @@
 #include "SerializationHelper.h"
 #include "../Engine/Options.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/Node.cpp
+++ b/src/Savegame/Node.cpp
@@ -18,6 +18,10 @@
  */
 #include "Node.h"
 
+#include <yaml-cpp/yaml.h>
+
+#include "../Battlescape/Position.hpp"
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/Node.h
+++ b/src/Savegame/Node.h
@@ -18,7 +18,17 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "../Battlescape/Position.h"
-#include <yaml-cpp/yaml.h>
+
+#include <vector>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/Production.cpp
+++ b/src/Savegame/Production.cpp
@@ -17,7 +17,6 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "Production.h"
-#include <algorithm>
 #include "../Mod/RuleManufacture.h"
 #include "Base.h"
 #include "SavedGame.h"
@@ -28,8 +27,12 @@
 #include "../Mod/RuleItem.h"
 #include "../Mod/RuleCraft.h"
 #include "../Mod/RuleCraftWeapon.h"
-#include <climits>
 #include "BaseFacility.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <climits>
+#include <algorithm>
 
 namespace OpenXcom
 {

--- a/src/Savegame/Production.h
+++ b/src/Savegame/Production.h
@@ -17,7 +17,15 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/Region.cpp
+++ b/src/Savegame/Region.cpp
@@ -19,6 +19,8 @@
 #include "Region.h"
 #include "../Mod/RuleRegion.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/Region.h
+++ b/src/Savegame/Region.h
@@ -18,7 +18,15 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <vector>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/ResearchProject.cpp
+++ b/src/Savegame/ResearchProject.cpp
@@ -19,6 +19,8 @@
 #include "ResearchProject.h"
 #include "../Mod/RuleResearch.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 const float PROGRESS_LIMIT_UNKNOWN = 0.333f;

--- a/src/Savegame/ResearchProject.h
+++ b/src/Savegame/ResearchProject.h
@@ -17,7 +17,17 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+#include <string>
+
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/SaveConverter.cpp
+++ b/src/Savegame/SaveConverter.cpp
@@ -19,10 +19,6 @@
 #include "SaveConverter.h"
 #include <yaml-cpp/yaml.h>
 #include <SDL_endian.h>
-#include <fstream>
-#include <sstream>
-#include <iomanip>
-#include <bitset>
 #include "../Engine/Options.h"
 #include "../Engine/CrossPlatform.h"
 #include "../Engine/Exception.h"
@@ -57,6 +53,13 @@
 #include "../Mod/RuleConverter.h"
 #include "../Ufopaedia/Ufopaedia.h"
 #include "../fmath.h"
+
+#include "../Mod/Unit.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <bitset>
 
 namespace OpenXcom
 {

--- a/src/Savegame/SavedBattleGame.cpp
+++ b/src/Savegame/SavedBattleGame.cpp
@@ -30,6 +30,7 @@
 #include "../Battlescape/BattlescapeState.h"
 #include "../Battlescape/BattlescapeGame.h"
 #include "../Battlescape/Position.h"
+#include "../Battlescape/Position.hpp"
 #include "../Mod/Mod.h"
 #include "../Mod/Armor.h"
 #include "../Engine/Game.h"

--- a/src/Savegame/SavedBattleGame.cpp
+++ b/src/Savegame/SavedBattleGame.cpp
@@ -16,8 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <assert.h>
-#include <vector>
 #include "BattleItem.h"
 #include "SavedBattleGame.h"
 #include "SavedGame.h"
@@ -41,6 +39,10 @@
 #include "../Engine/Logger.h"
 #include "SerializationHelper.h"
 #include "../Mod/RuleItem.h"
+
+#include <assert.h>
+#include <vector>
+#include <algorithm>
 
 namespace OpenXcom
 {

--- a/src/Savegame/SavedBattleGame.h
+++ b/src/Savegame/SavedBattleGame.h
@@ -17,11 +17,20 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <vector>
-#include <string>
-#include <yaml-cpp/yaml.h>
 #include "BattleUnit.h"
 #include "../Mod/AlienDeployment.h"
+
+#include <vector>
+#include <string>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/Soldier.cpp
+++ b/src/Savegame/Soldier.cpp
@@ -30,6 +30,10 @@
 #include "../Mod/Mod.h"
 #include "../Mod/StatString.h"
 
+#include "../Mod/Unit.hpp"
+
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/Soldier.h
+++ b/src/Savegame/Soldier.h
@@ -17,11 +17,19 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <string>
-#include <yaml-cpp/yaml.h>
 #include "../Mod/Unit.h"
 #include "../Mod/StatString.h"
-	 
+#include <string>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/SoldierDeath.h
+++ b/src/Savegame/SoldierDeath.h
@@ -17,8 +17,16 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
 #include "GameTime.h"
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/SoldierDiary.h
+++ b/src/Savegame/SoldierDiary.h
@@ -17,10 +17,18 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
 #include "BattleUnit.h"
 #include "SavedGame.h"
 #include "../Mod/Mod.h"
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/Target.cpp
+++ b/src/Savegame/Target.cpp
@@ -22,6 +22,8 @@
 #include "../fmath.h"
 #include "../Engine/Language.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/Target.h
+++ b/src/Savegame/Target.h
@@ -19,7 +19,15 @@
  */
 #include <string>
 #include <vector>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/Tile.cpp
+++ b/src/Savegame/Tile.cpp
@@ -29,6 +29,7 @@
 #include "../Mod/Armor.h"
 #include "SerializationHelper.h"
 #include "../Battlescape/Particle.h"
+#include "../Battlescape/Position.hpp"
 
 namespace OpenXcom
 {

--- a/src/Savegame/Tile.h
+++ b/src/Savegame/Tile.h
@@ -17,13 +17,14 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <list>
-#include <vector>
 #include "../Battlescape/Position.h"
 #include "../Mod/MapData.h"
 #include "BattleUnit.h"
 
 #include <SDL_types.h> // for Uint8
+
+#include <list>
+#include <vector>
 
 namespace OpenXcom
 {

--- a/src/Savegame/Transfer.cpp
+++ b/src/Savegame/Transfer.cpp
@@ -25,6 +25,8 @@
 #include "../Mod/Mod.h"
 #include "../Engine/Logger.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/Transfer.h
+++ b/src/Savegame/Transfer.h
@@ -18,7 +18,15 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <string>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/Ufo.h
+++ b/src/Savegame/Ufo.h
@@ -18,9 +18,17 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "MovingTarget.h"
-#include <string>
-#include <yaml-cpp/yaml.h>
 #include "Craft.h"
+#include <string>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/Vehicle.cpp
+++ b/src/Savegame/Vehicle.cpp
@@ -19,6 +19,8 @@
 #include "Vehicle.h"
 #include "../Mod/RuleItem.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/Vehicle.h
+++ b/src/Savegame/Vehicle.h
@@ -17,7 +17,15 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/Waypoint.cpp
+++ b/src/Savegame/Waypoint.cpp
@@ -19,6 +19,8 @@
 #include "Waypoint.h"
 #include "../Engine/Language.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/Waypoint.h
+++ b/src/Savegame/Waypoint.h
@@ -19,7 +19,15 @@
  */
 #include "Target.h"
 #include <string>
-#include <yaml-cpp/yaml.h>
+
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/Savegame/WeightedOptions.cpp
+++ b/src/Savegame/WeightedOptions.cpp
@@ -19,6 +19,8 @@
 #include "WeightedOptions.h"
 #include "../Engine/RNG.h"
 
+#include <yaml-cpp/yaml.h>
+
 namespace OpenXcom
 {
 

--- a/src/Savegame/WeightedOptions.h
+++ b/src/Savegame/WeightedOptions.h
@@ -20,8 +20,15 @@
 #include <string>
 #include <map>
 #include <vector>
-#include <yaml-cpp/yaml.h>
 
+/*
+* Instead of pulling in yaml-cpp, just pre-declare the require Node
+* we require in member function definitions.
+*/
+namespace YAML
+{
+class Node;
+}
 
 namespace OpenXcom
 {

--- a/src/fmath.h
+++ b/src/fmath.h
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <algorithm>
 #include <cfloat>
 #define _USE_MATH_DEFINES
 #include <cmath>
@@ -54,8 +53,23 @@ inline _Tx Sign(const _Tx& x)
 	return (_Tx(0) < x) - (x < _Tx(0));
 }
 
+namespace algorithmAvoidance{
+template<class T>
+const T& max(const T& a, const T& b)
+{
+    return (a < b) ? b : a;
+}
+
+
+template<class T>
+const T& min(const T& a, const T& b)
+{
+    return (b < a) ? b : a;
+}
+}
+
 template <class _Tx>
 inline _Tx Clamp(const _Tx& x, const _Tx& min, const _Tx& max)
 {
-	return std::min(std::max(x, min), max);
+	return algorithmAvoidance::min(algorithmAvoidance::max(x, min), max);
 }


### PR DESCRIPTION
**In short**

Reduced compilation time by eliminating unnecessary includes via forward declaring the types most interfaces required for serialization, and reducing inclusion scopes.

This was specifically tested with CMake & GCC & LLVM/Clang under Debian Stretch; no ill effects were observed either during build, or during gameplay.

The changes result in approximately 15% improvement on fast machines.

**In depth**

Compilation time was extremely slow on an older P3 laptop, and was in the multiple-minute range with 4 cores using a modern CPU: the former was 70+ minutes (!), and the latter was over 4 minutes.

According to GCC profiling, most of the time is taken up by parsing and template instantiation, which indicates nothing unusual is going on.

Examining the include hierarchy, I've come to the conclusion that multiple quite expensive headers are pulled into separate compilation units; these are:
        - YAML-CPP's all-inclusive header.
        - SDL's all-inclusive header.

The serialization interfaces are replicated consistently across the codebase, thus I've altered their includes first. Unfortunately, since YAML-CPP requires the template specialization in the following files to be present at the site of usage, the definition thereof had to be included in the files which serialized them in some manner.

Affected files:
- Unit.h
- Position.h
- RuleRegion.h
- Unit.h
- Texture.h

These files were given a new ".hpp" file, which contains their serialization related template specialization. This also indirectly affects multiple files, which depended upon the definition of these specializations. These pull in the ".hpp" directly.

Furthermore, two files received .cpp files to house their own definitions or I/O operators:
- MissionStatistics.h's definitions were externalized.
- Position.h's I/O operators were externalized. The definitions were left in place to facilitate inlining. (Though optimization wasn't the goal in this session.)

I've also taken the liberty of altering the include order in the touched files: the STL includes follow and internal and third party includes, to avoid polluting them with their contents. This revealed missing includes, which were added. The include order in the files touched is:
 - Internal project includes.
 - The specific .hpp includes mentioned previously.
 - External library includes.

These do not appear to be against the code conventions posted [here](https://openxcom.org/forum/index.php/topic,109.0.html).

Other notes:
 - Operated on the general assumption that any of the affected files are not singly used, or won't stay so, ie. at least two files will use the raw header files. Otherwise, it would not make sense to separate the serialization specialization.
 - Replaced SDL.h with SDL_stdinc.h, and SDL_video.h, etc. where appropriate: no need to pull in the entire SDL library just for type declarations.

Central includes:
  - State.h is extremely central, understandably due to the architectural decisions.
 - Mod.h is the one of the most central includes, and it pulled in Unit.h, which itself contained the serializing specialization.
 - Game.h is also high on the list.
 - TextButton.h is central too. and it pulls in InteractiveSurface, which itself pulls in Surface.h and State.h.
 - Options.h is central, which makes OptionInfo central as well.

I'll let the numbers speak for themselves, as measured on my development machine:
 - This version compiles in approximately 3 minutes 32 seconds.
 - The original compiles in approximately 4 minutes 9 seconds.
 - Thus, this is approximately a 15% improvement. I've yet to measure on my older laptop, but if the numbers hold, this is already a good 10 minutes faster there.
 -  The above numbers are from singular measurements, but the dispersion wasn't large enough to warrant serious statistics.