### PR TITLE
Correct nighttime shading of geoscape land textures

### DIFF
--- a/src/Geoscape/Globe.cpp
+++ b/src/Geoscape/Globe.cpp
@@ -208,7 +208,7 @@ struct CreateShadow
 	static inline Uint8 getLandShadow(const Uint8& dest, const Uint8& shadow)
 	{
 		if (shadow == 0) return dest;
-		const int s = shadow / 3;
+		const int s = shadow / 4 + 1;
 		const int e = dest + s;
 		const int d = dest & helper::ColorGroup;
 		if (e > d + helper::ColorShade)
@@ -1060,7 +1060,7 @@ void Globe::XuLine(Surface* surface, Surface* src, double x1, double y1, double 
 			}
 			else
 			{
-				tcol = CreateShadow::getLandShadow(tcol, shade * 3);
+				tcol = CreateShadow::getLandShadow(tcol, (shade - 1) * 4);
 			}
 			surface->setPixel((int)x0,(int)y0,tcol);
 		}


### PR DESCRIPTION
In the DOS version of UFO, the land texture pixel indices on the night side of the globe get shifted by exactly 8 positions. 146 becomes 154, 68 becomes 76, and so on.
This, combined with the textures themselves only using the left half of the palette, ensured each color had exact mapping without overlaps.

In OXC, the shadow range is clamped between 0..31 and then divided by 3 to get the shift value, leading to 2 extra steps of darkening (146 becomes 156).

This PR addresses the issue.


Attaching animated comparison to demonstrate the problem: aside from generally drawing the night side darker, OXC starts losing details on the mountain texture (due to the darker colors all shifting to the rightmost grey).
<img width="1280" height="800" alt="night" src="https://github.com/user-attachments/assets/b35366f0-bfa3-4090-af5d-b5c0c666ac89" />
