### PR TITLE
Feature - define inventory rules per armor

### DIFF
--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -2029,6 +2029,7 @@ bool BattlescapeGame::takeItem(BattleItem* item, BattleAction *action)
 {
 	bool placed = false;
 	Mod *mod = _parentState->getGame()->getMod();
+	RuleInventory * ruleI;
 	switch (item->getRules()->getBattleType())
 	{
 	case BT_AMMO:
@@ -2042,13 +2043,16 @@ bool BattlescapeGame::takeItem(BattleItem* item, BattleAction *action)
 		}
 		else
 		{
-			for (int i = 0; i != 4; ++i)
+			ruleI = mod->getInventory(action->actor->getArmor()->getDefaultInventoryMap("STR_BELT"), true);
+			//try to fit in the inventoryrule and test the actual inventory is empty also
+			for (std::vector<struct RuleSlot>::const_iterator is = ruleI->getSlots()->cbegin(); is != ruleI->getSlots()->cend(); is++)
 			{
-				if (!action->actor->getItem("STR_BELT", i))
+				if (ruleI->fitItemInSlot(item->getRules(), is->x, is->y, action->actor))
 				{
 					item->moveToOwner(action->actor);
-					item->setSlot(mod->getInventory("STR_BELT", true));
-					item->setSlotX(i);
+					item->setSlot(ruleI);
+					item->setSlotX(is->x);
+					item->setSlotY(is->y);
 					placed = true;
 					break;
 				}
@@ -2057,13 +2061,16 @@ bool BattlescapeGame::takeItem(BattleItem* item, BattleAction *action)
 		break;
 	case BT_GRENADE:
 	case BT_PROXIMITYGRENADE:
-		for (int i = 0; i != 4; ++i)
+		ruleI = mod->getInventory(action->actor->getArmor()->getDefaultInventoryMap("STR_BELT"), true);
+		//try to fit in the inventoryrule and test the actual inventory is empty also
+		for (std::vector<struct RuleSlot>::const_iterator is = ruleI->getSlots()->cbegin(); is != ruleI->getSlots()->cend(); is++)
 		{
-			if (!action->actor->getItem("STR_BELT", i))
+			if (ruleI->fitItemInSlot(item->getRules(), is->x, is->y, action->actor))
 			{
 				item->moveToOwner(action->actor);
-				item->setSlot(mod->getInventory("STR_BELT", true));
-				item->setSlotX(i);
+				item->setSlot(ruleI);
+				item->setSlotX(is->x);
+				item->setSlotY(is->y);
 				placed = true;
 				break;
 			}
@@ -2074,24 +2081,32 @@ bool BattlescapeGame::takeItem(BattleItem* item, BattleAction *action)
 		if (!action->actor->getItem("STR_RIGHT_HAND"))
 		{
 			item->moveToOwner(action->actor);
-			item->setSlot(mod->getInventory("STR_RIGHT_HAND", true));
+			item->setSlot(mod->getInventory(action->actor->getArmor()->getDefaultInventoryMap("STR_RIGHT_HAND"), true));
 			placed = true;
 		}
 		break;
 	case BT_MEDIKIT:
 	case BT_SCANNER:
-		if (!action->actor->getItem("STR_BACK_PACK"))
+		ruleI = mod->getInventory(action->actor->getArmor()->getDefaultInventoryMap("STR_BACK_PACK"), true);
+		//try to fit in the inventoryrule and test the actual inventory is empty also
+		for (std::vector<struct RuleSlot>::const_iterator is = ruleI->getSlots()->cbegin(); is != ruleI->getSlots()->cend(); is++)
 		{
-			item->moveToOwner(action->actor);
-			item->setSlot(mod->getInventory("STR_BACK_PACK", true));
-			placed = true;
+			if (ruleI->fitItemInSlot(item->getRules(), is->x, is->y, action->actor))
+			{
+				item->moveToOwner(action->actor);
+				item->setSlot(ruleI);
+				item->setSlotX(is->x);
+				item->setSlotY(is->y);
+				placed = true;
+				break;
+			}
 		}
 		break;
 	case BT_MINDPROBE:
 		if (!action->actor->getItem("STR_LEFT_HAND"))
 		{
 			item->moveToOwner(action->actor);
-			item->setSlot(mod->getInventory("STR_LEFT_HAND", true));
+			item->setSlot(mod->getInventory(action->actor->getArmor()->getDefaultInventoryMap("STR_LEFT_HAND"), true));
 			placed = true;
 		}
 		break;

--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -1315,8 +1315,8 @@ bool BattlescapeGenerator::placeItemByLayout(BattleItem *item)
  */
 static bool _addItem(BattleItem *item, BattleUnit *unit, Mod *mod, SavedBattleGame *addToSave, bool allowAutoLoadout, bool allowSecondClip)
 {
-	RuleInventory *rightHand = mod->getInventory("STR_RIGHT_HAND", true);
-	RuleInventory *leftHand = mod->getInventory("STR_LEFT_HAND", true);
+	RuleInventory *rightHand = mod->getInventory(unit->getArmor()->getDefaultInventoryMap("STR_RIGHT_HAND"), true);
+	RuleInventory *leftHand = mod->getInventory(unit->getArmor()->getDefaultInventoryMap("STR_LEFT_HAND"), true);
 	bool placed = false;
 	bool loaded = false;
 	BattleItem *rightWeapon = unit->getItem("STR_RIGHT_HAND");
@@ -1455,7 +1455,7 @@ static bool _addItem(BattleItem *item, BattleUnit *unit, Mod *mod, SavedBattleGa
 		{
 			if (unit->getBaseStats()->strength >= weight) // weight is always considered 0 for aliens
 			{
-				for (std::vector<std::string>::const_iterator i = mod->getInvsList().begin(); i != mod->getInvsList().end() && !placed; ++i)
+				for (std::vector<std::string>::const_iterator i = unit->getArmor()->getInventorySlots().begin(); i != unit->getArmor()->getInventorySlots().end() && !placed; ++i)
 				{
 					RuleInventory *slot = mod->getInventory(*i);
 					if (slot->getType() == INV_SLOT)

--- a/src/Battlescape/InventoryState.cpp
+++ b/src/Battlescape/InventoryState.cpp
@@ -218,9 +218,9 @@ InventoryState::InventoryState(bool tu, BattlescapeState *parent) : _tu(tu), _pa
 		_updateTemplateButtons(true);
 	}
 
-	_inv->draw();
-	_inv->setTuMode(_tu);
 	_inv->setSelectedUnit(_game->getSavedGame()->getSavedBattle()->getSelectedUnit());
+	_inv->setTuMode(_tu);
+	_inv->draw();
 	_inv->onMouseClick((ActionHandler)&InventoryState::invClick, 0);
 	_inv->onMouseOver((ActionHandler)&InventoryState::invMouseOver);
 	_inv->onMouseOut((ActionHandler)&InventoryState::invMouseOut);
@@ -314,6 +314,7 @@ void InventoryState::init()
 	_txtName->setBig();
 	_txtName->setText(unit->getName(_game->getLanguage()));
 	_inv->setSelectedUnit(unit);
+	_inv->draw();
 	Soldier *s = unit->getGeoscapeSoldier();
 	if (s)
 	{

--- a/src/Mod/Armor.cpp
+++ b/src/Mod/Armor.cpp
@@ -17,6 +17,7 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "Armor.h"
+#include "../Mod/RuleInventory.h"
 
 namespace OpenXcom
 {
@@ -37,6 +38,11 @@ Armor::Armor(const std::string &type) :
 {
 	for (int i=0; i < DAMAGE_TYPES; i++)
 		_damageModifier[i] = 1.0f;
+	for (std::vector<std::string>::const_iterator i = RuleInventory::DefaultInventories.cbegin(); i != RuleInventory::DefaultInventories.cend() ; i++)
+	{
+		_inventorySlots.push_back(*i);
+		_defaultInventoriesMap[*i] = *i;
+	}
 }
 
 /**
@@ -114,6 +120,15 @@ void Armor::load(const YAML::Node &node)
 	_rankColor = node["spriteRankColor"].as<std::vector<int> >(_rankColor);
 	_utileColor = node["spriteUtileColor"].as<std::vector<int> >(_utileColor);
 	_units = node["units"].as< std::vector<std::string> >(_units);
+	if(const YAML::Node &tst = node["inventorySlots"])
+		_inventorySlots = tst.as< std::vector<std::string> >(_inventorySlots);
+	if (const YAML::Node &tst = node["defaultInventoriesMap"])
+	{
+		std::map<std::string, std::string> par = tst.as <std::map<std::string, std::string> >(par);
+		for (std::map<std::string, std::string>::iterator i = par.begin(); i != par.end(); ++i)
+			_defaultInventoriesMap[i->first] = i->second;
+
+	}
 }
 
 /**
@@ -438,6 +453,27 @@ bool Armor::hasInventory() const
 const std::vector<std::string> &Armor::getUnits() const
 {
 	return _units;
+}
+
+/**
+* Gets the list of inventory slots this armor posess.
+* @return The list of inventory slots (empty => no inventory).
+*/
+const std::vector<std::string> &Armor::getInventorySlots() const
+{
+	return _inventorySlots;
+}
+
+/**
+* Gets the default inventory rule mapping.
+* @return The default inventory rule mapping.
+*/
+std::string Armor::getDefaultInventoryMap(std::string s) const
+{
+	std::map<std::string, std::string>::const_iterator i = _defaultInventoriesMap.find(s);
+	if(i != _defaultInventoriesMap.cend())
+		return i->second;
+	return s;
 }
 
 }

--- a/src/Mod/Armor.h
+++ b/src/Mod/Armor.h
@@ -51,7 +51,8 @@ private:
 	ForcedTorso _forcedTorso;
 	int _faceColorGroup, _hairColorGroup, _utileColorGroup, _rankColorGroup;
 	std::vector<int> _faceColor, _hairColor, _utileColor, _rankColor;
-	std::vector<std::string> _units;
+	std::vector<std::string> _units, _inventorySlots;
+	std::map<std::string, std::string> _defaultInventoriesMap;
 public:
 	/// Creates a blank armor ruleset.
 	Armor(const std::string &type);
@@ -123,6 +124,10 @@ public:
 	bool hasInventory() const;
 	/// Gets the armor's units.
 	const std::vector<std::string> &getUnits() const;
+	/// Gets the armor's inventory slots.
+	const std::vector<std::string> &getInventorySlots() const;
+	/// Gets the default inventory rules mapping
+	std::string getDefaultInventoryMap(std::string s) const;
 };
 
 }

--- a/src/Mod/RuleInventory.cpp
+++ b/src/Mod/RuleInventory.cpp
@@ -19,6 +19,7 @@
 #include "RuleInventory.h"
 #include <cmath>
 #include "RuleItem.h"
+#include "../Savegame/BattleUnit.h"
 
 namespace YAML
 {
@@ -48,6 +49,7 @@ namespace YAML
 namespace OpenXcom
 {
 
+const std::vector<std::string> RuleInventory::DefaultInventories = { "STR_GROUND", "STR_RIGHT_HAND", "STR_LEFT_HAND", "STR_BELT", "STR_RIGHT_LEG", "STR_LEFT_LEG", "STR_RIGHT_SHOULDER", "STR_LEFT_SHOULDER", "STR_BACK_PACK" };
 /**
  * Creates a blank ruleset for a certain
  * type of inventory section.
@@ -184,7 +186,7 @@ bool RuleInventory::checkSlotInPosition(int *x, int *y) const
  * @param y Slot Y position.
  * @return True if there's a slot there.
  */
-bool RuleInventory::fitItemInSlot(RuleItem *item, int x, int y) const
+bool RuleInventory::fitItemInSlot(RuleItem *item, int x, int y, BattleUnit *bu) const
 {
 	if (_type == INV_HAND)
 	{
@@ -216,6 +218,8 @@ bool RuleInventory::fitItemInSlot(RuleItem *item, int x, int y) const
 			if (i->x >= x && i->x < x + item->getInventoryWidth() &&
 				i->y >= y && i->y < y + item->getInventoryHeight())
 			{
+				if (bu && bu->getItem(this, i->x, i->y))
+					return false;
 				foundSlots++;
 			}
 		}

--- a/src/Mod/RuleInventory.h
+++ b/src/Mod/RuleInventory.h
@@ -33,6 +33,7 @@ struct RuleSlot
 enum InventoryType { INV_SLOT, INV_HAND, INV_GROUND };
 
 class RuleItem;
+class BattleUnit;
 
 /**
  * Represents a specific section of the inventory,
@@ -53,6 +54,7 @@ public:
 	static const int SLOT_H = 16;
 	static const int HAND_W = 2;
 	static const int HAND_H = 3;
+	static const std::vector<std::string> DefaultInventories;
 	/// Creates a blank inventory ruleset.
 	RuleInventory(const std::string &id);
 	/// Cleans up the inventory ruleset.
@@ -72,7 +74,7 @@ public:
 	/// Checks for a slot in a certain position.
 	bool checkSlotInPosition(int *x, int *y) const;
 	/// Checks if an item fits in a slot.
-	bool fitItemInSlot(RuleItem *item, int x, int y) const;
+	bool fitItemInSlot(RuleItem *item, int x, int y, BattleUnit *bu=NULL) const;
 	/// Gets a certain cost in the inventory.
 	int getCost(RuleInventory *slot) const;
 	int getListOrder() const;

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -1889,7 +1889,7 @@ Tile *BattleUnit::getTile() const
  * @param y Y position in slot.
  * @return Item in the slot, or NULL if none.
  */
-BattleItem *BattleUnit::getItem(RuleInventory *slot, int x, int y) const
+BattleItem *BattleUnit::getItem(const RuleInventory *slot, int x, int y) const
 {
 	// Soldier items
 	if (slot->getType() != INV_GROUND)
@@ -1926,12 +1926,20 @@ BattleItem *BattleUnit::getItem(RuleInventory *slot, int x, int y) const
  */
 BattleItem *BattleUnit::getItem(const std::string &slot, int x, int y) const
 {
+	//translate Inventory slot key
+	std::string actualSlot = slot;
+	for (std::vector<std::string>::const_iterator i = RuleInventory::DefaultInventories.cbegin(); i != RuleInventory::DefaultInventories.cend(); i++)
+		if (slot == *i)
+		{
+			actualSlot = _armor->getDefaultInventoryMap(slot);
+			break;
+		}
 	// Soldier items
 	if (slot != "STR_GROUND")
 	{
 		for (std::vector<BattleItem*>::const_iterator i = _inventory.begin(); i != _inventory.end(); ++i)
 		{
-			if ((*i)->getSlot() != 0 && (*i)->getSlot()->getId() == slot && (*i)->occupiesSlot(x, y))
+			if ((*i)->getSlot() != 0 && (*i)->getSlot()->getId() == actualSlot && (*i)->occupiesSlot(x, y))
 			{
 				return *i;
 			}

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -298,7 +298,7 @@ public:
 	/// Gets the unit's tile.
 	Tile *getTile() const;
 	/// Gets the item in the specified slot.
-	BattleItem *getItem(RuleInventory *slot, int x = 0, int y = 0) const;
+	BattleItem *getItem(const RuleInventory *slot, int x = 0, int y = 0) const;
 	/// Gets the item in the specified slot.
 	BattleItem *getItem(const std::string &slot, int x = 0, int y = 0) const;
 	/// Gets the item in the main hand.


### PR DESCRIPTION
Creation inspired by the workarounds Solarius_Scorch did in the XCOM-Files mod to hide some inventory slots...
This PR will allow to create many overlapping inventory rules (different size of e.g. belts, backpacks, etc.), which may overlap, and they may even have no slots and blank (" ") label to be fully hidden besides being fully unusable.
Modding descriptions =>
Each armor rule may contain an inventorySlots vector stating the inventory rules this armor has - e.g.:
    inventorySlots:
      - STR_GROUND
      - STR_RIGHT_HAND
      - STR_LEFT_HAND
      - STR_SMALL_BELT
      - STR_SMALL_RIGHT_LEG
      - STR_SMALL_LEFT_LEG
      - STR_RIGHT_SHOULDER
      - STR_LEFT_SHOULDER
      - STR_SMALL_BACK_PACK
Plus a map which will map default missing inventory rules to new ones:
    defaultInventoriesMap:
      STR_BELT: STR_SMALL_BELT
      STR_RIGHT_LEG: STR_SMALL_RIGHT_LEG
      STR_LEFT_LEG: STR_SMALL_LEFT_LEG
      STR_BACK_PACK: STR_SMALL_BACK_PACK
Both are optional, the default existing inventories will work without change.
The new inventory rules shall have, of course, the appropriate translations also.