### PR TITLE
Fixed civilian scoring

### DIFF
--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -1649,10 +1649,6 @@ void DebriefingState::recoverItems(std::vector<BattleItem*> *from, Base *base)
 						{
 							recoverAlien(corpseUnit, base);
 						}
-						else if (corpseUnit->getOriginalFaction() == FACTION_NEUTRAL)
-						{
-							addStat("STR_CIVILIANS_SAVED", 1, corpseUnit->getValue());
-						}
 					}
 				}
 				// only add recovery points for unresearched items


### PR DESCRIPTION
1. if civilians are not recoverable (e.g. vanilla), this was unreachable code
2. if civilians are recoverable (e.g. mods), this caused the unconscious ones to be counted twice