### PR TITLE
adding faction granularity when reviving target units

### DIFF
--- a/src/Battlescape/MedikitState.cpp
+++ b/src/Battlescape/MedikitState.cpp
@@ -234,7 +234,18 @@ void MedikitState::onHealClick(Action *)
 			if (!_revivedTarget)
 			{
 				_targetUnit->setTimeUnits(0);
-				_action->actor->getStatistics()->revivedSoldier++;
+                if(_targetUnit->getOriginalFaction() == FACTION_PLAYER)
+                {
+                    _action->actor->getStatistics()->revivedSoldier++;
+                }
+                else if(_targetUnit->getOriginalFaction() == FACTION_HOSTILE)
+                {
+                    _action->actor->getStatistics()->revivedHostile++;
+                }
+                else
+                {
+                    _action->actor->getStatistics()->revivedNeutral++;
+                }
 				_revivedTarget = true;
 			}
 			// if the unit has revived and has no more wounds, we quit this screen automatically
@@ -275,7 +286,18 @@ void MedikitState::onStimulantClick(Action *)
 		if (_targetUnit->getStatus() == STATUS_UNCONSCIOUS && _targetUnit->getStunlevel() < _targetUnit->getHealth() && _targetUnit->getHealth() > 0)
 		{
 			_targetUnit->setTimeUnits(0);
-			_action->actor->getStatistics()->revivedSoldier++;
+            if(_targetUnit->getOriginalFaction() == FACTION_PLAYER)
+            {
+                _action->actor->getStatistics()->revivedSoldier++;
+            }
+            else if(_targetUnit->getOriginalFaction() == FACTION_HOSTILE)
+            {
+                _action->actor->getStatistics()->revivedHostile++;
+            }
+            else
+            {
+                _action->actor->getStatistics()->revivedNeutral++;
+            }
 			onEndClick(0);
 		}
 	}

--- a/src/Savegame/BattleUnitStatistics.h
+++ b/src/Savegame/BattleUnitStatistics.h
@@ -324,7 +324,9 @@ struct BattleUnitStatistics
 	UnitStats delta;                     ///< Tracks the increase in unit stats (is not saved, only used during debriefing)
 	int appliedStimulant;                ///< Tracks how many times this soldier applied stimulant
 	int appliedPainKill;                 ///< Tracks how many times this soldier applied pain killers
-	int revivedSoldier;                  ///< Tracks how many times this soldier revived another unit
+	int revivedSoldier;                  ///< Tracks how many times this soldier revived another soldier
+	int revivedHostile;                  ///< Tracks how many times this soldier revived another hostile
+	int revivedNeutral;                  ///< Tracks how many times this soldier revived another civilian
 	bool MIA;                            ///< Tracks if the soldier was left behind :(
 	int martyr;                          ///< Tracks how many kills the soldier landed on the turn of his death
 	int slaveKills;                      ///< Tracks how many kills the soldier landed thanks to a mind controlled unit.
@@ -379,6 +381,8 @@ struct BattleUnitStatistics
 		appliedStimulant = node["appliedStimulant"].as<int>(appliedStimulant);
 		appliedPainKill = node["appliedPainKill"].as<int>(appliedPainKill);
 		revivedSoldier = node["revivedSoldier"].as<int>(revivedSoldier);
+		revivedHostile = node["revivedHostile"].as<int>(revivedHostile);
+		revivedNeutral = node["revivedNeutral"].as<int>(revivedNeutral);
 		martyr = node["martyr"].as<int>(martyr);
 		slaveKills = node["slaveKills"].as<int>(slaveKills);
 	}
@@ -409,13 +413,15 @@ struct BattleUnitStatistics
 		if (appliedStimulant) node["appliedStimulant"] = appliedStimulant;
 		if (appliedPainKill) node["appliedPainKill"] = appliedPainKill;
 		if (revivedSoldier) node["revivedSoldier"] = revivedSoldier;
+		if (revivedHostile) node["revivedHostile"] = revivedHostile;
+		if (revivedNeutral) node["revivedNeutral"] = revivedNeutral;
 		if (martyr) node["martyr"] = martyr;
 		if (slaveKills) node["slaveKills"] = slaveKills;
 		return node;
 	}
 
 	BattleUnitStatistics(const YAML::Node& node) { load(node); }
-	BattleUnitStatistics() : wasUnconcious(false), shotAtCounter(0), hitCounter(0), shotByFriendlyCounter(0), shotFriendlyCounter(0), loneSurvivor(false), ironMan(false), longDistanceHitCounter(0), lowAccuracyHitCounter(0), shotsFiredCounter(0), shotsLandedCounter(0), kills(), daysWounded(0), KIA(false), nikeCross(false), mercyCross(false), woundsHealed(0), appliedStimulant(0), appliedPainKill(0), revivedSoldier(0), MIA(false), martyr(0), slaveKills(0) { }
+	BattleUnitStatistics() : wasUnconcious(false), shotAtCounter(0), hitCounter(0), shotByFriendlyCounter(0), shotFriendlyCounter(0), loneSurvivor(false), ironMan(false), longDistanceHitCounter(0), lowAccuracyHitCounter(0), shotsFiredCounter(0), shotsLandedCounter(0), kills(), daysWounded(0), KIA(false), nikeCross(false), mercyCross(false), woundsHealed(0), appliedStimulant(0), appliedPainKill(0), revivedSoldier(0), revivedHostile(0), revivedNeutral(0), MIA(false), martyr(0), slaveKills(0) { }
 	~BattleUnitStatistics() { }
 };
 

--- a/src/Savegame/SoldierDiary.cpp
+++ b/src/Savegame/SoldierDiary.cpp
@@ -42,7 +42,8 @@ SoldierDiary::SoldierDiary() : _daysWoundedTotal(0), _totalShotByFriendlyCounter
 	_lowAccuracyHitCounterTotal(0), _shotsFiredCounterTotal(0), _shotsLandedCounterTotal(0), _shotAtCounter10in1Mission(0), _hitCounter5in1Mission(0),
 	_timesWoundedTotal(0), _KIA(0), _allAliensKilledTotal(0), _allAliensStunnedTotal(0), _woundsHealedTotal(0), _allUFOs(0), _allMissionTypes(0),
 	_statGainTotal(0), _revivedUnitTotal(0), _wholeMedikitTotal(0), _braveryGainTotal(0), _bestOfRank(0),
-	_MIA(0), _martyrKillsTotal(0), _postMortemKills(0), _slaveKillsTotal(0), _bestSoldier(false), _globeTrotter(false)
+	_MIA(0), _martyrKillsTotal(0), _postMortemKills(0), _slaveKillsTotal(0), _bestSoldier(false),
+    _revivedSoldierTotal(0), _revivedHostileTotal(0), _revivedNeutralTotal(0), _globeTrotter(false)
 {
 }
 
@@ -101,6 +102,9 @@ void SoldierDiary::load(const YAML::Node& node)
 	_allMissionTypes = node["allMissionTypes"].as<int>(_allMissionTypes);
 	_statGainTotal = node["statGainTotal"].as<int>(_statGainTotal);
 	_revivedUnitTotal = node["revivedUnitTotal"].as<int>(_revivedUnitTotal);
+	_revivedSoldierTotal = node["revivedSoldierTotal"].as<int>(_revivedSoldierTotal);
+	_revivedHostileTotal = node["revivedHostileTotal"].as<int>(_revivedHostileTotal);
+	_revivedNeutralTotal = node["revivedNeutralTotal"].as<int>(_revivedNeutralTotal);
 	_wholeMedikitTotal = node["wholeMedikitTotal"].as<int>(_wholeMedikitTotal);
 	_braveryGainTotal = node["braveryGainTotal"].as<int>(_braveryGainTotal);
 	_bestOfRank = node["bestOfRank"].as<int>(_bestOfRank);
@@ -146,6 +150,9 @@ YAML::Node SoldierDiary::save() const
 	if (_allMissionTypes) node["allMissionTypes"] = _allMissionTypes;
 	if (_statGainTotal) node["statGainTotal"] =_statGainTotal;
 	if (_revivedUnitTotal) node["revivedUnitTotal"] = _revivedUnitTotal;
+	if (_revivedSoldierTotal) node["revivedSoldierTotal"] = _revivedSoldierTotal;
+	if (_revivedHostileTotal) node["revivedHostileTotal"] = _revivedHostileTotal;
+	if (_revivedNeutralTotal) node["revivedNeutralTotal"] = _revivedNeutralTotal;
 	if (_wholeMedikitTotal) node["wholeMedikitTotal"] = _wholeMedikitTotal;
 	if (_braveryGainTotal) node["braveryGainTotal"] = _braveryGainTotal;
 	if (_bestOfRank) node["bestOfRank"] = _bestOfRank;
@@ -229,7 +236,10 @@ void SoldierDiary::updateDiary(BattleUnitStatistics *unitStatistics, std::vector
 	_statGainTotal += unitStatistics->delta.psiSkill;
 	
 	_braveryGainTotal = unitStatistics->delta.bravery;
-	_revivedUnitTotal += unitStatistics->revivedSoldier;
+	_revivedUnitTotal += (unitStatistics->revivedSoldier + unitStatistics->revivedHostile + unitStatistics->revivedNeutral);
+	_revivedSoldierTotal += unitStatistics->revivedSoldier;
+	_revivedNeutralTotal += unitStatistics->revivedNeutral;
+	_revivedHostileTotal += unitStatistics->revivedHostile;
 	_wholeMedikitTotal += std::min( std::min(unitStatistics->woundsHealed, unitStatistics->appliedStimulant), unitStatistics->appliedPainKill);
 	_missionIdList.push_back(missionStatistics->id);
 }
@@ -322,6 +332,9 @@ bool SoldierDiary::manageCommendations(Mod *mod, std::vector<MissionStatistics*>
 					((*j).first == "totalAllMissionTypes" && _allMissionTypes < (*j).second.at(nextCommendationLevel["noNoun"])) ||
 					((*j).first == "totalStatGain" && _statGainTotal < (*j).second.at(nextCommendationLevel["noNoun"])) ||
 					((*j).first == "totalRevives" && _revivedUnitTotal < (*j).second.at(nextCommendationLevel["noNoun"])) ||
+					((*j).first == "totalSoldierRevives" && _revivedSoldierTotal < (*j).second.at(nextCommendationLevel["noNoun"])) ||
+					((*j).first == "totalHostileRevives" && _revivedHostileTotal < (*j).second.at(nextCommendationLevel["noNoun"])) ||
+					((*j).first == "totalNeutralRevives" && _revivedNeutralTotal < (*j).second.at(nextCommendationLevel["noNoun"])) ||
 					((*j).first == "totalWholeMedikit" && _wholeMedikitTotal < (*j).second.at(nextCommendationLevel["noNoun"])) ||
 					((*j).first == "totalBraveryGain" && _braveryGainTotal < (*j).second.at(nextCommendationLevel["noNoun"])) ||
 					((*j).first == "bestOfRank" && _bestOfRank < (*j).second.at(nextCommendationLevel["noNoun"])) ||

--- a/src/Savegame/SoldierDiary.h
+++ b/src/Savegame/SoldierDiary.h
@@ -77,7 +77,7 @@ private:
 		_hitCounterTotal, _ironManTotal, _longDistanceHitCounterTotal, _lowAccuracyHitCounterTotal, _shotsFiredCounterTotal, _shotsLandedCounterTotal,
 		_shotAtCounter10in1Mission,	_hitCounter5in1Mission, _timesWoundedTotal, _KIA, _allAliensKilledTotal, _allAliensStunnedTotal,
 		_woundsHealedTotal, _allUFOs, _allMissionTypes, _statGainTotal, _revivedUnitTotal, _wholeMedikitTotal, _braveryGainTotal, _bestOfRank, _MIA,
-		_martyrKillsTotal, _postMortemKills, _slaveKillsTotal, _bestSoldier;
+		_martyrKillsTotal, _postMortemKills, _slaveKillsTotal, _bestSoldier, _revivedSoldierTotal, _revivedHostileTotal, _revivedNeutralTotal;
 	bool _globeTrotter;
 	void manageModularCommendations(std::map<std::string, int> &nextCommendationLevel, std::map<std::string, int> &modularCommendations, std::pair<std::string, int> statTotal, int criteria);
 	void awardCommendation(const std::string& type, const std::string& noun = "noNoun");


### PR DESCRIPTION
This fixes issues with awarding angel cross medal in Commendations where it's suppose to only award when reviving fellow soldier (as in one of your own).  The statistic was too generic and all encompassing for all revived units.  This fix will also allow awards to be made for reviving civilians and hostile units.