### PR TITLE
add ccache detection for linux builds, off by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,16 +7,26 @@ include(GNUInstallDirs)
 # For yaml-cpp
 set (CMAKE_CXX_STANDARD 11)
 
+
 option ( DEV_BUILD "Development Build. Disable this for release builds" ON )
 option ( BUILD_PACKAGE "Prepares build for creation of a package with CPack" ON )
 option ( ENABLE_WARNING "Always show warnings (even for release builds)" OFF )
 option ( FATAL_WARNING "Treat warnings as errors" OFF )
 option ( ENABLE_CLANG_ANALYSIS "When building with clang, enable the static analyzer" OFF )
+option ( CHECK_CCACHE "Check if ccache is installed and use it" OFF )
 set ( MSVC_WARNING_LEVEL 3 CACHE STRING "Visual Studio warning levels" )
 option ( FORCE_INSTALL_DATA_TO_BIN "Force installation of data to binary directory" OFF )
 set ( DATADIR "" CACHE STRING "Where to place datafiles" )
 set ( OPENXCOM_VERSION_STRING "" CACHE STRING "Version string (after x.x)" )
 
+if ( CHECK_CCACHE )
+    # Configure CCache if available
+    find_program(CCACHE_FOUND ccache)
+    if(CCACHE_FOUND)
+       set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+       set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+    endif(CCACHE_FOUND)
+endif ()
 
 if ( WIN32 )
   set ( default_deps_dir "${CMAKE_SOURCE_DIR}/deps" )


### PR DESCRIPTION
Surprised this is not an option already.  This makes building on linux systems while switching back and forth between git branches easier especially on more resource constrained systems.   This gets around monkeying with your system path or symbolic links to get ccache to work, but instead tell CMAKE to look for it.  This is off by default, so developers shouldn't be surprised by it.