### PR TITLE
Reduce osx build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,13 @@ addons:
       - libsdl-mixer1.2-dev
       - libsdl-image1.2-dev
       - libsdl-gfx1.2-dev
+  homebrew:
+    brewfile: Brewfile.travis
 
 env:
   - BUILD_TYPE=Release EXTRA_WARNING_FLAGS="-Wall -Wextra"
 
 before_install:
-  - if [ $TRAVIS_OS_NAME == osx ]; then brew install yaml-cpp sdl sdl_gfx sdl_image sdl_mixer --with-flac --with-libmikmod --with-libvorbis --with-static-lib; fi
   - if [ $TRAVIS_OS_NAME == linux ]; then mkdir $TRAVIS_BUILD_DIR/dependency-prefix; fi
   - if [ $TRAVIS_OS_NAME == linux ]; then export PKG_CONFIG_PATH=$TRAVIS_BUILD_DIR/dependency-prefix/lib/pkgconfig; fi
 

--- a/Brewfile.travis
+++ b/Brewfile.travis
@@ -1,0 +1,5 @@
+brew "yaml-cpp"
+brew "sdl"
+brew "sdl_gfx"
+brew "sdl_image"
+brew "sdl_mixer", args: ["with-flac"]


### PR DESCRIPTION
By using a Brewfile travis skips the `brew update` part which contributes significantly to the build time.
Contrary to the alternative (using homebrew packages inside `.travis.yml` a Brewfile allows to specify formulae options, needed for flac.

`yaml-cpp` no longer uses the `--static-lib` option (saves ~2 minutes).

The options: `--with-libmikmod --with-libvorbis` are part of he default formulae for `sdl_mixer` hence they are omitted.

Brewfile package information is available at: https://formulae.brew.sh/formula/