### PR TITLE
&glXXXVarName always has memory address value as it already initialized

### DIFF
--- a/src/Engine/OpenGL.cpp
+++ b/src/Engine/OpenGL.cpp
@@ -433,11 +433,11 @@ void OpenGL::init(int w, int h)
 
 
 
-	shader_support = &glCreateProgram && &glDeleteProgram && &glUseProgram && &glCreateShader
-	&& &glDeleteShader && &glShaderSource && &glCompileShader && &glAttachShader
-	&& &glDetachShader && &glLinkProgram && &glGetUniformLocation && &glIsProgram && &glIsShader
-	&& &glUniform1i && &glUniform2fv && &glUniform4fv && &glGetAttachedShaders
-	&& &glGetShaderiv && &glGetShaderInfoLog && &glGetProgramiv && &glGetProgramInfoLog;
+	shader_support = glCreateProgram && glDeleteProgram && glUseProgram && glCreateShader
+	&& glDeleteShader && glShaderSource && glCompileShader && glAttachShader
+	&& glDetachShader && glLinkProgram && glGetUniformLocation && glIsProgram && glIsShader
+	&& glUniform1i && glUniform2fv && glUniform4fv && glGetAttachedShaders
+	&& glGetShaderiv && glGetShaderInfoLog && glGetProgramiv && glGetProgramInfoLog;
 
 	if (shader_support)
 	{


### PR DESCRIPTION
at src/Engine/OpenGL.cpp L81:101 in non-apple platform

This raise warning, Debian8 x64 GCC 4.9.2-10, that treated as error as a result
of -Werror flag

full description of warnings:
<pre>
src/Engine/OpenGL.cpp: In member function ‘void OpenXcom::OpenGL::init(int, int)’:
src/Engine/OpenGL.cpp:436:40: error: the address of ‘OpenXcom::glCreateProgram’ will always evaluate as ‘true’ [-Werror=address]
  shader_support = &glCreateProgram && &glDeleteProgram && &glUseProgram && &glCreateShader
                                        ^
src/Engine/OpenGL.cpp:436:40: error: the address of ‘OpenXcom::glDeleteProgram’ will always evaluate as ‘true’ [-Werror=address]
src/Engine/OpenGL.cpp:436:60: error: the address of ‘OpenXcom::glUseProgram’ will always evaluate as ‘true’ [-Werror=address]
  shader_support = &glCreateProgram && &glDeleteProgram && &glUseProgram && &glCreateShader
                                                            ^
src/Engine/OpenGL.cpp:436:77: error: the address of ‘OpenXcom::glCreateShader’ will always evaluate as ‘true’ [-Werror=address]
  shader_support = &glCreateProgram && &glDeleteProgram && &glUseProgram && &glCreateShader
                                                                             ^
src/Engine/OpenGL.cpp:437:6: error: the address of ‘OpenXcom::glDeleteShader’ will always evaluate as ‘true’ [-Werror=address]
  && &glDeleteShader && &glShaderSource && &glCompileShader && &glAttachShader
      ^
src/Engine/OpenGL.cpp:437:25: error: the address of ‘OpenXcom::glShaderSource’ will always evaluate as ‘true’ [-Werror=address]
  && &glDeleteShader && &glShaderSource && &glCompileShader && &glAttachShader
                         ^
src/Engine/OpenGL.cpp:437:44: error: the address of ‘OpenXcom::glCompileShader’ will always evaluate as ‘true’ [-Werror=address]
  && &glDeleteShader && &glShaderSource && &glCompileShader && &glAttachShader
                                            ^
src/Engine/OpenGL.cpp:437:64: error: the address of ‘OpenXcom::glAttachShader’ will always evaluate as ‘true’ [-Werror=address]
  && &glDeleteShader && &glShaderSource && &glCompileShader && &glAttachShader
                                                                ^
src/Engine/OpenGL.cpp:438:6: error: the address of ‘OpenXcom::glDetachShader’ will always evaluate as ‘true’ [-Werror=address]
  && &glDetachShader && &glLinkProgram && &glGetUniformLocation && &glIsProgram && &glIsShader
      ^
src/Engine/OpenGL.cpp:438:25: error: the address of ‘OpenXcom::glLinkProgram’ will always evaluate as ‘true’ [-Werror=address]
  && &glDetachShader && &glLinkProgram && &glGetUniformLocation && &glIsProgram && &glIsShader
                         ^
src/Engine/OpenGL.cpp:438:43: error: the address of ‘OpenXcom::glGetUniformLocation’ will always evaluate as ‘true’ [-Werror=address]
  && &glDetachShader && &glLinkProgram && &glGetUniformLocation && &glIsProgram && &glIsShader
                                           ^
src/Engine/OpenGL.cpp:438:68: error: the address of ‘OpenXcom::glIsProgram’ will always evaluate as ‘true’ [-Werror=address]
  && &glDetachShader && &glLinkProgram && &glGetUniformLocation && &glIsProgram && &glIsShader
                                                                    ^
src/Engine/OpenGL.cpp:438:84: error: the address of ‘OpenXcom::glIsShader’ will always evaluate as ‘true’ [-Werror=address]
  && &glDetachShader && &glLinkProgram && &glGetUniformLocation && &glIsProgram && &glIsShader
                                                                                    ^
src/Engine/OpenGL.cpp:439:6: error: the address of ‘OpenXcom::glUniform1i’ will always evaluate as ‘true’ [-Werror=address]
  && &glUniform1i && &glUniform2fv && &glUniform4fv && &glGetAttachedShaders
      ^
src/Engine/OpenGL.cpp:439:22: error: the address of ‘OpenXcom::glUniform2fv’ will always evaluate as ‘true’ [-Werror=address]
  && &glUniform1i && &glUniform2fv && &glUniform4fv && &glGetAttachedShaders
                      ^
src/Engine/OpenGL.cpp:439:39: error: the address of ‘OpenXcom::glUniform4fv’ will always evaluate as ‘true’ [-Werror=address]
  && &glUniform1i && &glUniform2fv && &glUniform4fv && &glGetAttachedShaders
                                       ^
src/Engine/OpenGL.cpp:439:56: error: the address of ‘OpenXcom::glGetAttachedShaders’ will always evaluate as ‘true’ [-Werror=address]
  && &glUniform1i && &glUniform2fv && &glUniform4fv && &glGetAttachedShaders
                                                        ^
src/Engine/OpenGL.cpp:440:6: error: the address of ‘OpenXcom::glGetShaderiv’ will always evaluate as ‘true’ [-Werror=address]
  && &glGetShaderiv && &glGetShaderInfoLog && &glGetProgramiv && &glGetProgramInfoLog;
      ^
src/Engine/OpenGL.cpp:440:24: error: the address of ‘OpenXcom::glGetShaderInfoLog’ will always evaluate as ‘true’ [-Werror=address]
  && &glGetShaderiv && &glGetShaderInfoLog && &glGetProgramiv && &glGetProgramInfoLog;
                        ^
src/Engine/OpenGL.cpp:440:47: error: the address of ‘OpenXcom::glGetProgramiv’ will always evaluate as ‘true’ [-Werror=address]
  && &glGetShaderiv && &glGetShaderInfoLog && &glGetProgramiv && &glGetProgramInfoLog;
                                               ^
src/Engine/OpenGL.cpp:440:66: error: the address of ‘OpenXcom::glGetProgramInfoLog’ will always evaluate as ‘true’ [-Werror=address]
  && &glGetShaderiv && &glGetShaderInfoLog && &glGetProgramiv && &glGetProgramInfoLog;
                                                                  ^
  CXX      src/Engine/openxcom-OptionInfo.o
  CXX      src/Engine/openxcom-Options.o
  CXX      src/Engine/openxcom-Palette.o
cc1plus: all warnings being treated as errors

</pre>