### PR TITLE
fix bug where mercy or nike cross is erroneously awarded for instance…

### DIFF
--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -486,11 +486,11 @@ DebriefingState::DebriefingState() : _region(0), _country(0), _positiveScore(tru
 					soldierAlienStuns++;
 				}
 			}
-			if (aliensKilled && aliensKilled == soldierAlienKills && _missionStatistics->success == true)
+			if (aliensKilled && aliensKilled == soldierAlienKills && _missionStatistics->success == true && aliensStunned == 0)
 			{
 				(*j)->getStatistics()->nikeCross = true;
 			}
-			if (aliensStunned && aliensStunned == soldierAlienStuns && _missionStatistics->success == true)
+			if (aliensStunned && aliensStunned == soldierAlienStuns && _missionStatistics->success == true && aliensKilled == 0)
 			{
 				(*j)->getStatistics()->mercyCross = true;
 			}


### PR DESCRIPTION
…s where someone gets all the kills and someone else gets all the stuns in a single mission (supposed to be all aliens killed or stunned by single person not both in same mission)