### PR TITLE
Do not recover corpseBattle items if a soldier is just taking a nap

### DIFF
--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -1010,7 +1010,12 @@ void DebriefingState::prepareDebriefing()
 	{
 		if ((*j)->getOriginalFaction() == FACTION_PLAYER && (*j)->getStatus() != STATUS_DEAD)
 		{
-			if ((*j)->getStatus() == STATUS_UNCONSCIOUS || (*j)->getFaction() == FACTION_HOSTILE)
+			if ((*j)->getStatus() == STATUS_UNCONSCIOUS)
+			{
+				playersUnconscious++;
+				battle->removeUnconsciousBodyItem(*j);
+			}
+			else if ((*j)->getFaction() == FACTION_HOSTILE)
 			{
 				playersUnconscious++;
 			}


### PR DESCRIPTION
Prevents free armors items from unconscious soldiers
Which could happen if a modder allows recovery of armors