### PR TITLE
Fix monthly costs display for soldier types with salary but not purchasable.

### DIFF
--- a/src/Basescape/MonthlyCostsState.cpp
+++ b/src/Basescape/MonthlyCostsState.cpp
@@ -129,7 +129,7 @@ MonthlyCostsState::MonthlyCostsState(Base *base) : _base(base)
 	for (std::vector<std::string>::const_iterator i = soldiers.begin(); i != soldiers.end(); ++i)
 	{
 		RuleSoldier *soldier = _game->getMod()->getSoldier(*i);
-		if (soldier->getBuyCost() != 0 && _game->getSavedGame()->isResearched(soldier->getRequirements()))
+		if (soldier->getSalaryCost() != 0 && _game->getSavedGame()->isResearched(soldier->getRequirements()))
 		{
 			std::wostringstream ss4;
 			ss4 << _base->getSoldierCount(*i);


### PR DESCRIPTION
Fixes small bug in monthly costs report where soldiers with a salary but can not be purchased (ex: custom starting soldiers) would not appear on the report.