### PR TITLE
Fix incorrect titles of alien base assaults in soldier diaries

### DIFF
--- a/bin/standard/xcom1/alienDeployments.rul
+++ b/bin/standard/xcom1/alienDeployments.rul
@@ -997,7 +997,7 @@ alienDeployments:
       background: BACK01.SCR
       showTarget: false
     objectiveType: 3
-    markerName: STR_ALIEN_BASE
+    markerName: STR_ALIEN_BASE_
     markerIcon: 7
     genMission:
       STR_ALIEN_SUPPLY: 100

--- a/bin/standard/xcom2/alienDeployments.rul
+++ b/bin/standard/xcom2/alienDeployments.rul
@@ -2124,7 +2124,7 @@ alienDeployments: #done
     shade: 15
     depth: [3, 3]
     race: STR_MIXED_CREW
-    markerName: STR_ALIEN_BASE
+    markerName: STR_ALIEN_BASE_
     markerIcon: 7
     genMission:
       STR_ALIEN_SUPPLY: 100

--- a/src/Savegame/AlienBase.cpp
+++ b/src/Savegame/AlienBase.cpp
@@ -103,7 +103,7 @@ void AlienBase::setId(int id)
  */
 std::wstring AlienBase::getDefaultName(Language *lang) const
 {
-	return lang->getString(_deployment->getMarkerName() + "_").arg(_id);
+	return lang->getString(_deployment->getMarkerName()).arg(_id);
 }
 
 /**


### PR DESCRIPTION
This PR fixes [issue #1413](https://openxcom.org/bugs/openxcom/issues/1413) filed on the OpenXcom bug tracker.

In short: instead of "ALIEN BASE-N" and "ALIEN COLONY-N", alien base / colony assaults in soldier diaries will all be titled "Alien Base" / "Alien Colony Expansion". In XCOM 1, it looks legit at first, probably that's why nobody has noticed it yet. In TFTD, however, this is just plain wrong (because "Alien Colony Expansion" is actually the name of an alien mission, just like "Alien Base" is).

In detail: it seems that no other changes besides the ones proposed in the initial report are needed to fix this. Note, however, that existing saves will not be compatible if there are any active Alien Supply missions. This is because the corresponding AlienDeployment's markerName (I wonder why that and not the deployment's actual name?) seems to be used as part of an alien base's unique identifier, and the base will not be found by the game because markerName will have been changed. Saves can be fixed by manually editing the corresponding lines, however. Mission titles in soldier diaries will also NOT be fixed automatically, though any new alien base assaults will generate correct mission titles.

Side note: one peculiar appearance of "STR_ALIEN_BASE" in the code is in DebriefingState.cpp (prepareDebriefing method). It does not seem to be used for anything other than control flow, however, and is never converted into an actual translated string.
