### PR TITLE
Fix depth and music not changing between stages in multi-stage missions

### DIFF
--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -371,6 +371,7 @@ void BattlescapeGenerator::nextStage()
 	ruleDeploy->getDimensions(&_mapsize_x, &_mapsize_y, &_mapsize_z);
 	size_t pick = RNG::generate(0, ruleDeploy->getTerrains().size() -1);
 	_terrain = _game->getMod()->getTerrain(ruleDeploy->getTerrains().at(pick), true);
+	setDepth(ruleDeploy, true);
 	_worldShade = ruleDeploy->getShade();
 
 	const std::vector<MapScript*> *script = _game->getMod()->getMapScript(_terrain->getScript());
@@ -485,6 +486,7 @@ void BattlescapeGenerator::nextStage()
 	deployCivilians(ruleDeploy->getCivilians());
 
 	_save->setAborted(false);
+	setMusic(ruleDeploy, true);
 	_save->setGlobalShade(_worldShade);
 	_save->getTileEngine()->calculateSunShading();
 	_save->getTileEngine()->calculateTerrainLighting();
@@ -526,19 +528,8 @@ void BattlescapeGenerator::run()
 			_terrain = _game->getMod()->getTerrain(_worldTexture->getRandomTerrain(target), true);
 		}
 	}
-
-	// new battle menu will have set the depth already
-	if (_save->getDepth() == 0)
-	{
-		if (ruleDeploy->getMaxDepth() > 0)
-		{
-			_save->setDepth(RNG::generate(ruleDeploy->getMinDepth(), ruleDeploy->getMaxDepth()));
-		}
-		else if (_terrain->getMaxDepth() > 0)
-		{
-			_save->setDepth(RNG::generate(_terrain->getMinDepth(), _terrain->getMaxDepth()));
-		}
-	}
+	
+	setDepth(ruleDeploy, false);
 
 	if (ruleDeploy->getShade() != -1)
 	{
@@ -586,14 +577,7 @@ void BattlescapeGenerator::run()
 		explodePowerSources();
 	}
 
-	if (!ruleDeploy->getMusic().empty())
-	{
-		_save->setMusic(ruleDeploy->getMusic().at(RNG::generate(0, ruleDeploy->getMusic().size()-1)));
-	}
-	else if (!_terrain->getMusic().empty())
-	{
-		_save->setMusic(_terrain->getMusic().at(RNG::generate(0, _terrain->getMusic().size()-1)));
-	}
+	setMusic(ruleDeploy, false);
 	// set shade (alien bases are a little darker, sites depend on worldshade)
 	_save->setGlobalShade(_worldShade);
 
@@ -2992,6 +2976,50 @@ void BattlescapeGenerator::setupObjectives(AlienDeployment *ruleDeploy)
 				_save->setObjectiveCount(objectives);
 			}
 		}
+	}
+}
+
+/**
+* Sets the depth based on the terrain or the provided AlienDeployment rule.
+* @param ruleDeploy the deployment data we're gleaning data from.
+* @param nextStage whether the mission is progressing to the next stage.
+*/
+void BattlescapeGenerator::setDepth(AlienDeployment* ruleDeploy, bool nextStage)
+{
+	if (_save->getDepth() > 0 && !nextStage)
+	{
+		// new battle menu will have set the depth already
+		return;
+	}
+
+	if (ruleDeploy->getMaxDepth() > 0)
+	{
+		_save->setDepth(RNG::generate(ruleDeploy->getMinDepth(), ruleDeploy->getMaxDepth()));
+	}
+	else if (_terrain->getMaxDepth() > 0 || nextStage)
+	{
+		_save->setDepth(RNG::generate(_terrain->getMinDepth(), _terrain->getMaxDepth()));
+	}
+}
+
+/**
+* Sets the background music based on the terrain or the provided AlienDeployment rule.
+* @param ruleDeploy the deployment data we're gleaning data from.
+* @param nextStage whether the mission is progressing to the next stage.
+*/
+void BattlescapeGenerator::setMusic(AlienDeployment* ruleDeploy, bool nextStage)
+{
+	if (!ruleDeploy->getMusic().empty())
+	{
+		_save->setMusic(ruleDeploy->getMusic().at(RNG::generate(0, ruleDeploy->getMusic().size() - 1)));
+	}
+	else if (!_terrain->getMusic().empty())
+	{
+		_save->setMusic(_terrain->getMusic().at(RNG::generate(0, _terrain->getMusic().size() - 1)));
+	}
+	else if (nextStage)
+	{
+		_save->setMusic("");
 	}
 }
 

--- a/src/Battlescape/BattlescapeGenerator.h
+++ b/src/Battlescape/BattlescapeGenerator.h
@@ -132,6 +132,10 @@ private:
 	void drillModules(TunnelData* data, const std::vector<SDL_Rect *> *rects, MapDirection dir);
 	/// Clears all modules in a rect from a command.
 	bool removeBlocks(MapScript *command);
+	/// Sets the depth based on the terrain or the provided AlienDeployment rule.
+	void setDepth(AlienDeployment* ruleDeploy, bool nextStage);
+	/// Sets the background music based on the terrain or the provided AlienDeployment rule.
+	void setMusic(AlienDeployment* ruleDeploy, bool nextStage);
 public:
 	/// Creates a new BattlescapeGenerator class
 	BattlescapeGenerator(Game* game);


### PR DESCRIPTION
This PR fixes [issue #1416](https://openxcom.org/bugs/openxcom/issues/1416) filed on the OpenXcom bug tracker.

In short: depth and music will now change between mission stages as they should.

In detail: this PR adds two new private methods to BattlescapeGenerator.cpp: setDepth and setMusic with code refactored into them from the run method. These methods are now called in the run method as well as the nextStage method in BattlescapeGenerator.cpp. Note that these methods have to know whether the mission is currently at the first stage or progressing to a new stage.

Notes about the setDepth method:
- First we need to check if the depth is already set (not 0) by the battle generator (original behavior). This also requires the mission to be at the first stage.
- We assume that an AlienDeployment cannot force an underwater terrain to have a depth of 0 (land), so 0 instead means "use terrain depth", and thus the check for 0 here does not need any extra checks.
- Note that with the current code it is possible for an AlienDeployment to override a land terrain (depth 0) to be an underwater terrain. This is possibly unintended, but it is the current behavior (not changed by this PR). To rectify this, it would be necessary to also check for _terrain->getMaxDepth() > 0 when checking the AlienDeployment depth.
- If the terrain has a depth of 0, it needs to be set at a new stage only, because otherwise it would already be 0.

Notes about the setMusic method:
- We assume that if an AlienDeployment has an empty music vector, this means "use terrain music", so the check for emptiness here does not need any extra checks.
- If a terrain does not have any music set, we will set an empty music at a new stage only, because otherwise it would already be empty (note that empty music name seems to default to GMTACTIC).
