### PR TITLE
Split "MIDI" music format to "MIDI (GM.CAT)" and "MIDI (MID files)"

### DIFF
--- a/src/Engine/Options.h
+++ b/src/Engine/Options.h
@@ -33,7 +33,7 @@ enum KeyboardType { KEYBOARD_OFF, KEYBOARD_ON, KEYBOARD_VIRTUAL };
 /// Savegame sorting modes.
 enum SaveSort { SORT_NAME_ASC, SORT_NAME_DESC, SORT_DATE_ASC, SORT_DATE_DESC };
 /// Music format preferences.
-enum MusicFormat { MUSIC_AUTO, MUSIC_FLAC, MUSIC_OGG, MUSIC_MP3, MUSIC_MOD, MUSIC_WAV, MUSIC_ADLIB, MUSIC_MIDI };
+enum MusicFormat { MUSIC_AUTO, MUSIC_FLAC, MUSIC_OGG, MUSIC_MP3, MUSIC_MOD, MUSIC_WAV, MUSIC_ADLIB, MUSIC_GM, MUSIC_MIDI };
 /// Sound format preferences.
 enum SoundFormat { SOUND_AUTO, SOUND_14, SOUND_10 };
 /// Video format preferences.

--- a/src/Menu/OptionsAudioState.cpp
+++ b/src/Menu/OptionsAudioState.cpp
@@ -126,8 +126,8 @@ OptionsAudioState::OptionsAudioState(OptionsOrigin origin) : OptionsBaseState(or
 	musicText.push_back(L"MOD");
 	musicText.push_back(L"WAV");
 	musicText.push_back(L"Adlib");
-	musicText.push_back(L"MIDI (GM.CAT)");
-	musicText.push_back(L"MIDI (MID files)");
+	musicText.push_back(L"GM");
+	musicText.push_back(L"MIDI");
 
 	soundText.push_back(tr("STR_PREFERRED_FORMAT_AUTO"));
 	soundText.push_back(L"1.4");

--- a/src/Menu/OptionsAudioState.cpp
+++ b/src/Menu/OptionsAudioState.cpp
@@ -118,7 +118,7 @@ OptionsAudioState::OptionsAudioState(OptionsOrigin origin) : OptionsBaseState(or
 	_slrUiVolume->onMouseOut((ActionHandler)&OptionsAudioState::txtTooltipOut);
 
 	std::vector<std::wstring> musicText, soundText, videoText;
-	/* MUSIC_AUTO, MUSIC_FLAC, MUSIC_OGG, MUSIC_MP3, MUSIC_MOD, MUSIC_WAV, MUSIC_ADLIB, MUSIC_MIDI */
+	/* MUSIC_AUTO, MUSIC_FLAC, MUSIC_OGG, MUSIC_MP3, MUSIC_MOD, MUSIC_WAV, MUSIC_ADLIB, MUSIC_GM, MUSIC_MIDI */
 	musicText.push_back(tr("STR_PREFERRED_FORMAT_AUTO"));
 	musicText.push_back(L"FLAC");
 	musicText.push_back(L"OGG");
@@ -126,7 +126,8 @@ OptionsAudioState::OptionsAudioState(OptionsOrigin origin) : OptionsBaseState(or
 	musicText.push_back(L"MOD");
 	musicText.push_back(L"WAV");
 	musicText.push_back(L"Adlib");
-	musicText.push_back(L"MIDI");
+	musicText.push_back(L"MIDI (GM.CAT)");
+	musicText.push_back(L"MIDI (MID files)");
 
 	soundText.push_back(tr("STR_PREFERRED_FORMAT_AUTO"));
 	soundText.push_back(L"1.4");

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -3011,7 +3011,7 @@ void Mod::loadExtraResources()
 		}
 
 		// Try the preferred format first, otherwise use the default priority
-		MusicFormat priority[] = { Options::preferredMusic, MUSIC_FLAC, MUSIC_OGG, MUSIC_MP3, MUSIC_MOD, MUSIC_WAV, MUSIC_ADLIB, MUSIC_MIDI };
+		MusicFormat priority[] = { Options::preferredMusic, MUSIC_FLAC, MUSIC_OGG, MUSIC_MP3, MUSIC_MOD, MUSIC_WAV, MUSIC_ADLIB, MUSIC_GM, MUSIC_MIDI };
 		for (std::map<std::string, RuleMusic *>::const_iterator i = _musicDefs.begin(); i != _musicDefs.end(); ++i)
 		{
 			Music *music = 0;
@@ -3376,8 +3376,8 @@ bool Mod::isImageFile(std::string extension) const
  */
 Music *Mod::loadMusic(MusicFormat fmt, const std::string &file, int track, float volume, CatFile *adlibcat, CatFile *aintrocat, GMCatFile *gmcat) const
 {
-	/* MUSIC_AUTO, MUSIC_FLAC, MUSIC_OGG, MUSIC_MP3, MUSIC_MOD, MUSIC_WAV, MUSIC_ADLIB, MUSIC_MIDI */
-	static const std::string exts[] = { "", ".flac", ".ogg", ".mp3", ".mod", ".wav", "", ".mid" };
+	/* MUSIC_AUTO, MUSIC_FLAC, MUSIC_OGG, MUSIC_MP3, MUSIC_MOD, MUSIC_WAV, MUSIC_ADLIB, MUSIC_GM, MUSIC_MIDI */
+	static const std::string exts[] = { "", ".flac", ".ogg", ".mp3", ".mod", ".wav", "", "", ".mid" };
 	Music *music = 0;
 	std::set<std::string> soundContents = FileMap::getVFolderContents("SOUND");
 	try
@@ -3411,23 +3411,14 @@ Music *Mod::loadMusic(MusicFormat fmt, const std::string &file, int track, float
 				}
 			}
 		}
-		// Try MIDI music
-		else if (fmt == MUSIC_MIDI)
+		// Try MIDI music (from GM.CAT)
+		else if (fmt == MUSIC_GM)
 		{
 			// DOS MIDI
 			if (gmcat && track < gmcat->getAmount())
 			{
 				music = gmcat->loadMIDI(track);
-			}
-			// Windows MIDI
-			else
-			{
-				if (soundContents.find(fname) != soundContents.end())
-				{
-					music = new Music();
-					music->load(FileMap::getFilePath("SOUND/" + fname));
-				}
-			}
+			}			
 		}
 		// Try digital tracks
 		else


### PR DESCRIPTION
This pull request has been created to implement [feature request #1397](https://openxcom.org/bugs/openxcom/issues/1397) filed on the OpenXcom bug tracker.

Currently, if "MIDI" is selected as the music format, songs from the GM.CAT file will be used if it exists, otherwise .MID files will be used. This means that if GM.CAT is present, .MID files cannot be used at all unless GM.CAT is removed from the SOUND subfolder of the game data directory. This also affects mods: if a mod provides music replacement via .MID files, they will not be played back if GM.CAT is present.

This change allows the user to choose between MIDI music from the GM.CAT file (if it exists) and separate .MID files. Besides the fact that the Steam version of UFO Defense comes with both GM.CAT and .MID files, this change will also benefit mod users (see above).

A minor issue with this change is that it appears to be impossible to detect which type of MIDI music is currently playing, since the current format is queried by a call to SDL_mixer. Also, the names of the new options in the combo box could probably be edited to be more user-friendly.
