### PR TITLE
Fix offset pixels on MiniBaseView when using on SDL_compat-1.2.68

### DIFF
--- a/src/Engine/Surface.cpp
+++ b/src/Engine/Surface.cpp
@@ -706,6 +706,8 @@ void Surface::copy(Surface *surface)
  */
 void Surface::drawRect(SDL_Rect *rect, Uint8 color)
 {
+	if (rect->w == 0 || rect->h == 0) return;
+
 	SDL_FillRect(_surface, rect, color);
 }
 
@@ -719,6 +721,8 @@ void Surface::drawRect(SDL_Rect *rect, Uint8 color)
  */
 void Surface::drawRect(Sint16 x, Sint16 y, Sint16 w, Sint16 h, Uint8 color)
 {
+	if (w == 0 || h == 0) return;
+
 	SDL_Rect rect;
 	rect.w = w;
 	rect.h = h;


### PR DESCRIPTION
Fixes the problem where `MiniBaseView` showed an offset pixel when depending on SDLcompat-1.2.68.

| Error | expected |
| ------------- | ------------- |
| <img width="49" height="58" alt="image" src="https://github.com/user-attachments/assets/0a80cf93-b334-4657-b974-e2130333957b" /> | <img width="57" height="53" alt="image" src="https://github.com/user-attachments/assets/0e76d131-90bf-47ae-9fb3-e494e3febe88" />  |

This is caused by ``SDL_FillRect`` losing context when trying to draw a rectangle where one (or more) dimension is 0.
We are not sure if this is intended behavior or undefined behavior, but at least we can guard against this (what is a zero dimension supposed to draw?).

The mentioned error originated from ``MiniBaseView::draw()``
```c++
// Draw facilities
if (i < _bases->size())
{
	SDL_Rect r;
	lock();
	for (std::vector<BaseFacility*>::iterator f = _bases->at(i)->getFacilities()->begin(); f != _bases->at(i)->getFacilities()->end(); ++f)
	{
		int color;
		if ((*f)->getBuildTime() == 0)
			color = _green;
		else
			color = _red;

		r.x = i * (MINI_SIZE + 2) + 2 + (*f)->getX() * 2;
		r.y = 2 + (*f)->getY() * 2;
		r.w = (*f)->getRules()->getSize() * 2; // r1do:  = 2 for 1x1
		r.h = (*f)->getRules()->getSize() * 2; // r1do:  = 2 for 1x1
		drawRect(&r, color+3);
		r.x++;
		r.y++;
		r.w--; // r1do: = 1 for 1x1
		r.h--; // r1do: = 1 for 1x1
		drawRect(&r, color+5);
		r.x--;
		r.y--;
		drawRect(&r, color+2);
// Start context loss on SDLcompat 1.2.68
		r.x++;
		r.y++;
		r.w--; // r1do: = 0 for 1x1
		r.h--; // r1do: = 0 for 1x1
		drawRect(&r, color+3); // r1do: Tries to draw a 0x0 rectangle for 1x1 facilities
// End of context loss
		r.x--;
		r.y--;
		setPixel(r.x, r.y, color+1);
	}
	unlock();
}
```
Since some forks adapted this part, so I found it safer to put the guard in the ``surface::drawRect()`` routines as to prevent merge issues.
