### PR TITLE
Making macOS Universal Builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -255,7 +255,13 @@ jobs:
 
       - name: Compile source code
         run: |
-          cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/opt/local -G Ninja -B build
+          CMAKE_EXTRA_ARGS=(-DCMAKE_OSX_ARCHITECTURES="arm64;x86_64")
+          if [ -d /opt/local/share/doc/sdl12-compat ]
+          then
+            echo "SDL12-compat detected, linking SDL2 as well"
+            CMAKE_EXTRA_ARGS+=("-DEXTRA_XCOM_LIBS=/opt/local/lib/libSDL2.dylib")
+          fi
+          cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/opt/local -G Ninja -B build "${CMAKE_EXTRA_ARGS[@]}"
           cmake --build build
 
       - name: Create an archive with .app in it

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -493,7 +493,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES FreeBSD OR ${CMAKE_SYSTEM_NAME} MATCHES NetBSD 
   set ( system_libs -lexecinfo )
 endif ()
 
-target_link_libraries ( openxcom ${system_libs} ${SDLIMAGE_LIBRARY} ${SDLMIXER_LIBRARY} ${SDLGFX_LIBRARY} ${SDL_LIBRARY} ${OPENGL_LIBRARIES} debug ${YAMLCPP_LIBRARY_DEBUG} optimized ${YAMLCPP_LIBRARY} )
+target_link_libraries ( openxcom ${system_libs} ${SDLIMAGE_LIBRARY} ${SDLMIXER_LIBRARY} ${SDLGFX_LIBRARY} ${SDL_LIBRARY} ${OPENGL_LIBRARIES} ${EXTRA_XCOM_LIBS} debug ${YAMLCPP_LIBRARY_DEBUG} optimized ${YAMLCPP_LIBRARY} )
 
 # Pack libraries into bundle and link executable appropriately
 if ( APPLE AND CREATE_BUNDLE )


### PR DESCRIPTION
I noticed that latest daily while has working macOS build, and all the libraries are universal, the main binary is only arm64

This PR enables Universal x64 (Intel) and arm64 builds for nighties. It means both old Intel macs and new ARM64 macs Would be able to run the game.

It also detects if SDL_compat is used and links SDL2 then as well