### PR TITLE
SDL_port for macOS

### DIFF
--- a/scripts/macports-config.yml
+++ b/scripts/macports-config.yml
@@ -6,8 +6,6 @@ variants:
 ports:
   - name: libsdl
     select:
-      - legacy
-    deselect:
       - compat
   - name: libsdl_gfx
   - name: libsdl_image


### PR DESCRIPTION
I tried play testing both, and didn't see any SDL_port bugs, and experience is much better compared to the legacy SDL library.

I would recommend moving to SDL_port for macos. Full screen is quite broken with legacy one, and windowed isn't much better :(