### PR TITLE
Allow mods to define whether a unit can be captured alive

### DIFF
--- a/bin/standard/xcom1/units.rul
+++ b/bin/standard/xcom1/units.rul
@@ -307,6 +307,7 @@ units:
     energyRecovery: 50
     specab: 1
     livingWeapon: true
+    capturable: false
   - type: STR_FLOATER_SOLDIER
     race: STR_FLOATER
     rank: STR_LIVE_SOLDIER
@@ -829,6 +830,7 @@ units:
     aggression: 1
     energyRecovery: 50
     livingWeapon: true
+    capturable: false
   - type: STR_ZOMBIE
     race: STR_ZOMBIE
     rank: STR_LIVE_TERRORIST

--- a/src/Battlescape/UnitDieBState.cpp
+++ b/src/Battlescape/UnitDieBState.cpp
@@ -211,7 +211,7 @@ void UnitDieBState::think()
 		{
 			playDeathSound();
 		}
-		if (_unit->getStatus() == STATUS_UNCONSCIOUS && !_unit->isCapturable())
+		if (_unit->getStatus() == STATUS_UNCONSCIOUS && !_unit->getCapturable())
 		{
 			_unit->instaKill();
 		}

--- a/src/Battlescape/UnitDieBState.cpp
+++ b/src/Battlescape/UnitDieBState.cpp
@@ -211,7 +211,7 @@ void UnitDieBState::think()
 		{
 			playDeathSound();
 		}
-		if (_unit->getStatus() == STATUS_UNCONSCIOUS && (_unit->getSpecialAbility() == SPECAB_EXPLODEONDEATH || _unit->getSpecialAbility() == SPECAB_BURN_AND_EXPLODE))
+		if (_unit->getStatus() == STATUS_UNCONSCIOUS && !_unit->isCapturable())
 		{
 			_unit->instaKill();
 		}

--- a/src/Mod/Unit.cpp
+++ b/src/Mod/Unit.cpp
@@ -27,7 +27,7 @@ namespace OpenXcom
  * Creates a certain type of unit.
  * @param type String defining the type.
  */
-Unit::Unit(const std::string &type) : _type(type), _standHeight(0), _kneelHeight(0), _floatHeight(0), _value(0), _aggroSound(-1), _moveSound(-1), _intelligence(0), _aggression(0), _energyRecovery(30), _specab(SPECAB_NONE), _livingWeapon(false), _psiWeapon("ALIEN_PSI_WEAPON"), _capturable(CAP_DEFAULT)
+Unit::Unit(const std::string &type) : _type(type), _standHeight(0), _kneelHeight(0), _floatHeight(0), _value(0), _aggroSound(-1), _moveSound(-1), _intelligence(0), _aggression(0), _energyRecovery(30), _specab(SPECAB_NONE), _livingWeapon(false), _psiWeapon("ALIEN_PSI_WEAPON"), _capturable(true)
 {
 }
 
@@ -67,7 +67,7 @@ void Unit::load(const YAML::Node &node, Mod *mod)
 	_livingWeapon = node["livingWeapon"].as<bool>(_livingWeapon);
 	_meleeWeapon = node["meleeWeapon"].as<std::string>(_meleeWeapon);
 	_psiWeapon = node["psiWeapon"].as<std::string>(_psiWeapon);
-	_capturable = (Capturability)node["capturable"].as<int>(_capturable);
+	_capturable = node["capturable"].as<bool>(_capturable);
 	_builtInWeapons = node["builtInWeaponSets"].as<std::vector<std::vector<std::string> > >(_builtInWeapons);
 	if (node["builtInWeapons"])
 	{
@@ -298,7 +298,7 @@ const std::vector<std::vector<std::string> > &Unit::getBuiltInWeapons() const
 * Gets whether the alien can be captured alive.
 * @return a value determining whether the alien can be captured alive.
 */
-Capturability Unit::getCapturable() const
+bool Unit::getCapturable() const
 {
 	return _capturable;
 }

--- a/src/Mod/Unit.cpp
+++ b/src/Mod/Unit.cpp
@@ -27,7 +27,7 @@ namespace OpenXcom
  * Creates a certain type of unit.
  * @param type String defining the type.
  */
-Unit::Unit(const std::string &type) : _type(type), _standHeight(0), _kneelHeight(0), _floatHeight(0), _value(0), _aggroSound(-1), _moveSound(-1), _intelligence(0), _aggression(0), _energyRecovery(30), _specab(SPECAB_NONE), _livingWeapon(false), _psiWeapon("ALIEN_PSI_WEAPON")
+Unit::Unit(const std::string &type) : _type(type), _standHeight(0), _kneelHeight(0), _floatHeight(0), _value(0), _aggroSound(-1), _moveSound(-1), _intelligence(0), _aggression(0), _energyRecovery(30), _specab(SPECAB_NONE), _livingWeapon(false), _psiWeapon("ALIEN_PSI_WEAPON"), _capturable(CAP_DEFAULT)
 {
 }
 
@@ -67,6 +67,7 @@ void Unit::load(const YAML::Node &node, Mod *mod)
 	_livingWeapon = node["livingWeapon"].as<bool>(_livingWeapon);
 	_meleeWeapon = node["meleeWeapon"].as<std::string>(_meleeWeapon);
 	_psiWeapon = node["psiWeapon"].as<std::string>(_psiWeapon);
+	_capturable = (Capturability)node["capturable"].as<int>(_capturable);
 	_builtInWeapons = node["builtInWeaponSets"].as<std::vector<std::vector<std::string> > >(_builtInWeapons);
 	if (node["builtInWeapons"])
 	{
@@ -291,6 +292,15 @@ std::string Unit::getPsiWeapon() const
 const std::vector<std::vector<std::string> > &Unit::getBuiltInWeapons() const
 {
 	return _builtInWeapons;
+}
+
+/**
+* Gets whether the alien can be captured alive.
+* @return a value determining whether the alien can be captured alive.
+*/
+Capturability Unit::getCapturable() const
+{
+	return _capturable;
 }
 
 }

--- a/src/Mod/Unit.h
+++ b/src/Mod/Unit.h
@@ -24,6 +24,7 @@
 namespace OpenXcom
 {
 enum SpecialAbility { SPECAB_NONE, SPECAB_EXPLODEONDEATH, SPECAB_BURNFLOOR, SPECAB_BURN_AND_EXPLODE };
+enum Capturability { CAP_NOT_CAPTURABLE, CAP_ALWAYS_CAPTURABLE, CAP_DEFAULT };
 /**
  * This struct holds some plain unit attribute data together.
  */
@@ -71,6 +72,7 @@ private:
 	bool _livingWeapon;
 	std::string _meleeWeapon, _psiWeapon;
 	std::vector<std::vector<std::string> > _builtInWeapons;
+	Capturability _capturable;
 public:
 	/// Creates a blank unit ruleset.
 	Unit(const std::string &type);
@@ -120,6 +122,8 @@ public:
 	std::string getPsiWeapon() const;
 	/// Gets a vector of integrated items this unit has available.
 	const std::vector<std::vector<std::string> > &getBuiltInWeapons() const;
+	/// Gets whether the alien can be captured alive.
+	Capturability getCapturable() const;
 };
 
 }

--- a/src/Mod/Unit.h
+++ b/src/Mod/Unit.h
@@ -24,7 +24,6 @@
 namespace OpenXcom
 {
 enum SpecialAbility { SPECAB_NONE, SPECAB_EXPLODEONDEATH, SPECAB_BURNFLOOR, SPECAB_BURN_AND_EXPLODE };
-enum Capturability { CAP_NOT_CAPTURABLE, CAP_ALWAYS_CAPTURABLE, CAP_DEFAULT };
 /**
  * This struct holds some plain unit attribute data together.
  */
@@ -72,7 +71,7 @@ private:
 	bool _livingWeapon;
 	std::string _meleeWeapon, _psiWeapon;
 	std::vector<std::vector<std::string> > _builtInWeapons;
-	Capturability _capturable;
+	bool _capturable;
 public:
 	/// Creates a blank unit ruleset.
 	Unit(const std::string &type);
@@ -123,7 +122,7 @@ public:
 	/// Gets a vector of integrated items this unit has available.
 	const std::vector<std::vector<std::string> > &getBuiltInWeapons() const;
 	/// Gets whether the alien can be captured alive.
-	Capturability getCapturable() const;
+	bool getCapturable() const;
 };
 
 }

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -54,7 +54,7 @@ BattleUnit::BattleUnit(Soldier *soldier, int depth) :
 	_expBravery(0), _expReactions(0), _expFiring(0), _expThrowing(0), _expPsiSkill(0), _expPsiStrength(0), _expMelee(0),
 	_motionPoints(0), _kills(0), _hitByFire(false), _hitByAnything(false), _moraleRestored(0), _coverReserve(0), _charging(0), _turnsSinceSpotted(255),
 	_statistics(), _murdererId(0), _mindControllerID(0), _fatalShotSide(SIDE_FRONT), _fatalShotBodyPart(BODYPART_HEAD),
-	_geoscapeSoldier(soldier), _unitRules(0), _rankInt(0), _turretType(-1), _hidingForTurn(false), _respawn(false), _capturable(CAP_DEFAULT)
+	_geoscapeSoldier(soldier), _unitRules(0), _rankInt(0), _turretType(-1), _hidingForTurn(false), _respawn(false), _capturable(true)
 {
 	_name = soldier->getName(true);
 	_id = soldier->getId();
@@ -3291,18 +3291,9 @@ void BattleUnit::resetHitState()
 /**
  * Gets whether this unit can be captured alive (applies to aliens).
  */
-bool BattleUnit::isCapturable() const
+bool BattleUnit::getCapturable() const
 {
-	switch (_capturable)
-	{
-		case CAP_NOT_CAPTURABLE:
-			return false;
-		case CAP_ALWAYS_CAPTURABLE:
-			return true;
-		case CAP_DEFAULT:
-		default:
-			return !(getSpecialAbility() == SPECAB_EXPLODEONDEATH || getSpecialAbility() == SPECAB_BURN_AND_EXPLODE);
-	}
+	return _capturable;
 }
 
 }

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -54,7 +54,7 @@ BattleUnit::BattleUnit(Soldier *soldier, int depth) :
 	_expBravery(0), _expReactions(0), _expFiring(0), _expThrowing(0), _expPsiSkill(0), _expPsiStrength(0), _expMelee(0),
 	_motionPoints(0), _kills(0), _hitByFire(false), _hitByAnything(false), _moraleRestored(0), _coverReserve(0), _charging(0), _turnsSinceSpotted(255),
 	_statistics(), _murdererId(0), _mindControllerID(0), _fatalShotSide(SIDE_FRONT), _fatalShotBodyPart(BODYPART_HEAD),
-	_geoscapeSoldier(soldier), _unitRules(0), _rankInt(0), _turretType(-1), _hidingForTurn(false), _respawn(false)
+	_geoscapeSoldier(soldier), _unitRules(0), _rankInt(0), _turretType(-1), _hidingForTurn(false), _respawn(false), _capturable(CAP_DEFAULT)
 {
 	_name = soldier->getName(true);
 	_id = soldier->getId();
@@ -187,6 +187,7 @@ BattleUnit::BattleUnit(Unit *unit, UnitFaction faction, int id, Armor *armor, St
 	_spawnUnit = unit->getSpawnUnit();
 	_value = unit->getValue();
 	_faceDirection = -1;
+	_capturable = unit->getCapturable();
 
 	_movementType = _armor->getMovementType();
 	if (_movementType == MT_FLOAT)
@@ -3285,6 +3286,23 @@ bool BattleUnit::getHitState()
 void BattleUnit::resetHitState()
 {
 	_hitByAnything = false;
+}
+
+/**
+ * Gets whether this unit can be captured alive (applies to aliens).
+ */
+bool BattleUnit::isCapturable() const
+{
+	switch (_capturable)
+	{
+		case CAP_NOT_CAPTURABLE:
+			return false;
+		case CAP_ALWAYS_CAPTURABLE:
+			return true;
+		case CAP_DEFAULT:
+		default:
+			return !(getSpecialAbility() == SPECAB_EXPLODEONDEATH || getSpecialAbility() == SPECAB_BURN_AND_EXPLODE);
+	}
 }
 
 }

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -128,6 +128,7 @@ private:
 	bool _hidingForTurn, _floorAbove, _respawn;
 	MovementType _movementType;
 	std::vector<std::pair<Uint8, Uint8> > _recolor;
+	Capturability _capturable;
 
 	/// Helper function initing recolor vector.
 	void setRecolor(int basicLook, int utileLook, int rankLook);
@@ -502,7 +503,8 @@ public:
 	bool getHitState();
 	/// reset the unit hit state.
 	void resetHitState();
-
+	/// Gets whether this unit can be captured alive (applies to aliens).
+	bool isCapturable() const;
 };
 
 }

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -128,7 +128,7 @@ private:
 	bool _hidingForTurn, _floorAbove, _respawn;
 	MovementType _movementType;
 	std::vector<std::pair<Uint8, Uint8> > _recolor;
-	Capturability _capturable;
+	bool _capturable;
 
 	/// Helper function initing recolor vector.
 	void setRecolor(int basicLook, int utileLook, int rankLook);
@@ -504,7 +504,7 @@ public:
 	/// reset the unit hit state.
 	void resetHitState();
 	/// Gets whether this unit can be captured alive (applies to aliens).
-	bool isCapturable() const;
+	bool getCapturable() const;
 };
 
 }


### PR DESCRIPTION
This pull request has been created to implement [feature request #1398](https://openxcom.org/bugs/openxcom/issues/1398) filed on the OpenXcom bug tracker.

The logic which determines whether a unit can be captured or not is currently [hard-coded](https://github.com/SupSuper/OpenXcom/blob/master/src/Battlescape/UnitDieBState.cpp#L214). The unit can be captured alive if, and only if, it does not explode on death. There is no way to make a unit not capturable without making it explode on death, nor is it possible to make an alien which explodes on death capturable.


The proposed change introduces a new unit property called "capturable", which can take one of the three possible values:

* 0 (CAP_NOT_CAPTURABLE) - the unit cannot be captured alive by any means (it will simply die when it falls unconscious).
* 1 (CAP_ALWAYS_CAPTURABLE) - the unit can be captured even if the original logic wouldn't have allowed it (i.e. the unit explodes on death)
* 2 (CAP_DEFAULT) - the default, previously hard-coded logic applies (see above)

The default value for all units is 2 (CAP_DEFAULT), so that compatibility with existing mods is not broken. The original rulesets are NOT changed.

The implementation has been tested to work correctly for all values of the new property (battle generator + debug mode).