### PR TITLE
add option to abort game when placing initial custom base

### DIFF
--- a/src/Basescape/PlaceLiftState.cpp
+++ b/src/Basescape/PlaceLiftState.cpp
@@ -28,6 +28,7 @@
 #include "BasescapeState.h"
 #include "SelectStartFacilityState.h"
 #include "../Savegame/SavedGame.h"
+#include "../Menu/AbandonGameState.h"
 
 namespace OpenXcom
 {
@@ -66,6 +67,7 @@ PlaceLiftState::PlaceLiftState(Base *base, Globe *globe, bool first) : _base(bas
 	}
 	_view->setSelectable(_lift->getSize());
 	_view->onMouseClick((ActionHandler)&PlaceLiftState::viewClick);
+	_view->onKeyboardPress((ActionHandler)&PlaceLiftState::escapePress, SDLK_ESCAPE);
 
 	_txtTitle->setText(tr("STR_SELECT_POSITION_FOR_ACCESS_LIFT"));
 }
@@ -95,6 +97,20 @@ void PlaceLiftState::viewClick(Action *)
 	if (_first)
 	{
 		_game->pushState(new SelectStartFacilityState(_base, bState, _globe));
+	}
+}
+
+/**
+ * Handles pressing escape.
+ * If this is the first base, the player gets an abandon game dialog.
+ * @param action Pointer to an action.
+ * @param key SDLKey variable, should be equal to SDLK_ESCAPE
+ */
+void PlaceLiftState::escapePress(Action *, SDLKey)
+{
+	if (_first)
+	{
+		_game->pushState(new AbandonGameState(OPT_GEOSCAPE));
 	}
 }
 

--- a/src/Basescape/PlaceLiftState.h
+++ b/src/Basescape/PlaceLiftState.h
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <SDL.h>
 #include "../Engine/State.h"
 
 namespace OpenXcom
@@ -48,6 +49,8 @@ public:
 	~PlaceLiftState();
 	/// Handler for clicking the base view.
 	void viewClick(Action *action);
+	// Handler for pressing escape.
+	void escapePress(Action *, SDLKey);
 };
 
 }


### PR DESCRIPTION
Hello,
currently there is no way the player can exit the game when they are in the initial custom base placement screen. I found this very annoying so I added this little patch which makes it so that pressing the escape button while in the PlaceLiftState with the inital base (_first == true) shows an AbandonGame dialog.