### PR TITLE
Fixed BGM and depth for the GRUNGE terrain

### DIFF
--- a/bin/standard/xcom2/terrains.rul
+++ b/bin/standard/xcom2/terrains.rul
@@ -849,7 +849,8 @@ terrains: #done
         groups: 10
   - name: GRUNGE
     music:
-      - GMTACDRY
+      - GMTACWET
+    depth: [3, 3]
     ambience: 67
     ambientVolume: 0.25
     mapDataSets:


### PR DESCRIPTION
This PR is the proposed fix for [issue #1415](https://openxcom.org/bugs/openxcom/issues/1415) filed on the OpenXcom bug tracker.

In short: GRUNGE terrain seems to have wrong background music set in the standard ruleset (GMTACDRY instead of GMTACWET). It also doesn't have any depth set, which defaults to a depth of 0, though this is overridden by the alienDeployments.rul entry for the corresponding mission type (artifact site level 2). Nevertheless, I thought it would not hurt to specify the depth in this file also, considering it is specified for every other terrain where it differs from the default values, even if those terrains have it overridden during initialization.

BTW, considering the depth override, there seem to be certain inconsistencies between alienDeployments.rul and terrains.rul:

- Alien Colony level 1 deployment sets the depth range to [3, 3] but ENTRY terrain has a range of [2, 3]
- Alien Colony level 2 deployment sets the depth range to  [3, 3] but A_BASE terrain has a range of [1, 1]
- Artefact Site level 1 deployment sets the depth range to [1, 3] but ALART terrain has a range of [1, 2]. However, the override here doesn't seem to cause any effect as it uses the "siteDepth" parameter instead of just "depth". I couldn't find any references to this parameter within the game code outside of the AlienDeployment class; it seems to be unused by the game.

Which values are correct?